### PR TITLE
docs(ralph-crew): list cleanup subcommand in skill usage

### DIFF
--- a/docs/ralph-crew.md
+++ b/docs/ralph-crew.md
@@ -74,6 +74,7 @@ launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 /ralph-crew status
 /ralph-crew send qa "Run npm test and report results"
 /ralph-crew restart qa
+/ralph-crew cleanup
 /ralph-crew teardown
 ```
 


### PR DESCRIPTION
The `cleanup` subcommand was present in the `case "${1:-}"` dispatch block in `scripts/ralph-crew` but was missing from the skill usage examples under the 'スキル経由' heading in `docs/ralph-crew.md`. Added `/ralph-crew cleanup` between `restart` and `teardown` to match the actual subcommand order.