### PR TITLE
feat(tmux): add pane-level Claude Code idle notification

### DIFF
--- a/common/tmux/.config/tmux/tokyonight.tmux
+++ b/common/tmux/.config/tmux/tokyonight.tmux
@@ -27,7 +27,7 @@ set -g pane-border-style "fg=#3b4261,bg=default"
 # off: subtle, reload: active, thumbs: info, copy: error, sync: success, prefix: warning, zoom: inactive, default: primary
 set -g pane-active-border-style '#{?#{==:#{client_key_table},off},fg=#545c7e bg=#1a1b26,#{?#{==:#{@reload_mode},1},fg=#ff9e64 bg=#1a1b26,#{?#{==:#{window_name},[thumbs]},fg=#41a6b5 bg=#1a1b26,#{?pane_in_mode,fg=#f7768e bg=#1a1b26,#{?pane_synchronized,fg=#73daca bg=#1a1b26,#{?client_prefix,fg=#ffea00 bg=#1a1b26,#{?window_zoomed_flag,fg=#bb9af7 bg=#1a1b26,fg=#7aa2f7 bg=#1a1b26}}}}}}}'
 set -g pane-border-status top
-set -g pane-border-format " #P: #{?pane_title,#{pane_title},#{pane_current_command}} "
+set -g pane-border-format " #P: #{?pane_title,#{pane_title},#{pane_current_command}}#{?#{@claude_status}, #[fg=#{?#{==:#{@claude_status},permission},#f7768e,#ff9e64}]#{@claude_icon}#[default],} "
 set -g pane-border-indicators both
 
 # --- Window Style ---

--- a/scripts/tmux-claude-badge.sh
+++ b/scripts/tmux-claude-badge.sh
@@ -54,25 +54,34 @@ show_window_badge() {
   # キャッシュ無効/なし: 計算実行
   local count=0
 
-  for f in "$STATUS_DIR"/workspace_*.json; do
-    [[ -f "$f" ]] || continue
+  # 1. tmux pane option チェック (純ローカル、Beacon不要)
+  local pane_count
+  pane_count=$(tmux list-panes -t "${session_name}:${window_index}" -F '#{@claude_status}' 2>/dev/null \
+    | grep -cE '^(idle|permission|complete)$' || true)
+  count=$pane_count
 
-    # jq 1回で3フィールドを取得（@tsvでタブ区切り）
-    local result
-    result=$(jq -r '[.tmux_session // "", .tmux_window_index // "", .status // "none"] | @tsv' "$f" 2>/dev/null)
-    [[ -z "$result" ]] && continue
+  # 2. ファイルベースのフォールバック (リモート/Beacon連携用、pane通知がなければ参照)
+  if [[ $count -eq 0 ]]; then
+    for f in "$STATUS_DIR"/workspace_*.json; do
+      [[ -f "$f" ]] || continue
 
-    local file_session file_window file_status
-    IFS=$'\t' read -r file_session file_window file_status <<< "$result"
+      # jq 1回で3フィールドを取得（@tsvでタブ区切り）
+      local result
+      result=$(jq -r '[.tmux_session // "", .tmux_window_index // "", .status // "none"] | @tsv' "$f" 2>/dev/null)
+      [[ -z "$result" ]] && continue
 
-    if [[ "$file_session" == "$session_name" && "$file_window" == "$window_index" ]]; then
-      case "$file_status" in
-        idle|permission|complete)
-          ((count++))
-          ;;
-      esac
-    fi
-  done
+      local file_session file_window file_status
+      IFS=$'\t' read -r file_session file_window file_status <<< "$result"
+
+      if [[ "$file_session" == "$session_name" && "$file_window" == "$window_index" ]]; then
+        case "$file_status" in
+          idle|permission|complete)
+            ((count++))
+            ;;
+        esac
+      fi
+    done
+  fi
 
   # キャッシュ保存
   echo "$count" > "$cache_file" 2>/dev/null

