### PR TITLE
feat(claude): add ralph-crew persistent worker management

### DIFF
--- a/common/claude/.claude/skills/ralph-crew/SKILL.md
+++ b/common/claude/.claude/skills/ralph-crew/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: ralph-crew
+description: 常駐ワーカーの初期化・ディスパッチ・状態確認を行います。launchd と連携して定期的にタスクを注入する自律ワーカー管理システムです。
+user-invocable: true
+disable-model-invocation: true
+arguments: "<subcommand> [args...]"
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
+# Ralph Crew - 定期ディスパッチ自律ワーカー管理
+
+常駐 Claude TUI ワーカーを tmux 上で管理し、設定ファイルのスケジュールに基づいてタスクを定期注入するシステム。
+
+## 使い方
+
+```
+/ralph-crew init                          # ワーカー起動
+/ralph-crew dispatch                      # スケジュール評価 + タスク注入
+/ralph-crew status                        # 全ワーカー状態表示
+/ralph-crew send <worker-id> "<message>"  # 手動メッセージ送信
+/ralph-crew restart <worker-id>           # ワーカー再起動
+/ralph-crew teardown                      # 全停止 + cleanup
+```
+
+## 手順
+
+### 引数をパースしてサブコマンドを実行
+
+```bash
+ralph-crew <引数をそのまま渡す>
+```
+
+結果をユーザーに報告する。
+
+## セットアップガイド
+
+### 1. 設定ファイルを作成
+
+```bash
+mkdir -p ~/.config/ralph-crew
+cp ~/dotfiles/templates/crew.example.json ~/.config/ralph-crew/crew.json
+# crew.json を編集: workers, tasks, schedule を設定
+```
+
+### 2. ワーカーを起動
+
+```bash
+ralph-crew init
+# または: ralph-crew init --config /path/to/crew.json
+```
+
+### 3. launchd で定期実行 (任意)
+
+```bash
+# plist テンプレートをコピーしてプレースホルダーを置換
+# __INTERVAL__ は秒数 (例: 900 = 15分, 1800 = 30分, 3600 = 1時間)
+cp ~/dotfiles/templates/com.user.ralph-crew.plist ~/Library/LaunchAgents/
+sed -i '' "s|__HOME__|$HOME|g; s|__INTERVAL__|900|g" ~/Library/LaunchAgents/com.user.ralph-crew.plist
+
+# 登録
+launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
+```
+
+### 4. 手動ディスパッチ
+
+```bash
+ralph-crew dispatch
+```
+
+## 設定ファイル構造
+
+`~/.config/ralph-crew/crew.json`:
+
+- `tmux_session`: tmux セッション名 (default: "ralph-crew")
+- `state_dir`: ランタイム状態ディレクトリ (default: "/tmp/ralph-crew")
+- `workers[]`: ワーカー定義 (id, project_dir, model, mcp_config, system_prompt, permissions)
+- `tasks[]`: タスク定義 (id, pattern, worker_id, prompt, schedule)
+
+テンプレート: `~/dotfiles/templates/crew.example.json`

