### PR TITLE
Add automatic cache cleanup for Neovim to prevent performance degradation

### DIFF
--- a/common/nvim/.config/nvim/lua/config/autocmds.lua
+++ b/common/nvim/.config/nvim/lua/config/autocmds.lua
@@ -223,3 +223,220 @@ vim.api.nvim_create_autocmd("ColorScheme", {
   end,
 })
 
+-- Cache cleanup on startup
+-- Prevents performance degradation from accumulated logs, undo files, and compiled caches
+vim.api.nvim_create_autocmd("VimEnter", {
+  group = vim.api.nvim_create_augroup("cache_cleanup", { clear = true }),
+  callback = function()
+    vim.schedule(function()
+      local uv = vim.uv or vim.loop
+      local state_dir = vim.fn.stdpath("state")
+      local cache_dir = vim.fn.stdpath("cache")
+
+      -- Rotate LSP/Mason logs (compress if > 1MB, delete compressed files > 30 days old)
+      local function rotate_log(log_path)
+        local stat = uv.fs_stat(log_path)
+        if not stat then
+          return
+        end
+
+        local max_size = 1024 * 1024 -- 1MB
+        if stat.size > max_size then
+          local timestamp = os.date("%Y%m%d_%H%M%S")
+          local rotated = log_path .. "." .. timestamp .. ".gz"
+          -- Compress and truncate
+          vim.fn.system(string.format("gzip -c %s > %s && : > %s", log_path, rotated, log_path))
+        end
+
+        -- Delete old compressed logs (> 30 days)
+        local dir = vim.fn.fnamemodify(log_path, ":h")
+        local pattern = vim.fn.fnamemodify(log_path, ":t") .. ".*.gz"
+        local handle = uv.fs_scandir(dir)
+        if handle then
+          while true do
+            local name, type = uv.fs_scandir_next(handle)
+            if not name then
+              break
+            end
+            if type == "file" and name:match(vim.pesc(vim.fn.fnamemodify(log_path, ":t")) .. "%.%d+_%d+%.gz$") then
+              local file_path = dir .. "/" .. name
+              local file_stat = uv.fs_stat(file_path)
+              if file_stat then
+                local age_days = (os.time() - file_stat.mtime.sec) / 86400
+                if age_days > 30 then
+                  uv.fs_unlink(file_path)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      rotate_log(state_dir .. "/lsp.log")
+      rotate_log(state_dir .. "/mason.log")
+
+      -- Delete old undo files (> 30 days)
+      local undo_dir = state_dir .. "/undo"
+      local undo_handle = uv.fs_scandir(undo_dir)
+      if undo_handle then
+        while true do
+          local name, type = uv.fs_scandir_next(undo_handle)
+          if not name then
+            break
+          end
+          if type == "file" then
+            local undo_path = undo_dir .. "/" .. name
+            local undo_stat = uv.fs_stat(undo_path)
+            if undo_stat then
+              local age_days = (os.time() - undo_stat.mtime.sec) / 86400
+              if age_days > 30 then
+                uv.fs_unlink(undo_path)
+              end
+            end
+          end
+        end
+      end
+
+      -- Delete old luac cache (> 3 days)
+      -- Ref: https://github.com/neovim/neovim/issues/31165
+      local luac_dir = cache_dir .. "/luac"
+      local function cleanup_luac_recursive(dir)
+        local handle = uv.fs_scandir(dir)
+        if not handle then
+          return
+        end
+        while true do
+          local name, type = uv.fs_scandir_next(handle)
+          if not name then
+            break
+          end
+          local path = dir .. "/" .. name
+          if type == "directory" then
+            cleanup_luac_recursive(path)
+          elseif type == "file" and name:match("%.luac$") then
+            local stat = uv.fs_stat(path)
+            if stat then
+              local age_days = (os.time() - stat.mtime.sec) / 86400
+              if age_days > 3 then
+                uv.fs_unlink(path)
+              end
+            end
+          end
+        end
+      end
+      cleanup_luac_recursive(luac_dir)
+    end)
+  end,
+})
+
+-- Manual cache cleanup command
+vim.api.nvim_create_user_command("CleanupCache", function()
+  vim.notify("Starting cache cleanup...", vim.log.levels.INFO)
+
+  local uv = vim.uv or vim.loop
+  local state_dir = vim.fn.stdpath("state")
+  local cache_dir = vim.fn.stdpath("cache")
+  local stats = { logs_rotated = 0, undo_deleted = 0, luac_deleted = 0 }
+
+  -- Rotate LSP/Mason logs
+  local function rotate_log(log_path)
+    local stat = uv.fs_stat(log_path)
+    if not stat then
+      return
+    end
+    local max_size = 1024 * 1024 -- 1MB
+    if stat.size > max_size then
+      local timestamp = os.date("%Y%m%d_%H%M%S")
+      local rotated = log_path .. "." .. timestamp .. ".gz"
+      vim.fn.system(string.format("gzip -c %s > %s && : > %s", log_path, rotated, log_path))
+      stats.logs_rotated = stats.logs_rotated + 1
+    end
+    -- Delete old compressed logs
+    local dir = vim.fn.fnamemodify(log_path, ":h")
+    local handle = uv.fs_scandir(dir)
+    if handle then
+      while true do
+        local name, type = uv.fs_scandir_next(handle)
+        if not name then
+          break
+        end
+        if type == "file" and name:match(vim.pesc(vim.fn.fnamemodify(log_path, ":t")) .. "%.%d+_%d+%.gz$") then
+          local file_path = dir .. "/" .. name
+          local file_stat = uv.fs_stat(file_path)
+          if file_stat then
+            local age_days = (os.time() - file_stat.mtime.sec) / 86400
+            if age_days > 30 then
+              uv.fs_unlink(file_path)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  rotate_log(state_dir .. "/lsp.log")
+  rotate_log(state_dir .. "/mason.log")
+
+  -- Delete old undo files
+  local undo_dir = state_dir .. "/undo"
+  local undo_handle = uv.fs_scandir(undo_dir)
+  if undo_handle then
+    while true do
+      local name, type = uv.fs_scandir_next(undo_handle)
+      if not name then
+        break
+      end
+      if type == "file" then
+        local undo_path = undo_dir .. "/" .. name
+        local undo_stat = uv.fs_stat(undo_path)
+        if undo_stat then
+          local age_days = (os.time() - undo_stat.mtime.sec) / 86400
+          if age_days > 30 then
+            uv.fs_unlink(undo_path)
+            stats.undo_deleted = stats.undo_deleted + 1
+          end
+        end
+      end
+    end
+  end
+
+  -- Delete old luac cache
+  local luac_dir = cache_dir .. "/luac"
+  local function cleanup_luac_recursive(dir)
+    local handle = uv.fs_scandir(dir)
+    if not handle then
+      return
+    end
+    while true do
+      local name, type = uv.fs_scandir_next(handle)
+      if not name then
+        break
+      end
+      local path = dir .. "/" .. name
+      if type == "directory" then
+        cleanup_luac_recursive(path)
+      elseif type == "file" and name:match("%.luac$") then
+        local stat = uv.fs_stat(path)
+        if stat then
+          local age_days = (os.time() - stat.mtime.sec) / 86400
+          if age_days > 7 then
+            uv.fs_unlink(path)
+            stats.luac_deleted = stats.luac_deleted + 1
+          end
+        end
+      end
+    end
+  end
+  cleanup_luac_recursive(luac_dir)
+
+  vim.notify(
+    string.format(
+      "Cache cleanup complete: %d logs rotated, %d undo files deleted, %d luac files deleted",
+      stats.logs_rotated,
+      stats.undo_deleted,
+      stats.luac_deleted
+    ),
+    vim.log.levels.INFO
+  )
+end, { desc = "Clean up Neovim cache, logs, and old files" })
+

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -555,6 +555,27 @@ DBUI 内での操作:
 - `:ProfileStart` / `:ProfileStop` でカーソル移動等のプロファイリング（`/tmp/nvim-profile.log` に出力）
 - LazyVim デフォルトの `lazyvim_wrap_spell` を無効化（日本語テキストが SpellBad 扱いされるのを防止）
 - **大きいファイル最適化**: 100KB 以上のファイルを開いた際、syntax / filetype / swapfile / undofile / fold を自動無効化（リモート環境での遅延対策）
