### PR TITLE
feat(claude): add action modes (fix/issue-only) to ralph-crew tasks

### DIFF
--- a/common/claude/.claude/skills/ralph-crew/SKILL.md
+++ b/common/claude/.claude/skills/ralph-crew/SKILL.md
@@ -74,6 +74,7 @@ ralph-crew dispatch
 - `tmux_session`: tmux セッション名 (default: "ralph-crew")
 - `state_dir`: ランタイム状態ディレクトリ (default: "/tmp/ralph-crew")
 - `workers[]`: ワーカー定義 (id, project_dir, model, mcp_config, system_prompt, permissions)
-- `tasks[]`: タスク定義 (id, pattern, worker_id, prompt, schedule)
+- `tasks[]`: タスク定義 (id, pattern, worker_id, action, prompt, schedule)
+  - `action`: `"fix"` (デフォルト: worktree で修正 -> PR) または `"issue-only"` (報告のみ)
 
 テンプレート: `~/dotfiles/templates/crew.example.json`

--- a/docs/ralph-crew.md
+++ b/docs/ralph-crew.md
@@ -16,6 +16,9 @@ ralph-crew dispatch (flock で排他制御)
   |     idle  -> タスク注入 (常にファイル経由 + tmux send-keys)
   |     running -> スキップ
   |     dead  -> 自動再起動 (sliding window で制限)
+  +-- action モードに応じたプロンプト生成
+  |     fix        -> worktree 作成 → 修正 → commit → push → PR
+  |     issue-only -> 問題報告のみ (GitHub issue)
   +-- 実行時刻を記録
   v
 tmux session: "ralph-crew"
