### PR TITLE
Add ralph-schedule for one-shot scheduled Claude TUI execution

### DIFF
--- a/docs/ralph-schedule.md
+++ b/docs/ralph-schedule.md
@@ -1,0 +1,146 @@
+# Ralph Schedule - 予約投稿型 Claude TUI 実行
+
+指定時刻に Claude TUI を自動起動し、`/ralph` で自律実行させるワンショットスケジューラー。セッション切れ時でもシェルスクリプトのみで予約の登録・実行が完結する。
+
+`ralph-crew` (常駐型定期ディスパッチ) とは異なり、一回限りのスケジュール実行に特化。
+
+## Architecture
+
+```
+ralph-schedule "タスク" --at +2h --branch fix/bug
+  |
+  +-- 時刻パース (相対/絶対)
+  +-- worktree 作成 (--branch 指定時)
+  +-- プロンプトファイル作成
+  +-- ジョブメタデータ作成
+  +-- launchd (macOS) / at (Linux) 登録
+  v
+
+[指定時刻]
+  |
+  v
+ralph-schedule-exec.sh <job-id>
+  |
+  +-- ジョブメタデータ読み込み、status -> running
+  +-- Self-cleanup: launchd bootout + plist 削除
+  +-- tmux セッション確認/作成
+  +-- worktree 確認/作成 + tmux ウィンドウ作成
+  +-- ralph_setup_worker_settings (パーミッション設定)
+  +-- claude --model <model> 起動
+  +-- _wait_for_tui (ポーリングで TUI 準備待ち)
+  +-- /ralph 'Read <prompt_file>...' --skip-plan 注入
+  +-- status -> done
+  v
+Claude TUI が /ralph ループで自律実行
+```
+
+## Usage
+
+### 予約登録
+
+```bash
+# 相対時刻
+ralph-schedule "認証バグを修正して" --at +30m --branch fix/auth-bug
+ralph-schedule "テスト追加" --at +2h --branch feat/tests --base main
+ralph-schedule "lint修正" --at +1h30m
+
+# 絶対時刻 (HH:MM - 過去なら翌日に繰り越し)
+ralph-schedule "リファクタリング" --at 09:00 --branch refactor/cleanup
+
+# 絶対日時
+ralph-schedule "機能追加" --at "2026-03-28 14:00" --branch feat/new --model opus
+```
+
+### 管理
+
+```bash
+ralph-schedule list              # テーブル形式で一覧
+ralph-schedule list --json       # JSON 形式
+ralph-schedule cancel <job-id>   # 個別キャンセル
+ralph-schedule cancel --all      # 全 pending ジョブキャンセル
+```
+
+### クリーンアップ
+
+```bash
+claude-gc              # dry-run: 完了済みジョブ + 孤立 plist を表示
+claude-gc --force      # 実際に削除
+```
+
+## CLI Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `<prompt>` | (必須) | Claude に送るタスク記述 |
+| `--at <time-spec>` | (必須) | 実行時刻 |
+| `--branch <name>` | (なし) | worktree + tmux ウィンドウを作成 |
+| `--base <ref>` | HEAD | `--branch` 使用時のベース ref |
+| `--model <model>` | sonnet | Claude モデル |
+
+## Time Formats
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| `+Nm` | `+30m` | N 分後 |
+| `+Nh` | `+2h` | N 時間後 |
+| `+NhMm` | `+1h30m` | N 時間 M 分後 |
+| `HH:MM` | `09:00` | 当日の指定時刻 (過去なら翌日) |
+| `YYYY-MM-DD HH:MM` | `2026-03-28 14:00` | 絶対日時 (過去はエラー) |
+
+## State Directory
+
+```
+/tmp/ralph-schedule/
+  jobs/<job-id>.json       # ジョブメタデータ
+  prompts/<job-id>.md      # プロンプトファイル
+  logs/<job-id>.log        # executor 実行ログ
+  logs/<job-id>.out        # launchd stdout
+  logs/<job-id>.err        # launchd stderr
+```
+
+ジョブ ID: `sched-<epoch>-<random5>` (時系列ソート可能 + 一意性)
+
+Status 遷移: `pending` -> `running` -> `done` / `failed` (cancel 時は `cancelled`)
+
+## Scheduling
+
+### macOS: launchd (StartCalendarInterval)
+
+`templates/com.user.ralph-schedule.plist` をベースに、プレースホルダーを sed で置換して plist を生成。`StartCalendarInterval` で指定時刻に発火、executor 内で self-cleanup (bootout + plist 削除)。
+
+### Linux: at
+
+`at` コマンドが利用可能ならそれを使用。なければエラー終了。
+
+## Tmux Session Strategy
+
+executor は launchd から呼ばれるため `$TMUX` が未設定。worktree 作成と tmux ウィンドウ作成を分離して直接実行する:
+
+- 登録時の tmux セッション名を記録 (`$TMUX` 未設定時は `ralph-schedule` をデフォルトに)
+- executor はセッション存在確認 -> なければ作成
+- `tmux new-window -t <session> -n <window> -c <dir>` で直接ウィンドウ作成
+
+## File Structure
+
+```
+dotfiles/
++-- scripts/
+|   +-- ralph-schedule              # メイン CLI (add/list/cancel)
+|   +-- ralph-schedule-exec.sh      # launchd/at から呼ばれる executor
+|   +-- ralph-lib.sh                # 共有ユーティリティ (permissions setup)
+|   +-- wt-lib.sh                   # worktree + tmux ウィンドウ管理ライブラリ
+|   +-- claude-gc                   # クリーンアップ (_gc_ralph_schedule 追加)
++-- templates/
+|   +-- com.user.ralph-schedule.plist  # launchd plist テンプレート
++-- docs/
+    +-- ralph-schedule.md              # このドキュメント
+```
+
+## Design Decisions
+
+- ワンショット: ralph-crew (常駐定期ディスパッチ) とは異なり、一回限りのスケジュール実行に特化
+- Claudeレス登録: シェルスクリプトのみで予約完結。セッション切れ時でも使用可能
+- worktree 即時作成: 登録時に worktree を作成し、executor は存在確認のみ (フォールバックで作成も可)
+- launchd self-cleanup: executor が自身の plist を bootout + 削除。再発火を防止
+- ファイル経由プロンプト注入: tmux send-keys のエスケープ問題を回避 (ralph-crew と同じパターン)
+- claude-gc 統合: 完了済みジョブと孤立 plist のクリーンアップを既存 GC フローに統合

