### PR TITLE
ralph-crew: robustness fixes for autonomous launchd operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ linux/zsh/.zshrc.local
 
 # Claude runtime state (managed by common/claude/.claude/.gitignore)
 # Note: .stow-local-ignore prevents stow from linking these files
+
+# Ralph crew test config (personal, not stowed)
+.claude/crew.json

--- a/docs/ralph-crew.md
+++ b/docs/ralph-crew.md
@@ -74,6 +74,7 @@ launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 /ralph-crew status
 /ralph-crew send qa "Run npm test and report results"
 /ralph-crew restart qa
+/ralph-crew cleanup
 /ralph-crew teardown
 ```
 
@@ -85,6 +86,7 @@ launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 |--------|-----------|------|
 | `fix` | Yes | 問題検出 → worktree で修正 → commit → push → PR 作成。修正不能なら issue にフォールバック |
 | `issue-only` | No | 問題検出 → GitHub issue 作成のみ。修正は試みない |
+| `none` | No | プロンプトをそのまま注入 (wrapper 無し)。ドライラン・レポートのみ等、タスクプロンプト自体が終端挙動を定義しているケース向け |
 
 ### fix モードのワークフロー
 

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -208,8 +208,17 @@ _start_worker() {
     printf '%s' "$system_prompt" > "$system_prompt_file"
   fi
 
-  # Build claude command
-  local cmd="claude --model ${model}"
+  # Build claude command.
+  # --dangerously-skip-permissions is required for fully unattended operation:
+  # without it, Claude TUI prompts the user on any tool not in the allow list,
+  # which deadlocks the launchd-driven dispatch loop.
+  # Note: --permission-mode bypassPermissions has the same runtime effect but
+  # shows a first-time warning dialog that requires manual confirmation, which
+  # blocks autonomous launchd invocations on a fresh project. The
+  # --dangerously-skip-permissions flag launches directly into bypass mode
+  # with no dialog. The deny list in the worker's .claude/settings.local.json
+  # remains authoritative for safety boundaries.
+  local cmd="claude --model ${model} --dangerously-skip-permissions"
   if [[ -n "$mcp_config" ]]; then
     cmd+=" --mcp-config $(printf '%q' "$mcp_config")"
   fi

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -67,8 +67,8 @@ _crew_worker_status() {
   local worker_file="${STATE_DIR}/workers/${worker_id}.json"
 
   # Check pane existence
+  local pane_id=""
   if [[ -f "$worker_file" ]]; then
-    local pane_id
     pane_id="$(jq -r '.pane_id // empty' "$worker_file")"
     if [[ -n "$pane_id" ]] && ! tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$pane_id"; then
       echo "dead"
@@ -77,11 +77,38 @@ _crew_worker_status() {
   fi
 
   # Status file based detection
+  local status="unknown"
   if [[ -f "$status_file" ]]; then
-    cat "$status_file"
-  else
-    echo "unknown"
+    status="$(cat "$status_file")"
   fi
+
+  # Fallback: Claude's Notification(idle_prompt) hook does not fire on every
+  # task completion, so a running worker can stay stuck at "running" forever.
+  # Inspect the Claude TUI footer: the "esc to interrupt" marker is only
+  # present while a tool/thinking step is in flight. Its absence means idle.
+  #
+  # A 15s grace period after the last dispatch avoids racing the TUI before
+  # it has had a chance to render "esc to interrupt".
+  if [[ "$status" == "running" && -n "$pane_id" ]]; then
+    local last_dispatch_file="${STATE_DIR}/workers/${worker_id}.last_dispatch"
+    local elapsed=999
+    if [[ -f "$last_dispatch_file" ]]; then
+      local now_epoch last_epoch
+      now_epoch="$(date +%s)"
+      last_epoch="$(cat "$last_dispatch_file")"
+      elapsed=$(( now_epoch - last_epoch ))
+    fi
+    if [[ "$elapsed" -ge 15 ]]; then
+      local pane_tail
+      pane_tail="$(tmux capture-pane -t "$pane_id" -p 2>/dev/null | tail -5)"
+      if ! echo "$pane_tail" | grep -q 'esc to interrupt'; then
+        status="idle"
+        echo "$status" > "$status_file"
+      fi
+    fi
+  fi
+
+  echo "$status"
 }
 
 # --- Worker lifecycle ---
@@ -275,8 +302,12 @@ If no issues found, report: all checks passed.
 PROMPT_EOF
   fi
 
-  # Update status to running
+  # Update status to running; also stamp per-worker dispatch time so that
+  # the idle fallback in _crew_worker_status waits out a grace period before
+  # trusting the pane-content check (the TUI needs a moment to render the
+  # "esc to interrupt" marker after send-keys).
   echo "running" > "${STATE_DIR}/workers/${worker_id}.status"
+  date +%s > "${STATE_DIR}/workers/${worker_id}.last_dispatch"
 
   # Inject task via file reference (fixed string, no escaping issues)
   tmux send-keys -t "$pane_id" "Read ${prompt_file} and follow the instructions." Enter

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -143,10 +143,11 @@ _start_worker() {
   if tmux list-windows -t "$TMUX_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF "$window_name"; then
     tmux kill-window -t "${TMUX_SESSION}:${window_name}" 2>/dev/null || true
   fi
-  tmux new-window -t "$TMUX_SESSION" -n "$window_name" -c "$PROJECT_DIR"
-
+  # Capture the new window's initial pane id directly.
+  # Using -P -F is robust against after-new-window hooks that split the window
+  # (e.g. the opensessions sidebar) and shift active-pane focus.
   local pane_id
-  pane_id="$(tmux display-message -t "${TMUX_SESSION}:${window_name}" -p '#{pane_id}')"
+  pane_id="$(tmux new-window -t "$TMUX_SESSION" -n "$window_name" -c "$PROJECT_DIR" -P -F '#{pane_id}')"
 
   # Setup permissions + Notification hook
   local hook_json

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -269,7 +269,16 @@ _dispatch_task() {
   mkdir -p "${STATE_DIR}/prompts"
   local prompt_file="${STATE_DIR}/prompts/${task_id}.md"
 
-  if [[ "$action" == "issue-only" ]]; then
+  if [[ "$action" == "none" ]]; then
+    # Raw prompt: no action wrapper. Use this when the task prompt itself
+    # specifies the desired end behavior and the fix/issue-only wrappers
+    # would conflict with it (e.g. dry-run / report-only tests).
+    cat > "$prompt_file" <<PROMPT_EOF
+# Task: ${task_id}
+
+${prompt}
+PROMPT_EOF
+  elif [[ "$action" == "issue-only" ]]; then
     cat > "$prompt_file" <<PROMPT_EOF
 # Task: ${task_id}
 

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -770,10 +770,29 @@ cmd_teardown() {
     _info "No tmux session: $TMUX_SESSION"
   fi
 
+  # Restore the project's original .claude/settings.local.json that
+  # ralph_setup_worker_settings snapshotted on init. If there was no
+  # pre-existing file, remove the worker-scoped settings entirely so
+  # the user's normal Claude sessions do not inherit worker permissions
+  # or the now-dangling Notification hook path.
+  local settings_file="${PROJECT_DIR}/.claude/settings.local.json"
+  local backup_file="${settings_file}.pre-ralph-crew"
+  if [[ -f "$backup_file" ]]; then
+    mv -f "$backup_file" "$settings_file"
+    _success "Restored original settings.local.json"
+  elif [[ -f "$settings_file" ]]; then
+    rm -f "$settings_file"
+    _success "Removed worker-scoped settings.local.json"
+  fi
+
+  # Log the completion BEFORE wiping the state dir, otherwise _log
+  # re-creates the state dir (via mkdir in _log) immediately after rm -rf,
+  # leaving an empty logs/dispatch.log stub behind on every teardown.
+  _log "teardown completed"
+
   # Cleanup state
   rm -rf "$STATE_DIR"
   _success "Cleaned up state: $STATE_DIR"
-  _log "teardown completed"
 }
 
 # --- Main ---

--- a/scripts/ralph-lib.sh
+++ b/scripts/ralph-lib.sh
@@ -62,6 +62,14 @@ ralph_setup_worker_settings() {
   mkdir -p "$settings_dir"
 
   local settings_file="${settings_dir}/settings.local.json"
+  local backup_file="${settings_file}.pre-ralph-crew"
+
+  # Preserve any pre-existing user settings so teardown can restore them.
+  # Only snapshot on the first overwrite (restart/re-init must not clobber
+  # the original backup with an already-worker-scoped settings file).
+  if [[ -f "$settings_file" && ! -f "$backup_file" ]]; then
+    cp "$settings_file" "$backup_file"
+  fi
 
   if [[ -n "$extra_settings_json" ]]; then
     # Merge permissions + extra settings


### PR DESCRIPTION
## Summary

Hardens `scripts/ralph-crew` + `scripts/ralph-lib.sh` so the dispatch loop can run unattended under launchd. All fixes were validated end-to-end against this repository: a refactor task was autonomously detected, a worktree created, the docs edited, the branch pushed, and #50 opened without any human-in-the-loop prompts.

## Changes

1. **`fix: capture worker pane id robustly against window-split hooks`** — `tmux new-window -P -F '#{pane_id}'` captures the pane id at creation time. Previously, an async `after-new-window` hook (e.g. opensessions sidebar) could split the window and shift active-pane focus, causing the worker's `claude` command to be `send-keys`-injected into the sidebar pane.

2. **`fix: detect worker idle via TUI footer with dispatch grace period`** — `_crew_worker_status` now inspects the Claude TUI footer for the `esc to interrupt` marker when the status file says `running`, with a 15s grace period anchored to a new per-worker `last_dispatch` stamp. Fixes the case where Claude's `Notification(idle_prompt)` hook does not fire and leaves the status stuck at `running` forever.

3. **`feat: action=none task mode`** — raw prompt injection with no `## Action: ...` wrapper. Useful for tasks whose prompt already specifies the desired terminal behavior (dry-run / report-only) and would otherwise conflict with the fix/issue-only wrapper.

