### PR TITLE
feat(sketchybar): Claude使用量ゲージと入力方式インジケータを追加

### DIFF
--- a/common/sketchybar/.config/sketchybar/plugins/claude_usage.sh
+++ b/common/sketchybar/.config/sketchybar/plugins/claude_usage.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Claude Code 使用量ゲージ
+# ▁▂▃▄▅▆▇█ の縦棒文字でセッション/週間残量を表示
+#
+# データ取得: macOS キーチェーン "Claude Code-credentials" の OAuth トークンを使用
+# エンドポイント: https://api.anthropic.com/api/oauth/usage (非公式)
+
+# shellcheck source=/dev/null
+source "$CONFIG_DIR/plugins/colors.sh"
+
+USAGE_FILE="/tmp/claude_code_usage"
+MODE_COLOR=$(get_mode_color)
+
+# キーチェーンからOAuthアクセストークンを取得して使用量を更新
+update_usage() {
+  local creds_json
+  creds_json=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+  [[ -z "$creds_json" ]] && return 1
+
+  local token
+  token=$(echo "$creds_json" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d['claudeAiOauth']['accessToken'])
+" 2>/dev/null)
+  [[ -z "$token" ]] && return 1
+
+  curl -sf --max-time 5 \
+    -H "Authorization: Bearer $token" \
+    -H "anthropic-beta: oauth-2025-04-20" \
+    "https://api.anthropic.com/api/oauth/usage" 2>/dev/null | \
+  python3 -c "
+import sys, json
+try:
+  d = json.load(sys.stdin)
+  s = round(d['five_hour']['utilization'])
+  w = round(d['seven_day']['utilization'])
+  print(max(0, min(100, s)))
+  print(max(0, min(100, w)))
+except Exception:
+  sys.exit(1)
+" > "$USAGE_FILE" 2>/dev/null
+}
+
+# 同期で取得（--max-time 5 なので最大5秒、失敗時は既存キャッシュを使用）
+update_usage
+
+session_pct=0
+weekly_pct=0
+
+if [[ -f "$USAGE_FILE" ]]; then
+  session_pct=$(sed -n '1p' "$USAGE_FILE" 2>/dev/null | tr -d '[:space:]')
+  weekly_pct=$(sed -n '2p' "$USAGE_FILE" 2>/dev/null | tr -d '[:space:]')
+fi
+
+[[ "$session_pct" =~ ^[0-9]+$ ]] || session_pct=0
+[[ "$weekly_pct" =~ ^[0-9]+$ ]] || weekly_pct=0
+(( session_pct > 100 )) && session_pct=100
+(( weekly_pct > 100 )) && weekly_pct=100
+
+make_vbar() {
+  local pct=$1
+  local level=$(( pct * 8 / 100 ))
+  local chars=(" " "▁" "▂" "▃" "▄" "▅" "▆" "▇" "█")
+  echo "${chars[$level]}"
+}
+
+session_bar=$(make_vbar "$session_pct")
+weekly_bar=$(make_vbar "$weekly_pct")
+
+sketchybar --set claude_usage \
+  label="${session_bar}${weekly_bar} ${session_pct}%/${weekly_pct}%" \
+  background.border_color="$MODE_COLOR"

--- a/common/sketchybar/.config/sketchybar/plugins/input_method.sh
+++ b/common/sketchybar/.config/sketchybar/plugins/input_method.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# 入力方式インジケータ（日本語/英語）
+
+# shellcheck source=/dev/null
+source "$CONFIG_DIR/plugins/colors.sh"
+
+MODE_COLOR=$(get_mode_color)
+
+# 現在の入力モードを取得（Input Mode で判定）
+# Roman = 英語、Japanese/* = 日本語
+input_mode=$(defaults read ~/Library/Preferences/com.apple.HIToolbox.plist AppleSelectedInputSources 2>/dev/null \
+  | /usr/bin/grep '"Input Mode"' | head -1 \
+  | sed 's/.*= "\(.*\)";/\1/')
+
+if echo "$input_mode" | /usr/bin/grep -qi "japanese"; then
+  label="JP"
+  label_color=0xffffffff
+  bg_color="$ACCENT_COLOR"
+else
+  label="EN"
+  label_color=0xff6c757d
+  bg_color=0xff1e1f29
+fi
+
+sketchybar --set input_method \
+  label="$label" \
+  label.color="$label_color" \
+  background.color="$bg_color" \
+  background.border_color="$MODE_COLOR"

--- a/common/sketchybar/.config/sketchybar/sketchybarrc
+++ b/common/sketchybar/.config/sketchybar/sketchybarrc
@@ -135,6 +135,46 @@ sketchybar --add item pomodoro right \
            click_script="$HOME/dotfiles/scripts/pomodoro.sh toggle"
 
 
+##### Claude Code Usage (right side) #####
+# Unicode 半ブロック文字で上下2段ゲージを1行に表現
+# 上半分 = セッション残量、下半分 = 週間残量
+sketchybar --add item claude_usage right \
+           --subscribe claude_usage mode_color_changed \
+           --set claude_usage \
+           icon.drawing=off \
+           label="  0%/0%" \
+           label.font="Hack Nerd Font:Bold:10.0" \
+           label.color=0xffffffff \
+           label.padding_left=8 \
+           label.padding_right=8 \
+           background.color=0xff1e1f29 \
+           background.border_color="$ACCENT_COLOR" \
+           background.border_width=2 \
+           background.corner_radius=5 \
+           background.height=24 \
+           background.drawing=on \
+           update_freq=300 \
+           script="$PLUGIN_DIR/claude_usage.sh"
+
+##### Input Method Indicator (right side) #####
+sketchybar --add item input_method right \
+           --subscribe input_method mode_color_changed \
+           --set input_method \
+           icon.drawing=off \
+           label="EN" \
+           label.font="Hack Nerd Font:Bold:10.0" \
+           label.color=0xff6c757d \
+           label.padding_left=10 \
+           label.padding_right=10 \
+           background.color=0xff1e1f29 \
+           background.border_color="$ACCENT_COLOR" \
+           background.border_width=2 \
+           background.corner_radius=5 \
+           background.height=24 \
+           background.drawing=on \
+           update_freq=2 \
+           script="$PLUGIN_DIR/input_method.sh"
+
 ##### Layout Popup Anchor (invisible, center position) #####
 sketchybar --add item layout_anchor center \
            --set layout_anchor \


### PR DESCRIPTION
Closes #32

## Summary

- `claude_usage.sh`: OAuth トークンで Anthropic 使用量 API を叩き、セッション(5時間)/週間の利用率を Unicode 縦棒文字で表示
- `input_method.sh`: `AppleSelectedInputSources` の `Input Mode` フィールドを参照して JP/EN を判定・表示
- `sketchybarrc`: 両アイテムを `right` に追加

## Test plan

- [ ] `sketchybar --reload` 後に `claude_usage` ウィジェットが使用率を表示する
- [ ] 日本語入力に切り替えると `input_method` が JP（アクセントカラー）に変わる
- [ ] 英語入力に切り替えると `input_method` が EN（グレー）に戻る