### PR TITLE
fix(wt): create new branches from default branch instead of current HEAD

### DIFF
--- a/scripts/wt-lib.sh
+++ b/scripts/wt-lib.sh
@@ -34,6 +34,23 @@ wt_repo_name() {
   basename "$main"
 }
 
+wt_default_branch() {
+  local ref
+  ref="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)" && {
+    echo "${ref#refs/remotes/origin/}"
+    return 0
+  }
+  # origin/HEAD が未設定の場合、main / master をチェック
+  for candidate in main master; do
+    if git show-ref --verify --quiet "refs/remotes/origin/$candidate" 2>/dev/null; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  wt_error "Could not detect default branch"
+  return 1
+}
+
 wt_path() {
   local branch="$1"
   local main_path
@@ -200,11 +217,14 @@ wt_create() {
     elif git show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null; then
       git worktree add "$path" "$branch" >&2
     else
-      if [[ -n "$base" ]]; then
-        git worktree add -b "$branch" "$path" "$base" >&2
-      else
-        git worktree add -b "$branch" "$path" >&2
+      if [[ -z "$base" ]]; then
+        local default_branch
+        default_branch="$(wt_default_branch)" || return 1
+        git fetch origin "$default_branch" >&2
+        base="origin/$default_branch"
+        wt_info "Base: $base (default branch)"
       fi
+      git worktree add -b "$branch" "$path" "$base" >&2
     fi
     local main
     main="$(wt_main_worktree)"


### PR DESCRIPTION
## Summary

`wt new <branch>` (base未指定) が現在のHEADからブランチを作成していたため、フィーチャーブランチ上で実行すると意図しない分岐元になっていた。デフォルトブランチを fetch してそこから分岐するように変更。

## Changes

- `wt_default_branch()` 関数を追加: `origin/HEAD` からデフォルトブランチを検出、未設定時は main/master にフォールバック
- `wt_create()` の新ブランチ作成ロジックを変更: base 未指定時に `origin/<default_branch>` を fetch して分岐元に使用
- 現在のワークツリーのブランチには影響しない (`git worktree add -b` は HEAD を変更しない)

## Test plan

- [ ] `wt new test-branch` で `origin/main` から分岐することを確認
- [ ] `wt new test-branch develop` で指定した base から分岐することを確認
- [ ] フィーチャーブランチ上で `wt new` 実行時に現在のブランチが変わらないことを確認
- [ ] `origin/HEAD` 未設定のリポジトリで main/master フォールバックが動作することを確認

Closes #24