--- a/scripts/tmux-claude-focus.sh
+++ b/scripts/tmux-claude-focus.sh
@@ -15,7 +15,8 @@ WINDOW_INDEX=$(tmux display-message -p '#I' 2>/dev/null || echo "")
 
 [[ -z "$SESSION" || -z "$WINDOW_INDEX" ]] && exit 0
 
-# tmuxウィンドウの通知を消去（claude-status.shに委譲）
+# tmuxウィンドウの通知を消去（ファイルベースのみ）
+# pane option はペーン単位の通知なのでここでは消さない（PreToolUse hook で消去）
 clear_tmux_window() {
   local session="$1"
   local window_index="$2"
@@ -48,11 +49,18 @@ start_clear_timer() {
   echo "${session}:${window_index}:${now}:${timer_pid}" > "$FOCUS_STATE_FILE"
 }
 
-# このウィンドウに通知があるかチェック
+# このウィンドウに通知があるかチェック（pane option + ファイルベース）
 has_notification() {
   local session="$1"
   local window_index="$2"
 
+  # 1. pane option チェック（高速）
+  local pane_count
+  pane_count=$(tmux list-panes -t "${session}:${window_index}" -F '#{@claude_status}' 2>/dev/null \
+    | grep -cE '^(idle|permission|complete)$' || true)
+  [[ $pane_count -gt 0 ]] && return 0
+
+  # 2. ファイルベース フォールバック
   [[ ! -d "$STATUS_DIR" ]] && return 1
 
   for f in "$STATUS_DIR"/workspace_*.json; do

--- a/scripts/tmux-claude-pane.sh
+++ b/scripts/tmux-claude-pane.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# tmux Claude Code ペーン通知管理 (純tmuxローカル)
+# Claude Code hooks から呼び出され、pane user option で通知状態を管理する。
+# Beacon (workspace/Slack/SketchyBar) とは独立して動作。
+#
+# Usage:
+#   tmux-claude-pane.sh set <status>    # idle | permission | complete
+#   tmux-claude-pane.sh clear           # 通知クリア
+#   tmux-claude-pane.sh scan            # 全ペーンをスキャンして idle Claude を検出・設定
+
+set -euo pipefail
+
+# tmux 外では何もしない
+[[ -z "${TMUX:-}" ]] && exit 0
+
+# $TMUX_PANE はプロセス起動元ペーンの ID（固定）
+# tmux display-message -p はユーザーのアクティブペーンを返すため、
+# hook 経由だと別ペーンの通知を誤クリアする
+PANE_ID="${TMUX_PANE:-$(tmux display-message -p '#{pane_id}' 2>/dev/null)}"
+[[ -z "$PANE_ID" ]] && exit 0
+
+case "${1:-}" in
+  set)
+    STATUS="${2:-idle}"
+    case "$STATUS" in
+      idle)       ICON="󰔟" ;;
+      permission) ICON="󰌆" ;;
+      complete)   ICON="" ;;
+      *)
+        echo "Unknown status: $STATUS" >&2
+        exit 1
+        ;;
+    esac
+
+    tmux set-option -p -t "$PANE_ID" @claude_status "$STATUS"
+    tmux set-option -p -t "$PANE_ID" @claude_icon "$ICON"
+    tmux refresh-client -S 2>/dev/null || true
+
+    # complete は 10秒後に自動クリア（idle_prompt が先に来れば上書きされる）
+    if [[ "$STATUS" == "complete" ]]; then
+      (
+        sleep 10
+        # 現在の状態が complete のままなら解除（上書きされていたら何もしない）
+        CURRENT=$(tmux show-options -pv -t "$PANE_ID" @claude_status 2>/dev/null || echo "")
+        if [[ "$CURRENT" == "complete" ]]; then
+          tmux set-option -p -t "$PANE_ID" -u @claude_status 2>/dev/null || true
+          tmux set-option -p -t "$PANE_ID" -u @claude_icon 2>/dev/null || true
+          tmux refresh-client -S 2>/dev/null || true
+        fi
+      ) &
+      disown
+    fi
+    ;;
+
+  clear)
+    # 既にクリア済みなら何もしない（不要な refresh を避ける）
+    CURRENT=$(tmux show-options -pv -t "$PANE_ID" @claude_status 2>/dev/null || echo "")
+    [[ -z "$CURRENT" ]] && exit 0
+
+    tmux set-option -p -t "$PANE_ID" -u @claude_status 2>/dev/null || true
+    tmux set-option -p -t "$PANE_ID" -u @claude_icon 2>/dev/null || true
+    tmux refresh-client -S 2>/dev/null || true
+    ;;
+
+  scan)
+    # 全ペーンをスキャンして idle/permission 状態の Claude Code を検出
+    found=0
+    while IFS=$'\t' read -r pid cmd status; do
+      # 既に状態設定済みならスキップ
+      [[ -n "$status" ]] && continue
+      # Claude Code はバージョン番号がコマンド名になる (例: 2.1.39)
+      [[ "$cmd" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+
+      # ペーン内容の末尾を取得して状態を判定
+      content=$(tmux capture-pane -t "$pid" -p -S -10 2>/dev/null || echo "")
+
+      detected_status=""
+      if echo "$content" | grep -qE '(permission|approve|allow)'; then
+        detected_status="permission"
+      elif echo "$content" | grep -qE '(^❯ $|⏵⏵|RALPH_COMPLETE|^\$ $)'; then
+        detected_status="idle"
+      fi
+
+      if [[ -n "$detected_status" ]]; then
+        case "$detected_status" in
+          idle)       icon="󰔟" ;;
+          permission) icon="󰌆" ;;
+        esac
+        tmux set-option -p -t "$pid" @claude_status "$detected_status"
+        tmux set-option -p -t "$pid" @claude_icon "$icon"
+        pane_title=$(tmux display-message -t "$pid" -p '#{pane_title}' 2>/dev/null || echo "")
+        echo "$pid ($pane_title): $detected_status"
+        ((found++))
+      fi
+    done < <(tmux list-panes -a -F "#{pane_id}$(printf '\t')#{pane_current_command}$(printf '\t')#{@claude_status}")
+
+    if [[ $found -gt 0 ]]; then
+      tmux refresh-client -S 2>/dev/null || true
+      echo "Detected $found idle Claude pane(s)"
+    else
+      echo "No idle Claude panes found"
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 {set <idle|permission|complete>|clear|scan}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- tmux pane option (`@claude_status`) ベースの通知システムを追加
- Beacon (workspace/Slack/SketchyBar) とは独立し、workspace 登録不要で純 tmux ローカルに完結
- idle/permission/complete 状態を pane border のアイコンとウィンドウバッジで表示