+- **キャッシュ自動クリーンアップ**: Neovim起動時に古いキャッシュ・ログ・undoファイルを自動削除し、パフォーマンス低下を防止
+  - LSP/Masonログ: 1MB超過時に圧縮・ローテーション（30日以上前のgzファイルを削除）
+  - undoファイル: 30日以上前のファイルを削除
+  - luacキャッシュ: 3日以上前のコンパイル済みLuaファイルを削除
+  - 手動実行: `:CleanupCache` でクリーンアップ実行 + 統計表示
+
+### キャッシュクリーンアップ詳細
+
+Neovimの長時間使用により、以下のファイルが肥大化してパフォーマンス低下を引き起こします:
+
+1. **LSP/Masonログ** (`~/.local/state/nvim/lsp.log`, `mason.log`): ローテーションなしで蓄積
+2. **undoファイル** (`~/.local/state/nvim/undo/`): 古いundoファイルが削除されない
+3. **luacキャッシュ** (`~/.cache/nvim/luac/`): プラグイン更新後も古いキャッシュが残る（[Issue #31165](https://github.com/neovim/neovim/issues/31165)）
+
+`VimEnter` autocmdで以下を自動実行:
+- ログファイルが1MB超過時に `gzip` で圧縮・ローテーション
+- 圧縮済みログの30日以上前のファイルを削除
+- 30日以上前のundoファイルを削除
+- 3日以上前のluacキャッシュを削除
+
+手動で即座にクリーンアップしたい場合は `:CleanupCache` を実行。削除されたファイル数が通知されます。
 
 ## カーソル視認性
 


### PR DESCRIPTION
## Summary

Implements automatic cleanup of accumulated cache files, logs, and undo files that cause Neovim performance degradation over time. The cleanup runs on every Neovim startup and can also be triggered manually with the `:CleanupCache` command.

## Changes

- **Automatic cleanup on startup** (`VimEnter` autocmd):
  - LSP/Mason logs: rotate when > 1MB, delete compressed logs > 30 days old
  - Undo files: delete files > 30 days old
  - Luac cache: delete compiled Lua files > 3 days old (addresses [neovim/neovim#31165](https://github.com/neovim/neovim/issues/31165))
- **Manual cleanup command**: `:CleanupCache` with statistics output
- **Documentation**: added cache cleanup details to `docs/neovim.md`

## Implementation details

All cleanup operations are scheduled asynchronously using `vim.schedule()` to avoid blocking Neovim startup. The cleanup uses `vim.uv` (libuv) file system APIs for efficient file scanning and deletion.

## Test plan

- [x] Verify Neovim starts without errors
- [x] Confirm cleanup runs on startup (check file counts before/after)
- [x] Test `:CleanupCache` command manually
- [x] Verify documentation is clear and accurate

Closes #26