--- a/docs/ralph.md
+++ b/docs/ralph.md
@@ -271,15 +271,19 @@ dotfiles/
 |   |   +-- ralph-parallel/SKILL.md
 |   +-- claude-agents/
 |       +-- ralph-worker/ralph-worker.md
+|   +-- com.user.ralph-schedule.plist  # launchd plist for scheduled execution
 +-- scripts/
 |   +-- wt-lib.sh                      # Worktree + tmux window management library
 |   +-- ralph-lib.sh                   # Shared utilities (permissions setup)
 |   +-- ralph-orchestrate           # Parallel worker lifecycle management
 |   +-- ralph-crew                  # Persistent worker management with periodic dispatch
+|   +-- ralph-schedule              # One-shot scheduled Claude TUI execution
+|   +-- ralph-schedule-exec.sh      # Executor called by launchd/at
 |   +-- claude-gc                   # Cleanup all Claude artifacts (state, worktrees, branches, tmux)
 +-- docs/
     +-- ralph.md                       # This documentation
     +-- ralph-crew.md                  # Crew system documentation
+    +-- ralph-schedule.md              # Schedule system documentation
 ```
 
 `~/.claude/settings.json` contains the SessionStart hook registration.

--- a/scripts/claude-gc
+++ b/scripts/claude-gc
@@ -5,9 +5,10 @@
 #   1. /tmp/ralph/state/ の orphaned state/active ファイル
 #   2. /tmp/ralph/ 配下の workers, results, prompts, checkpoint
 #   3. /tmp/ralph-crew/ 配下のファイル
-#   4. git worktree (--wt-- パターン)
-#   5. orphaned git branch (ralph/*, crew/*)
-#   6. orphaned tmux sessions (数字名の空セッション)
+#   4. /tmp/ralph-schedule/ の完了済みジョブ + 孤立plist
+#   5. git worktree (--wt-- パターン)
+#   6. orphaned git branch (ralph/*, crew/*)
+#   7. orphaned tmux sessions (数字名の空セッション)
 #
 # Usage:
 #   claude-gc              # dry-run (削除対象を表示)
@@ -169,7 +170,83 @@ _gc_ralph_crew() {
   done
 }
 
-# --- 4. Git worktrees ---
+# --- 4. Ralph schedule artifacts ---
+_gc_ralph_schedule() {
+  local base="/tmp/ralph-schedule"
+  local jobs_dir="${base}/jobs"
+  [[ -d "$jobs_dir" ]] || return 0
+
+  local has_target=false
+  for job_file in "$jobs_dir"/*.json; do
+    [[ -f "$job_file" ]] || continue
+    local status
+    status="$(jq -r '.status' "$job_file" 2>/dev/null || echo "unknown")"
+    if [[ "$status" == "done" || "$status" == "failed" || "$status" == "cancelled" ]]; then
+      has_target=true
+      break
+    fi
+  done
+
+  # Check for orphaned plists
+  if [[ "$(uname)" == "Darwin" ]]; then
+    for plist in "$HOME/Library/LaunchAgents"/com.user.ralph-schedule.*.plist; do
+      [[ -f "$plist" ]] || continue
+      has_target=true
+      break
+    done
+  fi
+
+  [[ "$has_target" == true ]] || return 0
+
+  _info "Ralph schedule artifacts ($base)"
+
+  # Clean completed/failed/cancelled jobs and their artifacts
+  for job_file in "$jobs_dir"/*.json; do
+    [[ -f "$job_file" ]] || continue
+    local job_id status prompt_file
+    job_id="$(jq -r '.id' "$job_file" 2>/dev/null || true)"
+    status="$(jq -r '.status' "$job_file" 2>/dev/null || echo "unknown")"
+
+    if [[ "$status" == "done" || "$status" == "failed" || "$status" == "cancelled" ]]; then
+      # Remove prompt file
+      prompt_file="$(jq -r '.prompt_file // empty' "$job_file" 2>/dev/null || true)"
+      if [[ -n "$prompt_file" ]] && [[ -f "$prompt_file" ]]; then
+        _do_remove_file "$prompt_file"
+      fi
+      # Remove log files
+      for log_ext in log out err; do
+        local log_path="${base}/logs/${job_id}.${log_ext}"
+        if [[ -f "$log_path" ]]; then
+          _do_remove_file "$log_path"
+        fi
+      done
+      # Remove job file
+      _do_remove_file "$job_file"
+    fi
+  done
+
+  # Clean orphaned plists (no corresponding pending job)
+  if [[ "$(uname)" == "Darwin" ]]; then
+    for plist in "$HOME/Library/LaunchAgents"/com.user.ralph-schedule.*.plist; do
+      [[ -f "$plist" ]] || continue
+      local plist_basename
+      plist_basename="$(basename "$plist" .plist)"
+      # Extract job ID: com.user.ralph-schedule.<job-id> -> <job-id>
+      local plist_job_id="${plist_basename#com.user.ralph-schedule.}"
+
+      local matching_job="${jobs_dir}/${plist_job_id}.json"
+      if [[ ! -f "$matching_job" ]] || [[ "$(jq -r '.status' "$matching_job" 2>/dev/null)" != "pending" ]]; then
+        # Bootout before removing
+        if [[ "$DRY_RUN" == false ]]; then
+          launchctl bootout "gui/$(id -u)/${plist_basename}" 2>/dev/null || true
+        fi
+        _do_remove_file "$plist"
+      fi
+    done
+  fi
+}
+
+# --- 5. Git worktrees ---
 _gc_worktrees() {
   # 全リポジトリの worktree をチェックするのは困難なので、
   # カレントリポジトリ (git 管理下にいる場合) のみ対象
@@ -212,7 +289,7 @@ _gc_worktrees() {
   fi
 }
 
-# --- 5. Orphaned branches ---
+# --- 6. Orphaned branches ---
 _gc_branches() {
   if ! git rev-parse --git-dir &>/dev/null 2>&1; then
     return 0
@@ -243,7 +320,7 @@ _gc_branches() {
   done
 }
 
-# --- 6. Orphaned tmux sessions ---
+# --- 7. Orphaned tmux sessions ---
 _gc_tmux_sessions() {
   # 数字のみの名前のセッションで、アタッチされていないものを対象
   local found=false
@@ -274,6 +351,7 @@ echo ""
 _gc_ralph_state
 _gc_ralph_orchestrate
 _gc_ralph_crew
+_gc_ralph_schedule
 _gc_worktrees
 _gc_branches
 _gc_tmux_sessions

--- a/scripts/ralph-schedule
+++ b/scripts/ralph-schedule
@@ -1,0 +1,487 @@
+#!/usr/bin/env bash
+# ralph-schedule - One-shot scheduled Claude TUI execution
+#
+# Schedule a Claude TUI session to launch at a specified time.
+# Designed for launchd (macOS) / at (Linux) integration.
+#
+# Usage:
+#   ralph-schedule <prompt> --at <time-spec> [--branch <name>] [--base <ref>] [--model <model>]
+#   ralph-schedule list [--json]
+#   ralph-schedule cancel <job-id>
+#   ralph-schedule cancel --all
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/wt-lib.sh"
+
+STATE_DIR="/tmp/ralph-schedule"
+TEMPLATE_DIR="$(cd "${SCRIPT_DIR}/../templates" && pwd)"
+
+# --- Output ---
+
+_info()    { printf '\033[0;36minfo\033[0m %s\n' "$*" >&2; }
+_error()   { printf '\033[0;31merror\033[0m %s\n' "$*" >&2; }
+_success() { printf '\033[0;32mok\033[0m %s\n' "$*" >&2; }
+
+# --- Time parsing ---
+
+_parse_time_spec() {
+  local spec="$1"
+  local now
+  now="$(date +%s)"
+
+  # Relative: +NhMm
+  if [[ "$spec" =~ ^\+([0-9]+)h([0-9]+)m$ ]]; then
+    local hours="${BASH_REMATCH[1]}"
+    local mins="${BASH_REMATCH[2]}"
+    echo $(( now + hours * 3600 + mins * 60 ))
+    return 0
+  fi
+
+  # Relative: +Nh
+  if [[ "$spec" =~ ^\+([0-9]+)h$ ]]; then
+    local hours="${BASH_REMATCH[1]}"
+    echo $(( now + hours * 3600 ))
+    return 0
+  fi
+
+  # Relative: +Nm
+  if [[ "$spec" =~ ^\+([0-9]+)m$ ]]; then
+    local mins="${BASH_REMATCH[1]}"
+    echo $(( now + mins * 60 ))
+    return 0
+  fi
+
+  # Absolute datetime: YYYY-MM-DD HH:MM
+  if [[ "$spec" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}$ ]]; then
+    local epoch
+    if [[ "$(uname)" == "Darwin" ]]; then
+      epoch="$(date -j -f '%Y-%m-%d %H:%M' "$spec" +%s 2>/dev/null)" \
+        || { _error "Invalid datetime: $spec"; return 1; }
+    else
+      epoch="$(date -d "$spec" +%s 2>/dev/null)" \
+        || { _error "Invalid datetime: $spec"; return 1; }
+    fi
+    if [[ "$epoch" -le "$now" ]]; then
+      _error "Specified time is in the past: $spec"
+      return 1
+    fi
+    echo "$epoch"
+    return 0
+  fi
+
+  # Absolute time only: HH:MM
+  if [[ "$spec" =~ ^[0-9]{2}:[0-9]{2}$ ]]; then
+    local today_str
+    today_str="$(date '+%Y-%m-%d') $spec"
+    local epoch
+    if [[ "$(uname)" == "Darwin" ]]; then
+      epoch="$(date -j -f '%Y-%m-%d %H:%M' "$today_str" +%s 2>/dev/null)" \
+        || { _error "Invalid time: $spec"; return 1; }
+    else
+      epoch="$(date -d "$today_str" +%s 2>/dev/null)" \
+        || { _error "Invalid time: $spec"; return 1; }
+    fi
+    # If past, roll to tomorrow
+    if [[ "$epoch" -le "$now" ]]; then
+      epoch=$(( epoch + 86400 ))
+    fi
+    echo "$epoch"
+    return 0
+  fi
+
+  _error "Unsupported time format: $spec (use +Nh, +Nm, +NhMm, HH:MM, or YYYY-MM-DD HH:MM)"
+  return 1
+}
+
+_epoch_to_display() {
+  local epoch="$1"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    date -r "$epoch" '+%Y-%m-%d %H:%M'
+  else
+    date -d "@$epoch" '+%Y-%m-%d %H:%M'
+  fi
+}
+
+_epoch_to_calendar_field() {
+  local epoch="$1"
+  local field="$2"
+  if [[ "$(uname)" == "Darwin" ]]; then
+    case "$field" in
+      month)  date -r "$epoch" '+%-m' ;;
+      day)    date -r "$epoch" '+%-d' ;;
+      hour)   date -r "$epoch" '+%-H' ;;
+      minute) date -r "$epoch" '+%-M' ;;
+    esac
+  else
+    case "$field" in
+      month)  date -d "@$epoch" '+%-m' ;;
+      day)    date -d "@$epoch" '+%-d' ;;
+      hour)   date -d "@$epoch" '+%-H' ;;
+      minute) date -d "@$epoch" '+%-M' ;;
+    esac
+  fi
+}
+
+# --- Job ID ---
+
+_generate_job_id() {
+  local epoch="$1"
+  local random
+  random="$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c5 || true)"
+  echo "sched-${epoch}-${random}"
+}
+
+# --- Scheduler registration ---
+
+_register_launchd() {
+  local job_id="$1"
+  local epoch="$2"
+
+  local label="com.user.ralph-schedule.${job_id}"
+  local plist_src="${TEMPLATE_DIR}/com.user.ralph-schedule.plist"
+  local plist_dst="$HOME/Library/LaunchAgents/${label}.plist"
+
+  local month day hour minute
+  month="$(_epoch_to_calendar_field "$epoch" month)"
+  day="$(_epoch_to_calendar_field "$epoch" day)"
+  hour="$(_epoch_to_calendar_field "$epoch" hour)"
+  minute="$(_epoch_to_calendar_field "$epoch" minute)"
+
+  mkdir -p "$HOME/Library/LaunchAgents"
+  sed \
+    -e "s|__LABEL__|${label}|g" \
+    -e "s|__HOME__|${HOME}|g" \
+    -e "s|__JOB_ID__|${job_id}|g" \
+    -e "s|__MONTH__|${month}|g" \
+    -e "s|__DAY__|${day}|g" \
+    -e "s|__HOUR__|${hour}|g" \
+    -e "s|__MINUTE__|${minute}|g" \
+    "$plist_src" > "$plist_dst"
+
+  launchctl bootstrap "gui/$(id -u)" "$plist_dst"
+  echo "$label"
+}
+
+_register_at() {
+  local job_id="$1"
+  local epoch="$2"
+
+  if ! command -v at &>/dev/null; then
+    _error "'at' command not available. Install it or use macOS with launchd."
+    return 1
+  fi
+
+  local at_time
+  if [[ "$(uname)" == "Darwin" ]]; then
+    at_time="$(date -r "$epoch" '+%H:%M %m/%d/%Y')"
+  else
+    at_time="$(date -d "@$epoch" '+%H:%M %m/%d/%Y')"
+  fi
+
+  local exec_script="${SCRIPT_DIR}/ralph-schedule-exec.sh"
+  echo "${exec_script} ${job_id}" | at "$at_time" 2>&1
+}
+
+# === Subcommands ===
+
+cmd_add() {
+  local prompt="" time_spec="" branch="" base="" model="sonnet"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --at)
+        shift
+        time_spec="${1:-}"
+        # Handle "YYYY-MM-DD HH:MM" as two arguments
+        if [[ "$time_spec" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] && [[ "${2:-}" =~ ^[0-9]{2}:[0-9]{2}$ ]]; then
+          time_spec="$time_spec $2"
+          shift
+        fi
+        shift ;;
+      --branch) branch="${2:-}"; shift 2 ;;
+      --base)   base="${2:-}"; shift 2 ;;
+      --model)  model="${2:-}"; shift 2 ;;
+      --*)      _error "Unknown option: $1"; return 1 ;;
+      *)
+        if [[ -z "$prompt" ]]; then
+          prompt="$1"
+        else
+          _error "Unexpected argument: $1"
+          return 1
+        fi
+        shift ;;
+    esac
+  done
+
+  [[ -z "$prompt" ]] && { _error "prompt is required"; return 1; }
+  [[ -z "$time_spec" ]] && { _error "--at <time-spec> is required"; return 1; }
+
+  # Parse time
+  local scheduled_epoch
+  scheduled_epoch="$(_parse_time_spec "$time_spec")" || return 1
+  local scheduled_at
+  scheduled_at="$(_epoch_to_display "$scheduled_epoch")"
+
+  # Verify git repo
+  wt_check_git || return 1
+
+  local project_dir
+  project_dir="$(wt_main_worktree)"
+
+  # Generate job ID
+  local job_id
+  job_id="$(_generate_job_id "$scheduled_epoch")"
+
+  # Create state dirs
+  mkdir -p "${STATE_DIR}"/{jobs,prompts,logs}
+
+  # Determine tmux session
+  local tmux_session="ralph-schedule"
+  if [[ -n "${TMUX:-}" ]]; then
+    tmux_session="$(tmux display-message -p '#{session_name}')"
+  fi
+
+  # Determine tmux window name and worktree path
+  local tmux_window="" worktree_path=""
+  if [[ -n "$branch" ]]; then
+    tmux_window="$(wt_window_name "$branch")"
+    worktree_path="$(wt_path "$branch")"
+
+    # Create worktree now (executor will verify at execution time)
+    cd "$project_dir"
+    if ! wt_exists "$branch"; then
+      if git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+        git worktree add "$worktree_path" "$branch" >&2
+      elif git show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null; then
+        git worktree add "$worktree_path" "$branch" >&2
+      else
+        if [[ -n "$base" ]]; then
+          git worktree add -b "$branch" "$worktree_path" "$base" >&2
+        else
+          git worktree add -b "$branch" "$worktree_path" >&2
+        fi
+      fi
+      wt_copy_ignored "$project_dir" "$worktree_path"
+      _success "Created worktree: $worktree_path"
+    else
+      _info "Worktree already exists: $worktree_path"
+    fi
+  else
+    tmux_window="sched/${job_id}"
+  fi
+
+  # Write prompt file
+  local prompt_file="${STATE_DIR}/prompts/${job_id}.md"
+  printf '%s\n' "$prompt" > "$prompt_file"
+
+  # Register scheduler
+  local scheduler="" plist_label=""
+  if [[ "$(uname)" == "Darwin" ]]; then
+    scheduler="launchd"
+    plist_label="$(_register_launchd "$job_id" "$scheduled_epoch")"
+    _success "Registered launchd job: $plist_label"
+  else
+    scheduler="at"
+    _register_at "$job_id" "$scheduled_epoch"
+    _success "Registered at job"
+  fi
+
+  # Write job metadata
+  local created_at
+  created_at="$(date '+%Y-%m-%d %H:%M')"
+
+  jq -n \
+    --arg id "$job_id" \
+    --argjson scheduled_epoch "$scheduled_epoch" \
+    --arg scheduled_at "$scheduled_at" \
+    --arg created_at "$created_at" \
+    --arg branch "$branch" \
+    --arg base "$base" \
+    --arg model "$model" \
+    --arg project_dir "$project_dir" \
+    --arg tmux_session "$tmux_session" \
+    --arg tmux_window "$tmux_window" \
+    --arg worktree_path "$worktree_path" \
+    --arg prompt_file "$prompt_file" \
+    --arg scheduler "$scheduler" \
+    --arg plist_label "$plist_label" \
+    '{
+      id: $id,
+      scheduled_epoch: $scheduled_epoch,
+      scheduled_at: $scheduled_at,
+      created_at: $created_at,
+      branch: (if $branch == "" then null else $branch end),
+      base: (if $base == "" then null else $base end),
+      model: $model,
+      project_dir: $project_dir,
+      tmux_session: $tmux_session,
+      tmux_window: $tmux_window,
+      worktree_path: (if $worktree_path == "" then null else $worktree_path end),
+      prompt_file: $prompt_file,
+      status: "pending",
+      scheduler: $scheduler,
+      plist_label: (if $plist_label == "" then null else $plist_label end)
+    }' > "${STATE_DIR}/jobs/${job_id}.json"
+
+  _success "Scheduled job: $job_id"
+  _info "  At: $scheduled_at"
+  _info "  Model: $model"
+  if [[ -n "$branch" ]]; then
+    _info "  Branch: $branch"
+    _info "  Worktree: $worktree_path"
+  fi
+  _info "  Prompt: $(head -c 60 "$prompt_file")"
+}
+
+cmd_list() {
+  local json_mode=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) json_mode=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local jobs_dir="${STATE_DIR}/jobs"
+  if [[ ! -d "$jobs_dir" ]] || [[ -z "$(ls -A "$jobs_dir" 2>/dev/null)" ]]; then
+    if [[ "$json_mode" == true ]]; then
+      echo "[]"
+    else
+      _info "No scheduled jobs"
+    fi
+    return 0
+  fi
+
+  if [[ "$json_mode" == true ]]; then
+    local first=true
+    echo "["
+    for job_file in "$jobs_dir"/*.json; do
+      [[ -f "$job_file" ]] || continue
+      if [[ "$first" == true ]]; then
+        first=false
+      else
+        echo ","
+      fi
+      cat "$job_file"
+    done
+    echo "]"
+    return 0
+  fi
+
+  # Table format
+  printf '%-28s %-10s %-18s %-20s %s\n' "ID" "STATUS" "SCHEDULED" "BRANCH" "PROMPT"
+  printf '%-28s %-10s %-18s %-20s %s\n' "---" "------" "---------" "------" "------"
+
+  for job_file in "$jobs_dir"/*.json; do
+    [[ -f "$job_file" ]] || continue
+    local id status scheduled_at branch_val prompt_file prompt_head
+    id="$(jq -r '.id' "$job_file")"
+    status="$(jq -r '.status' "$job_file")"
+    scheduled_at="$(jq -r '.scheduled_at' "$job_file")"
+    branch_val="$(jq -r '.branch // "-"' "$job_file")"
+    prompt_file="$(jq -r '.prompt_file' "$job_file")"
+    if [[ -f "$prompt_file" ]]; then
+      prompt_head="$(head -c 30 "$prompt_file" | tr '\n' ' ')"
+    else
+      prompt_head="(file missing)"
+    fi
+    printf '%-28s %-10s %-18s %-20s %s\n' "$id" "$status" "$scheduled_at" "$branch_val" "$prompt_head"
+  done
+}
+
+cmd_cancel() {
+  local cancel_all=false
+  local job_id=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --all) cancel_all=true; shift ;;
+      *) job_id="$1"; shift ;;
+    esac
+  done
+
+  if [[ "$cancel_all" == true ]]; then
+    local jobs_dir="${STATE_DIR}/jobs"
+    [[ -d "$jobs_dir" ]] || { _info "No jobs to cancel"; return 0; }
+    local cancelled=0
+    for job_file in "$jobs_dir"/*.json; do
+      [[ -f "$job_file" ]] || continue
+      local id status
+      id="$(jq -r '.id' "$job_file")"
+      status="$(jq -r '.status' "$job_file")"
+      [[ "$status" == "pending" ]] || continue
+      _cancel_job "$id"
+      cancelled=$((cancelled + 1))
+    done
+    _success "Cancelled $cancelled job(s)"
+    return 0
+  fi
+
+  [[ -z "$job_id" ]] && { _error "Usage: ralph-schedule cancel <job-id> | --all"; return 1; }
+  _cancel_job "$job_id"
+}
+
+_cancel_job() {
+  local job_id="$1"
+  local job_file="${STATE_DIR}/jobs/${job_id}.json"
+
+  if [[ ! -f "$job_file" ]]; then
+    _error "Job not found: $job_id"
+    return 1
+  fi
+
+  local scheduler status
+  scheduler="$(jq -r '.scheduler' "$job_file")"
+  status="$(jq -r '.status' "$job_file")"
+
+  if [[ "$status" != "pending" ]]; then
+    _error "Job $job_id is not pending (status: $status)"
+    return 1
+  fi
+
+  # Unregister from scheduler
+  if [[ "$scheduler" == "launchd" ]]; then
+    local plist_label
+    plist_label="$(jq -r '.plist_label' "$job_file")"
+    local plist_path="$HOME/Library/LaunchAgents/${plist_label}.plist"
+    launchctl bootout "gui/$(id -u)/${plist_label}" 2>/dev/null || true
+    rm -f "$plist_path"
+  fi
+
+  # Update status
+  jq '.status = "cancelled"' "$job_file" > "${job_file}.tmp" \
+    && mv "${job_file}.tmp" "$job_file"
+
+  _success "Cancelled job: $job_id"
+}
+
+# --- Main ---
+
+case "${1:-}" in
+  list)    shift; cmd_list "$@" ;;
+  cancel)  shift; cmd_cancel "$@" ;;
+  help|-h|--help)
+    cat <<EOF
+ralph-schedule - One-shot scheduled Claude TUI execution
+
+Usage:
+  ralph-schedule <prompt> --at <time-spec> [options]
+  ralph-schedule list [--json]
+  ralph-schedule cancel <job-id>
+  ralph-schedule cancel --all
+
+Time formats:
+  +Nh, +Nm, +NhMm    Relative (e.g. +2h, +30m, +1h30m)
+  HH:MM               Today (rolls to tomorrow if past)
+  YYYY-MM-DD HH:MM    Absolute datetime
+
+Options:
+  --branch <name>    Create worktree + tmux window for branch
+  --base <ref>       Base ref for new branch (default: HEAD)
+  --model <model>    Claude model (default: sonnet)
+EOF
+    ;;
+  *)       cmd_add "$@" ;;
+esac

--- a/scripts/ralph-schedule-exec.sh
+++ b/scripts/ralph-schedule-exec.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# ralph-schedule-exec.sh - One-shot executor for scheduled Claude TUI sessions
+#
+# Called by launchd (macOS) or at (Linux).
+# Launches Claude TUI in a tmux window and injects /ralph with the prompt file.
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/wt-lib.sh"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/ralph-lib.sh"
+
+STATE_DIR="/tmp/ralph-schedule"
+JOB_ID="${1:-}"
+
+[[ -z "$JOB_ID" ]] && { echo "Usage: ralph-schedule-exec.sh <job-id>" >&2; exit 1; }
+
+JOB_FILE="${STATE_DIR}/jobs/${JOB_ID}.json"
+LOG_FILE="${STATE_DIR}/logs/${JOB_ID}.log"
+
+# --- Logging ---
+
+_log() {
+  local ts
+  ts="$(date '+%Y-%m-%d %H:%M:%S')"
+  mkdir -p "$(dirname "$LOG_FILE")"
+  printf '[%s] %s\n' "$ts" "$*" >> "$LOG_FILE"
+}
+
+_update_status() {
+  local new_status="$1"
+  jq --arg s "$new_status" '.status = $s' "$JOB_FILE" > "${JOB_FILE}.tmp" \
+    && mv "${JOB_FILE}.tmp" "$JOB_FILE"
+}
+
+# --- Wait for TUI (same pattern as ralph-crew) ---
+
+_wait_for_tui() {
+  local pane_id="$1"
+  local timeout="${2:-30}"
+  local elapsed=0
+
+  while [[ "$elapsed" -lt "$timeout" ]]; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+    local content
+    content="$(tmux capture-pane -t "$pane_id" -p 2>/dev/null || true)"
+    if echo "$content" | grep -qE '❯|^\s*>|^╭|tips'; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# --- Validate ---
+
+if [[ ! -f "$JOB_FILE" ]]; then
+  echo "Job file not found: $JOB_FILE" >&2
+  exit 1
+fi
+
+_log "Starting executor for job: $JOB_ID"
+_update_status "running"
+
+# --- Self-cleanup: launchd ---
+
+scheduler="$(jq -r '.scheduler' "$JOB_FILE")"
+if [[ "$scheduler" == "launchd" ]]; then
+  plist_label="$(jq -r '.plist_label' "$JOB_FILE")"
+  plist_path="$HOME/Library/LaunchAgents/${plist_label}.plist"
+  launchctl bootout "gui/$(id -u)/${plist_label}" 2>/dev/null || true
+  rm -f "$plist_path"
+  _log "Self-cleanup: removed launchd job $plist_label"
+fi
+
+# --- Read metadata ---
+
+tmux_session="$(jq -r '.tmux_session' "$JOB_FILE")"
+tmux_window="$(jq -r '.tmux_window' "$JOB_FILE")"
+project_dir="$(jq -r '.project_dir' "$JOB_FILE")"
+worktree_path="$(jq -r '.worktree_path // empty' "$JOB_FILE")"
+branch="$(jq -r '.branch // empty' "$JOB_FILE")"
+base="$(jq -r '.base // empty' "$JOB_FILE")"
+model="$(jq -r '.model // "sonnet"' "$JOB_FILE")"
+prompt_file="$(jq -r '.prompt_file' "$JOB_FILE")"
+
+# --- Ensure tmux session ---
+
+if ! tmux has-session -t "$tmux_session" 2>/dev/null; then
+  tmux new-session -d -s "$tmux_session"
+  _log "Created tmux session: $tmux_session"
+fi
+
+# --- Create worktree + tmux window ---
+
+work_dir="$project_dir"
+
+if [[ -n "$branch" ]]; then
+  # Worktree mode
+  if [[ -n "$worktree_path" ]] && [[ ! -d "$worktree_path" ]]; then
+    cd "$project_dir"
+    if git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+      git worktree add "$worktree_path" "$branch"
+    elif git show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null; then
+      git worktree add "$worktree_path" "$branch"
+    else
+      if [[ -n "$base" ]]; then
+        git worktree add -b "$branch" "$worktree_path" "$base"
+      else
+        git worktree add -b "$branch" "$worktree_path"
+      fi
+    fi
+    wt_copy_ignored "$project_dir" "$worktree_path"
+    _log "Created worktree: $worktree_path"
+  fi
+  work_dir="${worktree_path:-$project_dir}"
+fi
+
+# Kill existing window if present, then create new one
+if tmux list-windows -t "$tmux_session" -F '#{window_name}' 2>/dev/null | grep -qxF "$tmux_window"; then
+  tmux kill-window -t "${tmux_session}:${tmux_window}" 2>/dev/null || true
+fi
+tmux new-window -t "$tmux_session" -n "$tmux_window" -c "$work_dir"
+_log "Created tmux window: ${tmux_session}:${tmux_window}"
+
+# --- Get pane ID ---
+
+pane_id="$(tmux display-message -t "${tmux_session}:${tmux_window}" -p '#{pane_id}')"
+
+# --- Setup worker permissions ---
+
+ralph_setup_worker_settings "$work_dir"
+_log "Worker settings configured: ${work_dir}/.claude/settings.local.json"
+
+# --- Launch Claude TUI ---
+
+tmux send-keys -t "$pane_id" "claude --model ${model}" Enter
+
+if ! _wait_for_tui "$pane_id" 30; then
+  _log "Timeout waiting for TUI (continuing anyway)"
+fi
+
+# --- Inject /ralph ---
+
+tmux send-keys -t "$pane_id" "/ralph 'Read ${prompt_file} for task instructions and implement accordingly.' --skip-plan" Enter
+_log "Dispatched /ralph for job: $JOB_ID"
+
+_update_status "done"
+_log "Executor completed for job: $JOB_ID"

--- a/templates/com.user.ralph-schedule.plist
+++ b/templates/com.user.ralph-schedule.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>__LABEL__</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/dotfiles/scripts/ralph-schedule-exec.sh</string>
+        <string>__JOB_ID__</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Month</key>
+        <integer>__MONTH__</integer>
+        <key>Day</key>
+        <integer>__DAY__</integer>
+        <key>Hour</key>
+        <integer>__HOUR__</integer>
+        <key>Minute</key>
+        <integer>__MINUTE__</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/ralph-schedule/logs/__JOB_ID__.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ralph-schedule/logs/__JOB_ID__.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Add `ralph-schedule` command for scheduling one-shot Claude TUI sessions at specified times. Unlike `ralph-crew` (persistent periodic dispatch), this is designed for fire-and-forget scheduled execution that works even when Claude sessions are disconnected.

## Changes

- `scripts/ralph-schedule` - Main CLI with `add`, `list`, `cancel` subcommands
  - Time parsing: relative (`+Nh`, `+Nm`, `+NhMm`), absolute (`HH:MM`, `YYYY-MM-DD HH:MM`)
  - Worktree creation at registration time when `--branch` is specified
  - launchd (macOS) / at (Linux) scheduler registration
- `scripts/ralph-schedule-exec.sh` - Internal executor called by launchd/at
  - Self-cleanup (bootout + plist deletion)
  - tmux session/window creation, Claude TUI launch, `/ralph` injection
- `templates/com.user.ralph-schedule.plist` - launchd plist template with `StartCalendarInterval`
- `scripts/claude-gc` - Add `_gc_ralph_schedule()` for completed job + orphaned plist cleanup
- `docs/ralph-schedule.md` - Full documentation
- `docs/ralph.md` - Update File Structure section

## Test plan

- [ ] `ralph-schedule "test" --at +5m --branch test/schedule` creates job metadata, prompt file, plist, and worktree
- [ ] `ralph-schedule list` displays job table
- [ ] `ralph-schedule cancel <id>` removes plist and updates status
- [ ] Executor launches Claude TUI and injects `/ralph` at scheduled time
- [ ] `claude-gc --force` cleans up completed jobs

Closes #20