## Changes

- `scripts/tmux-claude-pane.sh` (new): `set`/`clear`/`scan` サブコマンドで pane option を管理
- `common/tmux/.config/tmux/tokyonight.tmux`: `pane-border-format` に `@claude_status` アイコン表示を追加
- `scripts/tmux-claude-badge.sh`: pane option を優先チェック、ファイルベースはフォールバック
- `scripts/tmux-claude-focus.sh`: pane option はウィンドウフォーカスで消さない (PreToolUse hook に委譲)

## Hook 設定 (settings.json に手動追加済み)

- `Notification(idle_prompt)` → `tmux-claude-pane.sh set idle`
- `Notification(permission_prompt)` → `tmux-claude-pane.sh set permission`
- `Stop` → `tmux-claude-pane.sh set complete`
- `PreToolUse` → `tmux-claude-pane.sh clear`

## Test plan

- [x] `tmux-claude-pane.sh set idle` で pane option が設定される
- [x] `tmux-claude-pane.sh clear` でクリアされる
- [x] `tmux-claude-pane.sh scan` で idle Claude pane を検出・設定
- [x] pane-border-format にアイコンが表示される
- [x] window badge が pane option を反映する
- [x] `$TMUX_PANE` 使用で別ペーンの通知を誤クリアしない
- [x] ウィンドウフォーカスで pane option が消えない

Closes #14