--- a/docs/ralph-crew.md
+++ b/docs/ralph-crew.md
@@ -1,0 +1,176 @@
+# Ralph Crew - 定期ディスパッチ自律ワーカー管理
+
+常駐 Claude TUI ワーカーを tmux 上で管理し、設定ファイルのスケジュールに基づいてタスクを定期注入するシステム。`ralph-parallel` とは独立したライフサイクルモデル (一時的な並列実行 vs 常駐ワーカーへの定期注入)。
+
+## Architecture
+
+```
+launchd (定期発火, e.g. 15分間隔)
+  |
+  v
+ralph-crew dispatch (flock で排他制御)
+  |
+  +-- crew.json を読み取り
+  +-- 各タスクの schedule 評価 (interval 経過判定, epoch 比較)
+  +-- 対象ワーカーの状態確認 (状態ファイルベース)
+  |     idle  -> タスク注入 (常にファイル経由 + tmux send-keys)
+  |     running -> スキップ
+  |     dead  -> 自動再起動 (sliding window で制限)
+  +-- 実行時刻を記録
+  v
+tmux session: "ralph-crew"
+  +-- window "crew/<worker-id>" : claude TUI (persistent, Notification hook で状態通知)
+```
+
+リーダー (Claude インスタンス) は置かない:
+- タスクルーティングは設定ファイルで静的に定義
+- シェルスクリプトのディスパッチャーなら launchd 統合が簡潔でデバッグも容易
+- KB アクセスはワーカー自身が MCP 経由で実行
+
+## Usage
+
+### セットアップ
+
+```bash
+# 1. 設定ファイルを作成
+mkdir -p ~/.config/ralph-crew
+cp ~/dotfiles/templates/crew.example.json ~/.config/ralph-crew/crew.json
+# crew.json を編集
+
+# 2. ワーカーを起動
+~/dotfiles/scripts/ralph-crew init
+
+# 3. 手動ディスパッチ
+~/dotfiles/scripts/ralph-crew dispatch
+
+# 4. 状態確認
+~/dotfiles/scripts/ralph-crew status
+```
+
+### launchd で定期実行
+
+```bash
+# __INTERVAL__ は秒数 (例: 900 = 15分, 1800 = 30分, 3600 = 1時間)
+cp ~/dotfiles/templates/com.user.ralph-crew.plist ~/Library/LaunchAgents/
+sed -i '' "s|__HOME__|$HOME|g; s|__INTERVAL__|900|g" ~/Library/LaunchAgents/com.user.ralph-crew.plist
+
+launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
+```
+
+`__INTERVAL__` を crew.json の最短 `schedule.minutes` に合わせて設定すること。dispatch 側でタスクごとの間隔を個別に評価するため、launchd の発火間隔は最短タスク以下であれば良い。
+
+### スキル経由
+
+```
+/ralph-crew init
+/ralph-crew dispatch
+/ralph-crew status
+/ralph-crew send qa-frontend "Run npm test and report results"
+/ralph-crew restart qa-frontend
+/ralph-crew teardown
+```
+
+## Task Patterns
+
+`pattern` フィールドは意味論的な分類。dispatch ロジックは共通 (schedule 評価 -> idle 確認 -> プロンプト注入)。
+
+| Pattern | 用途 | 例 |
+|---------|------|-----|
+| `standing` | 定期実行される固定プロンプト | テスト監視、lint チェック、品質レポート |
+| `kb_pull` | MCP 経由で KB にアクセスしてタスク取得・実行 | Notion/Linear からタスク取得 |
+
+## Worker State Detection
+
+Notification hook ベースの状態検出:
+
+1. ワーカーの `.claude/settings.local.json` に Notification hook を自動設定
+2. `idle_prompt` イベントで `${STATE_DIR}/workers/${worker_id}.status` を `idle` に更新
+3. タスク注入時に `running` に更新
+
+状態: `idle` / `running` / `dead` / `unknown`
+
+## Auto-restart
+
+ワーカーの pane が消失した場合、dispatch 時に自動再起動を試みる。再起動制限:
+
+- sliding window: 直近5分以内に3回再起動 -> 無効化
+- `restart_timestamps` 配列でタイムスタンプを追跡
+
+## Runtime Directory
+
+```
+/tmp/ralph-crew/
+  workers/           # {worker_id}.json (pane_id, started, restart_timestamps)
+                     # {worker_id}.status (idle / running / unknown)
+  dispatch/          # {task_id}.last (最終実行 epoch)
+  prompts/           # タスクプロンプト一時ファイル (24h TTL で自動削除)
+  system-prompts/    # ワーカー system_prompt ファイル
+  logs/              # dispatch.log, launchd.out, launchd.err
+  dispatch.lock      # flock 用ロックファイル
+```
+
+## Config Schema
+
+```jsonc
+{
+  "tmux_session": "ralph-crew",
+  "state_dir": "/tmp/ralph-crew",
+  "workers": [
+    {
+      "id": "qa-frontend",
+      "project_dir": "/path/to/project",
+      "model": "sonnet",         // claude model
+      "mcp_config": null,        // MCP config file path (for kb_pull pattern)
+      "system_prompt": "...",    // append-system-prompt
+      "permissions": {           // .claude/settings.local.json permissions
+        "allow": ["Bash(npm:*)"],
+        "deny": ["Bash(git push:*)"]
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "id": "test-watch",
+      "pattern": "standing",     // standing | kb_pull
+      "worker_id": "qa-frontend",
+      "prompt": "Run `npm test`...",
+      "schedule": {
+        "type": "interval",
+        "minutes": 30
+      }
+    }
+  ]
+}
+```
+
+## File Structure
+
+```
+dotfiles/
++-- scripts/
+|   +-- ralph-lib.sh            # Shared utilities (permissions setup)
+|   +-- ralph-crew           # Crew management script
++-- templates/
+|   +-- crew.example.json       # Config template
+|   +-- com.user.ralph-crew.plist  # launchd plist template
++-- common/claude/.claude/
+|   +-- skills/
+|       +-- ralph-crew/SKILL.md # /ralph-crew skill
++-- docs/
+    +-- ralph-crew.md           # This documentation
+```
+
+## Design Decisions
+
+- リーダーレス: LLM リーダーを置かず、シェルスクリプト + launchd で静的ルーティング
+- Notification hook: capture-pane の `❯` 検出より信頼性が高い状態検出
+- ファイル経由タスク注入: tmux send-keys のエスケープ問題を完全に回避
+- flock 排他制御: launchd の重複発火を防止
+- sliding window 再起動制限: 単純なカウンターではなく時間ベースで判定
+- `max_budget_usd` 非対応: persistent TUI では累積消費で予算到達時にフリーズするため
+- worktree 不使用: crew ワーカーはプロジェクトディレクトリで直接動作
+- ralph-orchestrate と独立: ライフサイクルモデルが異なる (一時的 vs 常駐)
+
+## TODO
+
+- プロンプトテンプレート変数 + フォーカスローテーション: 静的プロンプトだと毎回同じ箇所しかチェックしない問題への対策。crew.json に `focus_rotation` 配列を持たせ、dispatch のたびに次の観点を選んでプロンプトに展開する。`{{focus}}`, `{{recent_changes}}`, `{{last_result}}` などのテンプレート変数をサポート。実装コスト自体は低い (シェルスクリプトで配列インデックスを回すだけ) が、実際に品質向上に寄与するかは運用してから判断する

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -1,0 +1,563 @@
+#!/usr/bin/env bash
+# ralph-crew - Persistent worker management with periodic task dispatch
+#
+# Manages long-lived Claude TUI workers in tmux, dispatching tasks on schedule.
+# Designed for launchd integration (periodic dispatch via StartInterval).
+set -euo pipefail
+
+# shellcheck source=ralph-lib.sh
+source "$(dirname "$0")/ralph-lib.sh"
+
+# --- Defaults ---
+DEFAULT_CONFIG="$HOME/.config/ralph-crew/crew.json"
+STATE_DIR="/tmp/ralph-crew"
+TMUX_SESSION="ralph-crew"
+LOG_FILE="${STATE_DIR}/logs/dispatch.log"
+
+# --- Logging ---
+
+_log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  mkdir -p "$(dirname "$LOG_FILE")"
+  printf '[%s] %s\n' "$ts" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+_info() { printf '\033[0;36minfo\033[0m %s\n' "$*" >&2; }
+_error() { printf '\033[0;31merror\033[0m %s\n' "$*" >&2; }
+_success() { printf '\033[0;32mok\033[0m %s\n' "$*" >&2; }
+
+# --- Config ---
+
+_load_config() {
+  local config_file="${1:-$DEFAULT_CONFIG}"
+  if [[ ! -f "$config_file" ]]; then
+    _error "Config file not found: $config_file"
+    return 1
+  fi
+
+  # Validate JSON
+  if ! jq empty "$config_file" 2>/dev/null; then
+    _error "Invalid JSON: $config_file"
+    return 1
+  fi
+
+  TMUX_SESSION="$(jq -r '.tmux_session // "ralph-crew"' "$config_file")"
+  STATE_DIR="$(jq -r '.state_dir // "/tmp/ralph-crew"' "$config_file")"
+  LOG_FILE="${STATE_DIR}/logs/dispatch.log"
+
+  echo "$config_file"
+}
+
+# --- Worker state ---
+
+_crew_worker_status() {
+  local worker_id="$1"
+  local status_file="${STATE_DIR}/workers/${worker_id}.status"
+  local worker_file="${STATE_DIR}/workers/${worker_id}.json"
+
+  # Check pane existence
+  if [[ -f "$worker_file" ]]; then
+    local pane_id
+    pane_id="$(jq -r '.pane_id // empty' "$worker_file")"
+    if [[ -n "$pane_id" ]] && ! tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$pane_id"; then
+      echo "dead"
+      return
+    fi
+  fi
+
+  # Status file based detection
+  if [[ -f "$status_file" ]]; then
+    cat "$status_file"
+  else
+    echo "unknown"
+  fi
+}
+
+# --- Worker lifecycle ---
+
+_wait_for_tui() {
+  local pane_id="$1"
+  local timeout="${2:-30}"
+  local elapsed=0
+
+  while [[ "$elapsed" -lt "$timeout" ]]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+    local content
+    content="$(tmux capture-pane -t "$pane_id" -p 2>/dev/null || true)"
+    if echo "$content" | grep -qE '❯|^\s*>|^╭|tips'; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_start_worker() {
+  local config_file="$1"
+  local worker_id="$2"
+
+  # Read worker config
+  local worker_json
+  worker_json="$(jq --arg id "$worker_id" '.workers[] | select(.id == $id)' "$config_file")"
+  if [[ -z "$worker_json" ]]; then
+    _error "Worker not found in config: $worker_id"
+    return 1
+  fi
+
+  local project_dir model mcp_config system_prompt permissions_json
+  project_dir="$(echo "$worker_json" | jq -r '.project_dir')"
+  model="$(echo "$worker_json" | jq -r '.model // "sonnet"')"
+  mcp_config="$(echo "$worker_json" | jq -r '.mcp_config // empty')"
+  system_prompt="$(echo "$worker_json" | jq -r '.system_prompt // empty')"
+  permissions_json="$(echo "$worker_json" | jq '.permissions // empty')"
+
+  if [[ ! -d "$project_dir" ]]; then
+    _error "Project directory not found: $project_dir"
+    return 1
+  fi
+
+  # Create tmux window
+  local window_name="crew/${worker_id}"
+  if tmux list-windows -t "$TMUX_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF "$window_name"; then
+    tmux kill-window -t "${TMUX_SESSION}:${window_name}" 2>/dev/null || true
+  fi
+  tmux new-window -t "$TMUX_SESSION" -n "$window_name" -c "$project_dir"
+
+  local pane_id
+  pane_id="$(tmux display-message -t "${TMUX_SESSION}:${window_name}" -p '#{pane_id}')"
+
+  # Setup permissions + Notification hook
+  local hook_json
+  hook_json="$(jq -n --arg worker_id "$worker_id" --arg state_dir "$STATE_DIR" '{
+    "hooks": {
+      "Notification": [
+        {
+          "matcher": "idle_prompt",
+          "hooks": [
+            {
+              "type": "command",
+              "command": ("bash -c " + ("echo idle > " + $state_dir + "/workers/" + $worker_id + ".status" | @sh))
+            }
+          ]
+        }
+      ]
+    }
+  }')"
+
+  if [[ -n "$permissions_json" && "$permissions_json" != "null" ]]; then
+    ralph_setup_worker_settings "$project_dir" "$permissions_json" "$hook_json"
+  else
+    ralph_setup_worker_settings "$project_dir" "$RALPH_DEFAULT_PERMISSIONS" "$hook_json"
+  fi
+  _info "Worker settings created: ${project_dir}/.claude/settings.local.json"
+
+  # Write system prompt to file
+  local system_prompt_file="${STATE_DIR}/system-prompts/${worker_id}.txt"
+  mkdir -p "$(dirname "$system_prompt_file")"
+  if [[ -n "$system_prompt" ]]; then
+    printf '%s' "$system_prompt" > "$system_prompt_file"
+  fi
+
+  # Build claude command
+  local cmd="claude --model ${model}"
+  if [[ -n "$mcp_config" ]]; then
+    cmd+=" --mcp-config $(printf '%q' "$mcp_config")"
+  fi
+  if [[ -n "$system_prompt" ]]; then
+    cmd+=" --append-system-prompt \"\$(cat $(printf '%q' "$system_prompt_file"))\""
+  fi
+
+  # Launch Claude TUI
+  tmux send-keys -t "$pane_id" "$cmd" Enter
+
+  # Wait for TUI to be ready
+  if ! _wait_for_tui "$pane_id" 30; then
+    _log "worker=$worker_id timeout waiting for TUI (continuing)"
+  fi
+
+  # Record worker metadata
+  mkdir -p "${STATE_DIR}/workers"
+  jq -n \
+    --arg id "$worker_id" \
+    --arg pane_id "$pane_id" \
+    --arg project_dir "$project_dir" \
+    --arg model "$model" \
+    --argjson started "$(date +%s)" \
+    '{
+      id: $id,
+      pane_id: $pane_id,
+      project_dir: $project_dir,
+      model: $model,
+      started: $started,
+      restart_timestamps: []
+    }' > "${STATE_DIR}/workers/${worker_id}.json"
+
+  # Initial status
+  echo "idle" > "${STATE_DIR}/workers/${worker_id}.status"
+
+  _success "Started worker: $worker_id (pane: $pane_id)"
+}
+
+# --- Task dispatch ---
+
+_dispatch_task() {
+  local pane_id="$1"
+  local task_id="$2"
+  local prompt="$3"
+  local worker_id="$4"
+
+  # Write prompt to file
+  mkdir -p "${STATE_DIR}/prompts"
+  local prompt_file="${STATE_DIR}/prompts/${task_id}.md"
+  printf '%s' "$prompt" > "$prompt_file"
+
+  # Update status to running
+  echo "running" > "${STATE_DIR}/workers/${worker_id}.status"
+
+  # Inject task via file reference (fixed string, no escaping issues)
+  tmux send-keys -t "$pane_id" "Read ${prompt_file} and follow the instructions." Enter
+
+  # Record dispatch time
+  mkdir -p "${STATE_DIR}/dispatch"
+  date +%s > "${STATE_DIR}/dispatch/${task_id}.last"
+
+  _log "task=$task_id worker=$worker_id status=dispatched"
+}
+
+_should_dispatch() {
+  local task_id="$1"
+  local interval_minutes="$2"
+
+  local last_file="${STATE_DIR}/dispatch/${task_id}.last"
+  if [[ ! -f "$last_file" ]]; then
+    return 0  # Never dispatched
+  fi
+
+  local last_epoch now_epoch
+  last_epoch="$(cat "$last_file")"
+  now_epoch="$(date +%s)"
+  local elapsed_minutes=$(( (now_epoch - last_epoch) / 60 ))
+
+  [[ "$elapsed_minutes" -ge "$interval_minutes" ]]
+}
+
+# --- Auto-restart ---
+
+_should_restart() {
+  local worker_file="$1"
+  local now
+  now="$(date +%s)"
+  local window=300  # 5 minutes
+  local max_restarts=3
+
+  local recent_count
+  recent_count="$(jq --argjson now "$now" --argjson window "$window" \
+    '[.restart_timestamps[]? | select(. > ($now - $window))] | length' \
+    "$worker_file")"
+
+  [[ "$recent_count" -lt "$max_restarts" ]]
+}
+
+_record_restart() {
+  local worker_file="$1"
+  local now
+  now="$(date +%s)"
+  jq --argjson now "$now" '.restart_timestamps += [$now]' \
+    "$worker_file" > "${worker_file}.tmp" && mv "${worker_file}.tmp" "$worker_file"
+}
+
+# --- Cleanup ---
+
+_cleanup_old_prompts() {
+  find "${STATE_DIR}/prompts" -type f -mmin +1440 -delete 2>/dev/null || true
+}
+
+# === Subcommands ===
+
+cmd_init() {
+  local config_file="$DEFAULT_CONFIG"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config) config_file="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  config_file="$(_load_config "$config_file")" || return 1
+
+  # Create state directories
+  mkdir -p "${STATE_DIR}"/{workers,dispatch,prompts,system-prompts,logs}
+
+  # Create or attach to tmux session
+  if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    _info "Session already exists: $TMUX_SESSION"
+  else
+    tmux new-session -d -s "$TMUX_SESSION" -n "control"
+    _success "Created tmux session: $TMUX_SESSION"
+  fi
+
+  # Start all workers
+  local worker_count
+  worker_count="$(jq '.workers | length' "$config_file")"
+  local i=0
+  while [[ "$i" -lt "$worker_count" ]]; do
+    local worker_id
+    worker_id="$(jq -r ".workers[$i].id" "$config_file")"
+    _start_worker "$config_file" "$worker_id"
+    i=$((i + 1))
+  done
+
+  _success "Initialized $worker_count worker(s) in session: $TMUX_SESSION"
+  _log "init completed: $worker_count workers"
+}
+
+cmd_dispatch() {
+  local config_file="$DEFAULT_CONFIG"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config) config_file="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  config_file="$(_load_config "$config_file")" || return 1
+
+  # Exclusive lock
+  mkdir -p "$STATE_DIR"
+  local lock_file="${STATE_DIR}/dispatch.lock"
+  exec 9>"$lock_file"
+  if ! flock -n 9; then
+    _log "dispatch already running, skipping"
+    return 0
+  fi
+
+  # Cleanup old prompt files
+  _cleanup_old_prompts
+
+  # Check session exists
+  if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    _log "tmux session not found: $TMUX_SESSION (run init first)"
+    return 1
+  fi
+
+  # Process each task
+  local task_count
+  task_count="$(jq '.tasks | length' "$config_file")"
+  local i=0
+  local dispatched=0
+  while [[ "$i" -lt "$task_count" ]]; do
+    local task_id worker_id prompt interval_minutes
+    task_id="$(jq -r ".tasks[$i].id" "$config_file")"
+    worker_id="$(jq -r ".tasks[$i].worker_id" "$config_file")"
+    prompt="$(jq -r ".tasks[$i].prompt" "$config_file")"
+    interval_minutes="$(jq -r ".tasks[$i].schedule.minutes" "$config_file")"
+
+    # Check schedule
+    if ! _should_dispatch "$task_id" "$interval_minutes"; then
+      i=$((i + 1))
+      continue
+    fi
+
+    # Check worker status
+    local status
+    status="$(_crew_worker_status "$worker_id")"
+
+    case "$status" in
+      idle)
+        local worker_file="${STATE_DIR}/workers/${worker_id}.json"
+        local pane_id
+        pane_id="$(jq -r '.pane_id' "$worker_file")"
+        _dispatch_task "$pane_id" "$task_id" "$prompt" "$worker_id"
+        dispatched=$((dispatched + 1))
+        ;;
+      running)
+        _log "task=$task_id worker=$worker_id status=skipped (worker busy)"
+        ;;
+      dead)
+        _log "task=$task_id worker=$worker_id status=dead, attempting restart"
+        local worker_file="${STATE_DIR}/workers/${worker_id}.json"
+        if [[ -f "$worker_file" ]] && _should_restart "$worker_file"; then
+          _record_restart "$worker_file"
+          _start_worker "$config_file" "$worker_id"
+          _log "worker=$worker_id restarted"
+        else
+          _log "worker=$worker_id restart limit exceeded, skipping"
+        fi
+        ;;
+      *)
+        _log "task=$task_id worker=$worker_id status=$status (unknown, skipping)"
+        ;;
+    esac
+
+    i=$((i + 1))
+  done
+
+  _log "dispatch completed: $dispatched task(s) dispatched"
+}
+
+cmd_status() {
+  local json_mode=false
+  local config_file="$DEFAULT_CONFIG"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) json_mode=true; shift ;;
+      --config) config_file="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  config_file="$(_load_config "$config_file")" || return 1
+
+  if [[ "$json_mode" == true ]]; then
+    local result="{"
+    local first=true
+    for status_file in "${STATE_DIR}/workers"/*.status; do
+      [[ -f "$status_file" ]] || continue
+      local wid
+      wid="$(basename "$status_file" .status)"
+      local st
+      st="$(_crew_worker_status "$wid")"
+      if [[ "$first" == true ]]; then
+        first=false
+      else
+        result+=","
+      fi
+      result+="\"${wid}\":\"${st}\""
+    done
+    result+="}"
+    echo "$result"
+  else
+    local worker_count
+    worker_count="$(jq '.workers | length' "$config_file")"
+    local i=0
+    while [[ "$i" -lt "$worker_count" ]]; do
+      local wid
+      wid="$(jq -r ".workers[$i].id" "$config_file")"
+      local st
+      st="$(_crew_worker_status "$wid")"
+      local last_task=""
+
+      # Find latest dispatch for this worker
+      for task_last in "${STATE_DIR}/dispatch"/*.last; do
+        [[ -f "$task_last" ]] || continue
+        local tid
+        tid="$(basename "$task_last" .last)"
+        local task_worker
+        task_worker="$(jq -r --arg tid "$tid" '.tasks[] | select(.id == $tid) | .worker_id' "$config_file" 2>/dev/null || true)"
+        if [[ "$task_worker" == "$wid" ]]; then
+          local epoch
+          epoch="$(cat "$task_last")"
+          local ts
+          ts="$(date -r "$epoch" '+%H:%M:%S' 2>/dev/null || date -d "@$epoch" '+%H:%M:%S' 2>/dev/null || echo "?")"
+          last_task="$tid@$ts"
+        fi
+      done
+
+      printf "  %-20s %-10s %s\n" "$wid" "$st" "${last_task:-(no dispatch)}"
+      i=$((i + 1))
+    done
+  fi
+}
+
+cmd_send() {
+  local worker_id="${1:-}"
+  local message="${2:-}"
+  [[ -z "$worker_id" ]] && { _error "Usage: ralph-crew send <worker-id> <message>"; return 1; }
+  [[ -z "$message" ]] && { _error "message is required"; return 1; }
+
+  local worker_file="${STATE_DIR}/workers/${worker_id}.json"
+  [[ -f "$worker_file" ]] || { _error "Worker not found: $worker_id"; return 1; }
+
+  local pane_id
+  pane_id="$(jq -r '.pane_id // empty' "$worker_file")"
+  [[ -z "$pane_id" ]] && { _error "No pane_id for worker: $worker_id"; return 1; }
+
+  if ! tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$pane_id"; then
+    _error "Pane $pane_id no longer exists for $worker_id"
+    return 1
+  fi
+
+  # Write message to file for safe injection
+  mkdir -p "${STATE_DIR}/prompts"
+  local msg_file="${STATE_DIR}/prompts/manual-${worker_id}-$(date +%s).md"
+  printf '%s' "$message" > "$msg_file"
+
+  echo "running" > "${STATE_DIR}/workers/${worker_id}.status"
+  tmux send-keys -t "$pane_id" "Read ${msg_file} and follow the instructions." Enter
+
+  _success "Sent message to $worker_id ($pane_id)"
+}
+
+cmd_restart() {
+  local worker_id="${1:-}"
+  local config_file="$DEFAULT_CONFIG"
+  [[ -z "$worker_id" ]] && { _error "Usage: ralph-crew restart <worker-id> [--config <path>]"; return 1; }
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config) config_file="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  config_file="$(_load_config "$config_file")" || return 1
+
+  # Kill existing window if present
+  local window_name="crew/${worker_id}"
+  if tmux list-windows -t "$TMUX_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF "$window_name"; then
+    tmux kill-window -t "${TMUX_SESSION}:${window_name}" 2>/dev/null || true
+  fi
+
+  # Record restart timestamp
+  local worker_file="${STATE_DIR}/workers/${worker_id}.json"
+  if [[ -f "$worker_file" ]]; then
+    _record_restart "$worker_file"
+  fi
+
+  _start_worker "$config_file" "$worker_id"
+  _log "worker=$worker_id manually restarted"
+}
+
+cmd_teardown() {
+  # Kill tmux session
+  if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+    tmux kill-session -t "$TMUX_SESSION"
+    _success "Killed tmux session: $TMUX_SESSION"
+  else
+    _info "No tmux session: $TMUX_SESSION"
+  fi
+
+  # Cleanup state
+  rm -rf "$STATE_DIR"
+  _success "Cleaned up state: $STATE_DIR"
+  _log "teardown completed"
+}
+
+# --- Main ---
+
+case "${1:-}" in
+  init)      shift; cmd_init "$@" ;;
+  dispatch)  shift; cmd_dispatch "$@" ;;
+  status)    shift; cmd_status "$@" ;;
+  send)      shift; cmd_send "$@" ;;
+  restart)   shift; cmd_restart "$@" ;;
+  teardown)  cmd_teardown ;;
+  help|*)
+    cat <<EOF
+ralph-crew - Persistent worker management with periodic task dispatch
+
+Usage:
+  ralph-crew init [--config <path>]           Create tmux session and start all workers
+  ralph-crew dispatch [--config <path>]        Evaluate schedules and dispatch tasks
+  ralph-crew status [--json] [--config <path>] Show worker status
+  ralph-crew send <worker-id> "<message>"      Send manual message to worker
+  ralph-crew restart <worker-id> [--config <path>]
+                                                   Restart a worker
+  ralph-crew teardown                           Stop all workers and cleanup
+
+Config file default: $DEFAULT_CONFIG
+EOF
+    ;;
+esac

--- a/scripts/ralph-lib.sh
+++ b/scripts/ralph-lib.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# ralph-lib.sh - Shared utilities for ralph-orchestrate and ralph-crew
+#
+# Usage: source this file in your scripts
+#   source "$(dirname "$0")/ralph-lib.sh"
+
+# Default permissions JSON for ralph workers
+readonly RALPH_DEFAULT_PERMISSIONS='{
+  "allow": [
+    "Bash(git add:*)",
+    "Bash(git commit:*)",
+    "Bash(git diff:*)",
+    "Bash(git status:*)",
+    "Bash(git log:*)",
+    "Bash(git branch:*)",
+    "Bash(git checkout:*)",
+    "Bash(git stash:*)",
+    "Bash(git show:*)",
+    "Bash(git ls-files:*)",
+    "Bash(git ls-tree:*)",
+    "Bash(gh issue:*)",
+    "Bash(gh pr:*)",
+    "Bash(gh api:*)",
+    "Bash(cat:*)",
+    "Bash(ls:*)",
+    "Bash(tree:*)",
+    "Bash(wc:*)",
+    "Bash(grep:*)",
+    "Bash(find:*)",
+    "Bash(readlink:*)",
+    "Bash(bash:*)",
+    "Bash(npm:*)",
+    "Bash(npx:*)",
+    "Bash(cargo:*)",
+    "Bash(python3:*)",
+    "Bash(shellcheck:*)",
+    "Bash(chmod:*)",
+    "Bash(stow:*)",
+    "WebSearch"
+  ],
+  "deny": [
+    "Bash(git push:*)",
+    "Bash(git push)"
+  ]
+}'
+
+# Setup worker settings.local.json in the specified directory.
+#
+# Usage:
+#   ralph_setup_worker_settings <project_dir> [permissions_json] [extra_settings_json]
+#
+# Args:
+#   project_dir:          Directory where .claude/settings.local.json will be created
+#   permissions_json:     JSON object with "allow" and "deny" arrays (optional, uses defaults)
+#   extra_settings_json:  Additional JSON to merge into settings (optional, e.g. hooks)
+ralph_setup_worker_settings() {
+  local project_dir="$1"
+  local permissions_json="${2:-$RALPH_DEFAULT_PERMISSIONS}"
+  local extra_settings_json="${3:-}"
+  local settings_dir="${project_dir}/.claude"
+  mkdir -p "$settings_dir"
+
+  local settings_file="${settings_dir}/settings.local.json"
+
+  if [[ -n "$extra_settings_json" ]]; then
+    # Merge permissions + extra settings
+    jq -n \
+      --argjson perms "$permissions_json" \
+      --argjson extra "$extra_settings_json" \
+      '{"permissions": $perms} * $extra' \
+      > "$settings_file"
+  else
+    jq -n --argjson perms "$permissions_json" '{"permissions": $perms}' > "$settings_file"
+  fi
+}

--- a/templates/com.user.ralph-crew.plist
+++ b/templates/com.user.ralph-crew.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.ralph-crew</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/dotfiles/scripts/ralph-crew</string>
+        <string>dispatch</string>
+        <string>--config</string>
+        <string>__HOME__/.config/ralph-crew/crew.json</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+    <key>StartInterval</key>
+    <integer>__INTERVAL__</integer>
+    <key>StandardOutPath</key>
+    <string>/tmp/ralph-crew/logs/launchd.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ralph-crew/logs/launchd.err</string>
+</dict>
+</plist>

--- a/templates/crew.example.json
+++ b/templates/crew.example.json
@@ -1,0 +1,48 @@
+{
+  "tmux_session": "ralph-crew",
+  "state_dir": "/tmp/ralph-crew",
+  "workers": [
+    {
+      "id": "qa-frontend",
+      "project_dir": "/path/to/project",
+      "model": "sonnet",
+      "mcp_config": null,
+      "system_prompt": "You are a QA engineer focused on the frontend module.",
+      "permissions": {
+        "allow": [
+          "Bash(npm:*)",
+          "Bash(npx:*)",
+          "Bash(git diff:*)",
+          "Bash(git status:*)",
+          "Bash(gh issue:*)"
+        ],
+        "deny": [
+          "Bash(git push:*)",
+          "Bash(git push)"
+        ]
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "id": "test-watch",
+      "pattern": "standing",
+      "worker_id": "qa-frontend",
+      "prompt": "Run `npm test`. If any tests fail, analyze failures and create a GitHub issue.",
+      "schedule": {
+        "type": "interval",
+        "minutes": 30
+      }
+    },
+    {
+      "id": "kb-pull",
+      "pattern": "kb_pull",
+      "worker_id": "qa-frontend",
+      "prompt": "Use Notion MCP to fetch tasks marked 'Ready'. For each, create an implementation plan.",
+      "schedule": {
+        "type": "interval",
+        "minutes": 60
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- 常駐 Claude TUI ワーカーを tmux + launchd で管理する `ralph-crew` システムを追加
- `ralph-orchestrate` / `ralph-crew` 共通ユーティリティを `ralph-lib.sh` に抽出
- `/ralph-crew` スキル、設定テンプレート、launchd plist テンプレート、ドキュメントを追加

## Test plan

- [ ] `ralph-crew help` でヘルプが表示される
- [ ] `ralph-crew init --config templates/crew.example.json` でセッション作成を確認
- [ ] `ralph-crew status` でステータス表示を確認
- [ ] `ralph-crew teardown` でクリーンアップを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)