@@ -70,6 +73,28 @@ launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 /ralph-crew teardown
 ```
 
+## Action Modes
+
+タスクの `action` フィールドで検出後の行動を制御する。
+
+| Action | デフォルト | 動作 |
+|--------|-----------|------|
+| `fix` | Yes | 問題検出 → worktree で修正 → commit → push → PR 作成。修正不能なら issue にフォールバック |
+| `issue-only` | No | 問題検出 → GitHub issue 作成のみ。修正は試みない |
+
+### fix モードのワークフロー
+
+```
+1. project_dir でチェック実行 (read-only)
+2. 問題検出
+3. git worktree add /tmp/ralph-crew/fix/<task-id>-<ts> -b crew/<task-id>-<ts> HEAD
+4. worktree 内で修正 → commit → push
+5. gh pr create
+6. worktree 削除、project_dir に戻る
+```
+
+fix モードのワーカーは自動的に git push / worktree 権限が付与される (force push は deny)。
+
 ## Task Patterns
 
 `pattern` フィールドは意味論的な分類。dispatch ロジックは共通 (schedule 評価 -> idle 確認 -> プロンプト注入)。
@@ -103,6 +128,7 @@ Notification hook ベースの状態検出:
   workers/           # {worker_id}.json (pane_id, started, restart_timestamps)
                      # {worker_id}.status (idle / running / unknown)
   dispatch/          # {task_id}.last (最終実行 epoch)
+  fix/               # fix モードの一時 worktree ({task_id}-{timestamp})
   prompts/           # タスクプロンプト一時ファイル (24h TTL で自動削除)
   system-prompts/    # ワーカー system_prompt ファイル
   logs/              # dispatch.log, launchd.out, launchd.err
@@ -133,6 +159,7 @@ Notification hook ベースの状態検出:
       "id": "test-watch",
       "pattern": "standing",     // standing | kb_pull
       "worker_id": "qa-frontend",
+      "action": "fix",           // "fix" (default) | "issue-only"
       "prompt": "Run `npm test`...",
       "schedule": {
         "type": "interval",
@@ -168,7 +195,7 @@ dotfiles/
 - flock 排他制御: launchd の重複発火を防止
 - sliding window 再起動制限: 単純なカウンターではなく時間ベースで判定
 - `max_budget_usd` 非対応: persistent TUI では累積消費で予算到達時にフリーズするため
-- worktree 不使用: crew ワーカーはプロジェクトディレクトリで直接動作
+- fix モードで worktree 分離: チェックは project_dir (read-only)、修正は一時 worktree で実施。ワーカー間の競合を防止
 - ralph-orchestrate と独立: ライフサイクルモデルが異なる (一時的 vs 常駐)
 
 ## TODO

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -117,6 +117,23 @@ _start_worker() {
     return 1
   fi
 
+  # If worker has fix tasks, adjust permissions: allow git push, deny only force push
+  local has_fix
+  has_fix="$(jq --arg wid "$worker_id" \
+    '[.tasks[] | select(.worker_id == $wid) | .action // "fix" | select(. == "fix")] | length' \
+    "$config_file")"
+  if [[ "$has_fix" -gt 0 ]]; then
+    if [[ -z "$permissions_json" || "$permissions_json" == "null" ]]; then
+      permissions_json="$RALPH_DEFAULT_PERMISSIONS"
+    fi
+    permissions_json="$(echo "$permissions_json" | jq '
+      .deny = [.deny[]? | select(
+        (. == "Bash(git push:*)" or . == "Bash(git push)") | not
+      )] + ["Bash(git push --force:*)", "Bash(git push -f:*)"] |
+      .allow = (.allow + ["Bash(git worktree:*)", "Bash(git push:*)", "Bash(gh pr:*)"]) | .allow |= unique
+    ')"
+  fi
+
   # Create tmux window
   local window_name="crew/${worker_id}"
   if tmux list-windows -t "$TMUX_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF "$window_name"; then
@@ -206,11 +223,50 @@ _dispatch_task() {
   local task_id="$2"
   local prompt="$3"
   local worker_id="$4"
+  local action="${5:-fix}"
+  local project_dir="${6:-}"
 
-  # Write prompt to file
+  local ts
+  ts="$(date +%Y%m%d-%H%M%S)"
+  local branch="crew/${task_id}-${ts}"
+  local worktree="${STATE_DIR}/fix/${task_id}-${ts}"
+
+  # Build prompt with action mode wrapper
   mkdir -p "${STATE_DIR}/prompts"
   local prompt_file="${STATE_DIR}/prompts/${task_id}.md"
-  printf '%s' "$prompt" > "$prompt_file"
+
+  if [[ "$action" == "issue-only" ]]; then
+    cat > "$prompt_file" <<PROMPT_EOF
+# Task: ${task_id}
+
+${prompt}
+
+## Action: issue-only
+If issues are found, create a GitHub issue with analysis and suggested fix.
+Do not attempt to fix the issues directly.
+If no issues found, report: all checks passed.
+PROMPT_EOF
+  else
+    cat > "$prompt_file" <<PROMPT_EOF
+# Task: ${task_id}
+
+${prompt}
+
+## Action: fix (worktree isolation)
+If issues are found, fix them in an isolated worktree:
+\`\`\`bash
+git worktree add ${worktree} -b ${branch} HEAD
+cd ${worktree}
+# ... fix issues ...
+git add <files> && git commit -m "fix(<scope>): <description>"
+git push -u origin ${branch}
+gh pr create --title "fix(<scope>): <description>" --body "<analysis>"
+cd ${project_dir} && git worktree remove ${worktree}
+\`\`\`
+If auto-fix fails or issues are too complex, create a GitHub issue instead.
+If no issues found, report: all checks passed.
+PROMPT_EOF
+  fi
 
   # Update status to running
   echo "running" > "${STATE_DIR}/workers/${worker_id}.status"
@@ -222,7 +278,7 @@ _dispatch_task() {
   mkdir -p "${STATE_DIR}/dispatch"
   date +%s > "${STATE_DIR}/dispatch/${task_id}.last"
 
-  _log "task=$task_id worker=$worker_id status=dispatched"
+  _log "task=$task_id worker=$worker_id action=$action status=dispatched"
 }
 
 _should_dispatch() {
@@ -347,11 +403,12 @@ cmd_dispatch() {
   local i=0
   local dispatched=0
   while [[ "$i" -lt "$task_count" ]]; do
-    local task_id worker_id prompt interval_minutes
+    local task_id worker_id prompt interval_minutes action
     task_id="$(jq -r ".tasks[$i].id" "$config_file")"
     worker_id="$(jq -r ".tasks[$i].worker_id" "$config_file")"
     prompt="$(jq -r ".tasks[$i].prompt" "$config_file")"
     interval_minutes="$(jq -r ".tasks[$i].schedule.minutes" "$config_file")"
+    action="$(jq -r '.tasks['"$i"'].action // "fix"' "$config_file")"
 
     # Check schedule
     if ! _should_dispatch "$task_id" "$interval_minutes"; then
@@ -366,9 +423,10 @@ cmd_dispatch() {
     case "$status" in
       idle)
         local worker_file="${STATE_DIR}/workers/${worker_id}.json"
-        local pane_id
+        local pane_id project_dir
         pane_id="$(jq -r '.pane_id' "$worker_file")"
-        _dispatch_task "$pane_id" "$task_id" "$prompt" "$worker_id"
+        project_dir="$(jq -r '.project_dir' "$worker_file")"
+        _dispatch_task "$pane_id" "$task_id" "$prompt" "$worker_id" "$action" "$project_dir"
         dispatched=$((dispatched + 1))
         ;;
       running)

--- a/scripts/ralph-lib.sh
+++ b/scripts/ralph-lib.sh
@@ -36,6 +36,7 @@ readonly RALPH_DEFAULT_PERMISSIONS='{
     "Bash(shellcheck:*)",
     "Bash(chmod:*)",
     "Bash(stow:*)",
+    "Bash(git worktree:*)",
     "WebSearch"
   ],
   "deny": [

--- a/templates/crew.example.json
+++ b/templates/crew.example.json
@@ -25,20 +25,22 @@
   ],
   "tasks": [
     {
-      "id": "test-watch",
+      "id": "lint-fix",
       "pattern": "standing",
       "worker_id": "qa-frontend",
-      "prompt": "Run `npm test`. If any tests fail, analyze failures and create a GitHub issue.",
+      "action": "fix",
+      "prompt": "Run `npx eslint .` and `npx tsc --noEmit`. If issues found, fix them.",
       "schedule": {
         "type": "interval",
         "minutes": 30
       }
     },
     {
-      "id": "kb-pull",
-      "pattern": "kb_pull",
+      "id": "test-watch",
+      "pattern": "standing",
       "worker_id": "qa-frontend",
-      "prompt": "Use Notion MCP to fetch tasks marked 'Ready'. For each, create an implementation plan.",
+      "action": "issue-only",
+      "prompt": "Run `npm test`. If any tests fail, analyze failures and create a GitHub issue.",
       "schedule": {
         "type": "interval",
         "minutes": 60


### PR DESCRIPTION
## Summary

- ralph-crew タスクに `action` フィールドを追加: `"fix"` (デフォルト) / `"issue-only"`
- fix モード: 問題検出 → worktree で修正 → commit → push → PR 作成 (修正不能なら issue にフォールバック)
- issue-only モード: 問題検出 → GitHub issue 作成のみ
- fix モードワーカーの permissions を自動調整 (git push 許可、force push のみ deny)

## Test plan

- [ ] `jq '.tasks[0].action // "fix"' crew.json` で action フィールドが読み取れる
- [ ] fix モードのプロンプトに worktree 手順が含まれる
- [ ] issue-only モードのプロンプトに「Do not attempt fixes」が含まれる
- [ ] fix タスクを持つワーカーの permissions から `git push:*` deny が除去され `git push --force:*` deny に置換される

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)