### PR TITLE
rfac(claude): move crew.json to project-local .claude/crew.json

### DIFF
--- a/common/claude/.claude/skills/ralph-crew/SKILL.md
+++ b/common/claude/.claude/skills/ralph-crew/SKILL.md
@@ -37,8 +37,9 @@ ralph-crew <引数をそのまま渡す>
 ### 1. 設定ファイルを作成
 
 ```bash
-mkdir -p ~/.config/ralph-crew
-cp ~/dotfiles/templates/crew.example.json ~/.config/ralph-crew/crew.json
+# プロジェクトディレクトリで実行
+mkdir -p .claude
+cp ~/dotfiles/templates/crew.example.json .claude/crew.json
 # crew.json を編集: workers, tasks, schedule を設定
 ```
 
@@ -54,8 +55,9 @@ ralph-crew init
 ```bash
 # plist テンプレートをコピーしてプレースホルダーを置換
 # __INTERVAL__ は秒数 (例: 900 = 15分, 1800 = 30分, 3600 = 1時間)
+# __PROJECT__ はプロジェクトの絶対パス
 cp ~/dotfiles/templates/com.user.ralph-crew.plist ~/Library/LaunchAgents/
-sed -i '' "s|__HOME__|$HOME|g; s|__INTERVAL__|900|g" ~/Library/LaunchAgents/com.user.ralph-crew.plist
+sed -i '' "s|__HOME__|$HOME|g; s|__PROJECT__|/path/to/project|g; s|__INTERVAL__|900|g" ~/Library/LaunchAgents/com.user.ralph-crew.plist
 
 # 登録
 launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
@@ -69,11 +71,11 @@ ralph-crew dispatch
 
 ## 設定ファイル構造
 
-`~/.config/ralph-crew/crew.json`:
+`<project>/.claude/crew.json` (プロジェクトディレクトリから自動導出):
 
-- `tmux_session`: tmux セッション名 (default: "ralph-crew")
-- `state_dir`: ランタイム状態ディレクトリ (default: "/tmp/ralph-crew")
-- `workers[]`: ワーカー定義 (id, project_dir, model, mcp_config, system_prompt, permissions)
+- `tmux_session`: tmux セッション名 (default: `crew-<project-name>`)
+- `state_dir`: ランタイム状態ディレクトリ (default: `/tmp/ralph-crew/<project-name>`)
+- `workers[]`: ワーカー定義 (id, model, mcp_config, system_prompt, permissions)
 - `tasks[]`: タスク定義 (id, pattern, worker_id, action, prompt, schedule)
   - `action`: `"fix"` (デフォルト: worktree で修正 -> PR) または `"issue-only"` (報告のみ)
 

--- a/docs/ralph-crew.md
+++ b/docs/ralph-crew.md
@@ -35,27 +35,31 @@ tmux session: "ralph-crew"
 ### セットアップ
 
 ```bash
-# 1. 設定ファイルを作成
-mkdir -p ~/.config/ralph-crew
-cp ~/dotfiles/templates/crew.example.json ~/.config/ralph-crew/crew.json
-# crew.json を編集
+# 1. プロジェクト配下に設定ファイルを作成
+cd /path/to/project
+mkdir -p .claude
+cp ~/dotfiles/templates/crew.example.json .claude/crew.json
+# crew.json を編集: workers, tasks, schedule を設定
 
-# 2. ワーカーを起動
-~/dotfiles/scripts/ralph-crew init
+# 2. ワーカーを起動 (プロジェクトディレクトリで実行)
+ralph-crew init
 
 # 3. 手動ディスパッチ
-~/dotfiles/scripts/ralph-crew dispatch
+ralph-crew dispatch
 
 # 4. 状態確認
-~/dotfiles/scripts/ralph-crew status
+ralph-crew status
 ```
+
+設定ファイルはプロジェクトの `.claude/crew.json` に配置する。プロジェクトディレクトリは config ファイルのパスから自動導出される。`tmux_session` と `state_dir` を省略するとプロジェクト名ベースのデフォルト値が使われる。
 
 ### launchd で定期実行
 
 ```bash
 # __INTERVAL__ は秒数 (例: 900 = 15分, 1800 = 30分, 3600 = 1時間)
+# __PROJECT__ はプロジェクトの絶対パス
 cp ~/dotfiles/templates/com.user.ralph-crew.plist ~/Library/LaunchAgents/
