### PR TITLE
ralph-crew: unattended launchd operation (auto-init + trust pre-accept)

### DIFF
--- a/docs/ralph-crew.md
+++ b/docs/ralph-crew.md
@@ -66,6 +66,8 @@ launchctl load ~/Library/LaunchAgents/com.user.ralph-crew.plist
 
 `__INTERVAL__` を crew.json の最短 `schedule.minutes` に合わせて設定すること。dispatch 側でタスクごとの間隔を個別に評価するため、launchd の発火間隔は最短タスク以下であれば良い。
 
+`dispatch` は tmux セッションが存在しない場合 (再起動後・初回インストール・teardown 後) に自動で `init` 相当の処理を実行するため、launchd plist は `dispatch` のみをスケジュールすれば復旧を含めて無人運用可能。別途 `RunAtLoad` init plist を用意する必要はない。
+
 ### スキル経由
 
 ```
@@ -119,6 +121,16 @@ Notification hook ベースの状態検出:
 3. タスク注入時に `running` に更新
 
 状態: `idle` / `running` / `dead` / `unknown`
+
+## Trust Dialog Pre-accept
+
+`_start_worker` は worker 起動前に `~/.claude.json` の `projects[<abs_path>].hasTrustDialogAccepted = true` を書き込む (`ralph_preaccept_trust`)。
+
+- `--dangerously-skip-permissions` では Claude の "Quick safety check" 信頼ダイアログは抑止されないため
+- 既に accepted 済みであれば no-op
+- `~/.claude.json` が存在しない場合も no-op (Claude 起動時に自動生成されるため)
+
+これにより新規プロジェクト (launchd 初回起動時) でも対話ブロックなしで worker 起動が完了する。
 
 ## Auto-restart
 

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -463,17 +463,13 @@ _sync_remote() {
 
 # === Subcommands ===
 
-cmd_init() {
-  local config_file="$DEFAULT_CONFIG"
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --config) config_file="${2:-}"; shift 2 ;;
-      *) shift ;;
-    esac
-  done
-
-  _load_config "$config_file" || return 1
-  config_file="$CONFIG_FILE"
+# Idempotent initialization: create state dirs, tmux session, and all workers.
+# Safe to call repeatedly - has-session / window-exists checks make each step
+# a no-op if already done. Extracted from cmd_init so cmd_dispatch can recover
+# from a missing session (e.g. after a reboot) without requiring a separate
+# launchd plist for init.
+_run_init() {
+  local config_file="$1"
 
   # Create state directories
   mkdir -p "${STATE_DIR}"/{workers,dispatch,prompts,system-prompts,logs}
@@ -499,6 +495,21 @@ cmd_init() {
 
   _success "Initialized $worker_count worker(s) in session: $TMUX_SESSION"
   _log "init completed: $worker_count workers"
+}
+
+cmd_init() {
+  local config_file="$DEFAULT_CONFIG"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config) config_file="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  _load_config "$config_file" || return 1
+  config_file="$CONFIG_FILE"
+
+  _run_init "$config_file"
 }
 
 cmd_dispatch() {
@@ -529,10 +540,12 @@ cmd_dispatch() {
   _cleanup_orphaned_worktrees
   _cleanup_orphaned_branches
 
-  # Check session exists
+  # Auto-init when the tmux session is missing. This lets a single launchd
+  # plist (dispatch-only, StartInterval N) recover from reboots and cover the
+  # first-time install case, without a separate init plist.
   if ! tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-    _log "tmux session not found: $TMUX_SESSION (run init first)"
-    return 1
+    _log "tmux session $TMUX_SESSION missing - running init to restore workers"
+    _run_init "$config_file" || { _log "auto-init failed"; return 1; }
   fi
 
   # Process each task

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -208,6 +208,11 @@ _start_worker() {
     printf '%s' "$system_prompt" > "$system_prompt_file"
   fi
 
+  # Pre-accept Claude's trust dialog for this project so the worker does not
+  # block on the first-launch "Quick safety check" prompt. This is essential
+  # for unattended launchd operation on fresh project directories.
+  ralph_preaccept_trust "$PROJECT_DIR" || _info "trust pre-accept failed (continuing)"
+
   # Build claude command.
   # --dangerously-skip-permissions is required for fully unattended operation:
   # without it, Claude TUI prompts the user on any tool not in the allow list,

--- a/scripts/ralph-lib.sh
+++ b/scripts/ralph-lib.sh
@@ -82,3 +82,44 @@ ralph_setup_worker_settings() {
     jq -n --argjson perms "$permissions_json" '{"permissions": $perms}' > "$settings_file"
   fi
 }
+
+# Pre-populate Claude Code's project-local trust state so a freshly-launched
+# worker does not block on the interactive "Quick safety check" trust dialog.
+#
+# Claude records trust acceptance per absolute (real) project path in
+# ~/.claude.json under .projects[<abs_path>].hasTrustDialogAccepted = true.
+# --dangerously-skip-permissions does NOT suppress this dialog, so unattended
+# launchd operation requires writing the acceptance up-front.
+#
+# Usage:
+#   ralph_preaccept_trust <project_dir>
+#
+# No-ops when ~/.claude.json does not exist (Claude will create it on first
+# launch with trust already set), or when the project entry already has
+# hasTrustDialogAccepted = true.
+ralph_preaccept_trust() {
+  local project_dir="$1"
+  local claude_config="${HOME}/.claude.json"
+
+  [[ -f "$claude_config" ]] || return 0
+
+  local abs_dir
+  abs_dir="$(cd "$project_dir" 2>/dev/null && pwd -P)" || return 1
+
+  local accepted
+  accepted="$(jq -r --arg d "$abs_dir" '.projects[$d].hasTrustDialogAccepted // false' "$claude_config" 2>/dev/null)"
+  [[ "$accepted" == "true" ]] && return 0
+
+  local tmp="${claude_config}.ralph-tmp.$$"
+  if jq --arg d "$abs_dir" '
+    .projects[$d] = ((.projects[$d] // {}) + {
+      hasTrustDialogAccepted: true,
+      hasCompletedProjectOnboarding: true
+    })
+  ' "$claude_config" > "$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$claude_config"
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}


### PR DESCRIPTION
## Summary

Removes the last two blockers between `ralph-crew` and truly unattended launchd operation:

- **Auto-init on dispatch**: a single dispatch-only launchd plist now recovers from reboots, post-teardown, and first-time installs. No separate RunAtLoad plist required.
- **Trust dialog pre-accept**: worker setup writes `~/.claude.json` `projects[<abs_path>].hasTrustDialogAccepted = true` before launching, so fresh projects no longer stall on Claude's "Quick safety check" prompt.

Validated end-to-end with a real `launchctl bootstrap` → `RunAtLoad` run. Exit code 0, tmux session created, worker claude started with `⏵⏵ bypass permissions on`, no dialogs, clean logs.

## Changes

1. **`feat(ralph-crew): auto-init tmux session and workers in dispatch when missing`**
   Extracted the init body into a `_run_init` helper. `cmd_dispatch` now calls it when `tmux has-session` reports missing, instead of returning early with "run init first".

2. **`feat(ralph-crew): pre-accept Claude trust dialog for new project directories`**
   New `ralph_preaccept_trust` in `ralph-lib.sh`, invoked from `_start_worker` before building the `claude` command. Idempotent (no-op when already accepted); no-op when `~/.claude.json` is absent.

3. **`docs(ralph-crew): document auto-init in dispatch and trust pre-accept`**

## Test plan

- [x] `ralph-crew teardown` then `ralph-crew dispatch` (no prior init) correctly auto-initializes: tmux session + workers created, dispatch proceeds (verified locally)
- [x] Fresh project (`/tmp/ralph-trust-test`) not yet in `~/.claude.json` → `ralph-crew init` writes `hasTrustDialogAccepted: true` + `hasCompletedProjectOnboarding: true`; worker starts with no trust dialog
- [x] 2nd init on same project is a no-op for trust pre-accept (idempotency: accepted project skips the jq write)
- [x] `launchctl bootstrap gui/<uid>` with a `RunAtLoad` test plist → `last exit code = 0`; logs show `auto-init ran → tmux session created → worker started → dispatch completed (0 tasks)`; no manual intervention needed
- [x] `shellcheck -x -S warning` clean on both modified scripts

## Known gaps (follow-up, not part of this PR)

- Long-running stability of persistent worker Claude TUIs (session token expiry, memory) — not exercised here.
- Per-worker MCP auth flows are still interactive if tokens expire.

Closes #53