4. **`fix: --dangerously-skip-permissions for workers`** — launches worker Claude TUIs directly into bypass mode with no confirmation dialog. `--permission-mode bypassPermissions` was tried first but shows a first-time manual-acceptance warning that deadlocks launchd dispatch. The deny list in the worker's `.claude/settings.local.json` remains authoritative.

5. **`fix: preserve and restore project settings across init/teardown`** — `ralph_setup_worker_settings` now snapshots an existing `.claude/settings.local.json` to `.pre-ralph-crew` (first overwrite only); `cmd_teardown` restores from that backup, or removes the worker-scoped file if there was no pre-existing one. Verified with md5 round-trip: the project's settings file is byte-identical before init and after teardown. Also reorders the teardown completion log before `rm -rf "$STATE_DIR"` so the log call no longer re-creates the directory and leaves an empty `logs/dispatch.log` stub.

6. **`docs: cleanup subcommand and action=none`** — fills documentation drift in `docs/ralph-crew.md` (Action Mode table + skill usage list).

7. **`chore: ignore project-local .claude/crew.json`** — this dotfiles repo keeps a personal crew config for ad-hoc runs; it is not stowed.

## Test plan

- [x] `ralph-crew init` captures the worker pane id reliably even when `after-new-window` hooks split the window (verified: pane %60 claude 249×66 running alongside sidebar pane 30×66)
- [x] Running worker is detected as idle once the TUI footer no longer shows `esc to interrupt` (verified: task completion → idle at ~21s for scripts-shellcheck, ~17s for docs-drift)
- [x] Grace period suppresses premature idle classification (verified: second task in same dispatch cycle correctly reported `skipped (worker busy)`)
- [x] `action: none` injects raw prompt with no wrapper (verified: generated prompt file contains only user prompt body)
- [x] Worker launches with `--dangerously-skip-permissions` and goes straight to ready with `⏵⏵ bypass permissions on` (verified on fresh init: no dialog)
- [x] Fresh init → teardown leaves `.claude/` with no worker settings file
- [x] Pre-existing `.claude/settings.local.json` round-trips to byte-identical state (verified with md5)
- [x] Teardown leaves no `/tmp/ralph-crew/<project>/` directory (no stub log)
- [x] End-to-end fix-mode task creates PR autonomously (proof: #50 opened by the refactor worker in 86 seconds)

## Known gaps (follow-up, not blocking this PR)

- launchd plist (`templates/com.user.ralph-crew.plist`) only dispatches; an init-at-boot companion is still needed for a truly fire-and-forget setup.
- Long-running stability of the worker Claude TUI (session token expiry, memory) has not been exercised.

Closes #51