### PR TITLE
Add opensessions tmux plugin for session management and AI agent monitoring

### DIFF
--- a/common/opensessions/.config/opensessions/config.json
+++ b/common/opensessions/.config/opensessions/config.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [],
+  "theme": "tokyo-night",
+  "sidebarPosition": "left",
+  "sidebarWidth": 30,
+  "sessionFilter": "active",
+  "detailPanelHeights": {
+    "MAIN": 30
+  }
+}

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -178,6 +178,7 @@ set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'christoomey/vim-tmux-navigator'  # Neovim⇔tmux シームレス移動
 set -g @plugin 'fcsonline/tmux-thumbs'            # Vimium-style hint text selection
 set -g @plugin 'alexwforsythe/tmux-which-key'     # which-key popup menu
+set -g @plugin 'ataraxy-labs/opensessions'         # Session sidebar + AI agent status
 
 # Plugin settings
 set -g @continuum-restore 'on'

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -5,6 +5,7 @@
 tap "dotenvx/brew"
 tap "FelixKratz/formulae"
 tap "trasta298/tap"
+tap "oven-sh/bun"
 
 # --- Shell & Terminal ---
 brew "tmux"
@@ -32,6 +33,7 @@ brew "ghq"
 brew "mise"
 brew "uv"
 brew "rust"
+brew "oven-sh/bun/bun"
 brew "dotenvx/brew/dotenvx"
 
 # --- Development Workflow ---

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -29,6 +29,10 @@ NERD_FONT_URL="https://github.com/yuru7/udev-gothic/releases/download/${NERD_FON
 # curl-pipe installs
 # ════════════════════════════════════════
 
+TOOL_bun_check_cmd="bun"
+TOOL_bun_method="curl_pipe"
+TOOL_bun_curl_cmd='curl -fsSL https://bun.sh/install | bash'
+
 TOOL_starship_check_cmd="starship"
 TOOL_starship_method="curl_pipe"
 TOOL_starship_curl_cmd='curl -sS https://starship.rs/install.sh | sh -s -- -y'
@@ -328,7 +332,7 @@ TOOL_pgcli_depends_on="uv"
 
 LINUX_TOOL_ORDER=(
   # Infrastructure (no deps)
-  starship mise sheldon zoxide atuin dotenvx uv rust lazydocker direnv
+  bun starship mise sheldon zoxide atuin dotenvx uv rust lazydocker direnv
   # GitHub releases (no deps)
   fzf fastfetch delta lazygit ghq dops yazi rainfrog typst
   just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -318,6 +318,9 @@ common/tmux/.config/tmux/
 └── plugins/tmux-which-key/
     └── config.yaml    # which-key メニュー設定
 
+common/opensessions/.config/opensessions/
+└── config.json        # opensessions 設定（テーマ、サイドバー幅、詳細パネル高さ）
+
 scripts/
 ├── regenerate-tmux-theme.sh  # テーマ再生成
 ├── tmux-utils.sh             # 共通ユーティリティ（get_mtime: クロスプラットフォーム対応）
@@ -344,6 +347,7 @@ scripts/
 | tmux-continuum | 自動復元（`@continuum-restore on`） |
 | tmux-thumbs | Vimium風ヒントベーステキスト選択（URL、パス、gitハッシュ等を即コピー） |
 | tmux-which-key | which-key スタイルのキーバインドヘルプポップアップ |
+| opensessions | セッション管理サイドバー + AI エージェント状態監視 |
 
 Resurrect 設定:
 - `@resurrect-capture-pane-contents on` — Pane の表示内容も保存
@@ -359,6 +363,39 @@ tmux-which-key 設定:
 - 設定ファイル: `plugins/tmux-which-key/config.yaml`（dotfiles で管理）
 - `tmux.conf` でプラグインディレクトリへシンボリックリンクを自動作成
 - TokyoNight テーマに合わせたスタイリング
+
+opensessions 設定:
+- 設定ファイル: `common/opensessions/.config/opensessions/config.json`（stow 管理）
+- Bun ランタイム必須（macOS: `oven-sh/bun` tap、Linux: curl インストール）
+- サイドバーで全セッション一覧 + Claude Code / Amp / Codex 等の AI エージェント状態をリアルタイム表示
+- テーマ: tokyo-night（tmux テーマと統一）
+- サーバー: `127.0.0.1:7391` で自動起動、WebSocket クライアント接続なしで 30 秒後に自動終了
+- config 変更の反映にはサーバー再起動が必要（`curl -X POST localhost:7391/quit` → toggle）
+
+opensessions キーバインド:
+
+| キー | 動作 |
+|------|------|
+| `prefix o s` | サイドバーにフォーカス |
+| `prefix o t` | サイドバー toggle |
+| `prefix o 1-9` | インデックスでセッション切替 |
+| `C-s` | サイドバーフォーカス（prefix 不要） |
+| `C-t` | サイドバー toggle（prefix 不要） |
+
+サイドバー内操作:
+
+| キー | 動作 |
+|------|------|
+| `j/k` | フォーカス移動 |
+| `Enter` | セッション切替 / エージェントペインにジャンプ |
+| `Tab/Shift+Tab` | 次/前セッションに切替 |
+| `l` / 右矢印 | エージェントモード（個別スレッド操作） |
+| `h` / 左矢印 | セッションモードに戻る |
+| `Alt+Up/Down` | セッション順序変更（永続化） |
+| `f` | フィルタ切替（all / active / running） |
+| `n` | 新規セッション |
+| `d` | セッション非表示 / エージェント dismiss |
+| `x` | セッション kill（確認あり） |
 
 以前使用していた tmux-sensible、tmux-yank、tmux-cpu は削除済み:
 - tmux-sensible: 自前設定でカバー（`focus-events`、`history-limit` 等を明示指定）


### PR DESCRIPTION
## Summary

opensessions tmux プラグインを導入し、セッション管理サイドバーと AI エージェント（Claude Code, Amp, Codex）のリアルタイム状態監視を追加。

## Changes

- Bun ランタイムを macOS (Homebrew tap) と Linux (curl install) の両環境に追加
- opensessions を TPM プラグインとして tmux.conf に登録
- `common/opensessions/.config/opensessions/config.json` を stow 管理で追加（tokyo-night テーマ）
- `docs/tmux.md` に opensessions のセットアップ、キーバインド、設定方法を記載

## Test plan

- [ ] macOS で `brew install oven-sh/bun/bun` が正常にインストールされる
- [ ] Linux で `curl -fsSL https://bun.sh/install | bash` が正常にインストールされる
- [ ] `prefix + I` で TPM が opensessions プラグインをインストールできる
- [ ] `prefix o t` でサイドバーが toggle される
- [ ] 既存のキーバインドと競合しない

Closes #44