-sed -i '' "s|__HOME__|$HOME|g; s|__INTERVAL__|900|g" ~/Library/LaunchAgents/com.user.ralph-crew.plist
+sed -i '' "s|__HOME__|$HOME|g; s|__PROJECT__|/path/to/project|g; s|__INTERVAL__|900|g" ~/Library/LaunchAgents/com.user.ralph-crew.plist
 
 launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 ```
@@ -68,8 +72,8 @@ launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 /ralph-crew init
 /ralph-crew dispatch
 /ralph-crew status
-/ralph-crew send qa-frontend "Run npm test and report results"
-/ralph-crew restart qa-frontend
+/ralph-crew send qa "Run npm test and report results"
+/ralph-crew restart qa
 /ralph-crew teardown
 ```
 
@@ -124,7 +128,7 @@ Notification hook ベースの状態検出:
 ## Runtime Directory
 
 ```
-/tmp/ralph-crew/
+/tmp/ralph-crew/<project-name>/
   workers/           # {worker_id}.json (pane_id, started, restart_timestamps)
                      # {worker_id}.status (idle / running / unknown)
   dispatch/          # {task_id}.last (最終実行 epoch)
@@ -137,14 +141,15 @@ Notification hook ベースの状態検出:
 
 ## Config Schema
 
+配置場所: `<project>/.claude/crew.json`
+
 ```jsonc
 {
-  "tmux_session": "ralph-crew",
-  "state_dir": "/tmp/ralph-crew",
+  // "tmux_session": "crew-<project-name>",  // optional (default: derived from project dir)
+  // "state_dir": "/tmp/ralph-crew/<project-name>",  // optional (default: derived from project dir)
   "workers": [
     {
-      "id": "qa-frontend",
-      "project_dir": "/path/to/project",
+      "id": "qa",
       "model": "sonnet",         // claude model
       "mcp_config": null,        // MCP config file path (for kb_pull pattern)
       "system_prompt": "...",    // append-system-prompt

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -9,7 +9,8 @@ set -euo pipefail
 source "$(dirname "$0")/ralph-lib.sh"
 
 # --- Defaults ---
-DEFAULT_CONFIG="$HOME/.config/ralph-crew/crew.json"
+DEFAULT_CONFIG=".claude/crew.json"
+PROJECT_DIR=""
 STATE_DIR="/tmp/ralph-crew"
 TMUX_SESSION="ralph-crew"
 LOG_FILE="${STATE_DIR}/logs/dispatch.log"
@@ -42,8 +43,16 @@ _load_config() {
     return 1
   fi
 
-  TMUX_SESSION="$(jq -r '.tmux_session // "ralph-crew"' "$config_file")"
-  STATE_DIR="$(jq -r '.state_dir // "/tmp/ralph-crew"' "$config_file")"
+  # Derive project directory from config file path
+  # e.g. /path/to/project/.claude/crew.json -> /path/to/project
+  local abs_config
+  abs_config="$(cd "$(dirname "$config_file")" && pwd)/$(basename "$config_file")"
+  PROJECT_DIR="$(dirname "$(dirname "$abs_config")")"
+
+  local project_name
+  project_name="$(basename "$PROJECT_DIR")"
+  TMUX_SESSION="$(jq -r --arg default "crew-${project_name}" '.tmux_session // $default' "$config_file")"
+  STATE_DIR="$(jq -r --arg default "/tmp/ralph-crew/${project_name}" '.state_dir // $default' "$config_file")"
   LOG_FILE="${STATE_DIR}/logs/dispatch.log"
 
   echo "$config_file"
@@ -105,17 +114,11 @@ _start_worker() {
     return 1
   fi
 
-  local project_dir model mcp_config system_prompt permissions_json
-  project_dir="$(echo "$worker_json" | jq -r '.project_dir')"
+  local model mcp_config system_prompt permissions_json
   model="$(echo "$worker_json" | jq -r '.model // "sonnet"')"
   mcp_config="$(echo "$worker_json" | jq -r '.mcp_config // empty')"
   system_prompt="$(echo "$worker_json" | jq -r '.system_prompt // empty')"
   permissions_json="$(echo "$worker_json" | jq '.permissions // empty')"
-
-  if [[ ! -d "$project_dir" ]]; then
-    _error "Project directory not found: $project_dir"
-    return 1
-  fi
 
   # If worker has fix tasks, adjust permissions: allow git push, deny only force push
   local has_fix
@@ -139,7 +142,7 @@ _start_worker() {
   if tmux list-windows -t "$TMUX_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF "$window_name"; then
     tmux kill-window -t "${TMUX_SESSION}:${window_name}" 2>/dev/null || true
   fi
-  tmux new-window -t "$TMUX_SESSION" -n "$window_name" -c "$project_dir"
+  tmux new-window -t "$TMUX_SESSION" -n "$window_name" -c "$PROJECT_DIR"
 
   local pane_id
   pane_id="$(tmux display-message -t "${TMUX_SESSION}:${window_name}" -p '#{pane_id}')"
@@ -163,11 +166,11 @@ _start_worker() {
   }')"
 
   if [[ -n "$permissions_json" && "$permissions_json" != "null" ]]; then
-    ralph_setup_worker_settings "$project_dir" "$permissions_json" "$hook_json"
+    ralph_setup_worker_settings "$PROJECT_DIR" "$permissions_json" "$hook_json"
   else
-    ralph_setup_worker_settings "$project_dir" "$RALPH_DEFAULT_PERMISSIONS" "$hook_json"
+    ralph_setup_worker_settings "$PROJECT_DIR" "$RALPH_DEFAULT_PERMISSIONS" "$hook_json"
   fi
-  _info "Worker settings created: ${project_dir}/.claude/settings.local.json"
+  _info "Worker settings created: ${PROJECT_DIR}/.claude/settings.local.json"
 
   # Write system prompt to file
   local system_prompt_file="${STATE_DIR}/system-prompts/${worker_id}.txt"
@@ -198,7 +201,7 @@ _start_worker() {
   jq -n \
     --arg id "$worker_id" \
     --arg pane_id "$pane_id" \
-    --arg project_dir "$project_dir" \
+    --arg project_dir "$PROJECT_DIR" \
     --arg model "$model" \
     --argjson started "$(date +%s)" \
     '{
@@ -615,7 +618,7 @@ Usage:
                                                    Restart a worker
   ralph-crew teardown                           Stop all workers and cleanup
 
-Config file default: $DEFAULT_CONFIG
+Config file default: \$PWD/$DEFAULT_CONFIG
 EOF
     ;;
 esac

--- a/templates/com.user.ralph-crew.plist
+++ b/templates/com.user.ralph-crew.plist
@@ -9,7 +9,7 @@
         <string>__HOME__/dotfiles/scripts/ralph-crew</string>
         <string>dispatch</string>
         <string>--config</string>
-        <string>__HOME__/.config/ralph-crew/crew.json</string>
+        <string>__PROJECT__/.claude/crew.json</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>

--- a/templates/crew.example.json
+++ b/templates/crew.example.json
@@ -1,13 +1,9 @@
 {
-  "tmux_session": "ralph-crew",
-  "state_dir": "/tmp/ralph-crew",
   "workers": [
     {
-      "id": "qa-frontend",
-      "project_dir": "/path/to/project",
+      "id": "qa",
       "model": "sonnet",
-      "mcp_config": null,
-      "system_prompt": "You are a QA engineer focused on the frontend module.",
+      "system_prompt": "You are a QA engineer. Run checks, fix issues or report them.",
       "permissions": {
         "allow": [
           "Bash(npm:*)",
@@ -27,7 +23,7 @@
     {
       "id": "lint-fix",
       "pattern": "standing",
-      "worker_id": "qa-frontend",
+      "worker_id": "qa",
       "action": "fix",
       "prompt": "Run `npx eslint .` and `npx tsc --noEmit`. If issues found, fix them.",
       "schedule": {
@@ -38,7 +34,7 @@
     {
       "id": "test-watch",
       "pattern": "standing",
-      "worker_id": "qa-frontend",
+      "worker_id": "qa",
       "action": "issue-only",
       "prompt": "Run `npm test`. If any tests fail, analyze failures and create a GitHub issue.",
       "schedule": {


### PR DESCRIPTION
## Summary

- crew.json の配置をグローバル (`~/.config/ralph-crew/`) からプロジェクトローカル (`<project>/.claude/crew.json`) に変更
- プロジェクトディレクトリを config ファイルパスから自動導出
- workers から `project_dir` フィールドを削除 (冗長)
- `tmux_session` / `state_dir` のデフォルトをプロジェクト名ベースに変更

## Test plan

- [ ] `ralph-crew help` のデフォルトパスが `$PWD/.claude/crew.json` と表示される
- [ ] `ralph-crew init --config /path/to/project/.claude/crew.json` でプロジェクトディレクトリが正しく導出される
- [ ] launchd plist の `__PROJECT__` プレースホルダーが置換可能

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)