### PR TITLE
Add no-sudo install mode + host-side tmux aggregation with docker exec wrapper

### DIFF
--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -317,13 +317,19 @@ rssh() {
   fi
 }
 
-# リモート接続 (SSH + Docker + tmux をワンコマンドで)
+# リモート接続 (SSH + host tmux + Docker をワンコマンドで)
 # Usage: rcon [host:container | host] [tmux-session]
 #   rcon                      → fzf でターゲット選択
 #   rcon ailab:syntopic-dev   → 直接指定 (host:container)
 #   rcon pi-500               → 直接指定 (host のみ)
 #   rcon pi-500 dev           → セッション名を明示指定
 # Targets for fzf: ~/.config/rcon/targets (1行1ターゲット: host:container or host)
+#
+# Architecture (2026-04 onwards):
+#   - tmux はリモートホスト側で1サーバー集約
+#   - container 指定時: session名=container名で、default-command に tmux-docker-enter を設定
+#     → pane分割/新window で自動的に docker exec (cwd 引き継ぎ付き)
+#   - opensessions サイドバーに container 単位でセッションが並ぶ
 rcon() {
   local target="$1" session="$2"
 
@@ -344,16 +350,30 @@ rcon() {
 
   local context="${CLAUDE_CONTEXT:-$(_claude_context)}"
 
-  local tmux_cmd
-  if [[ -n "$session" ]]; then
-    tmux_cmd="tmux attach-session -d -t $session 2>/dev/null || tmux new-session -s $session"
-  else
-    tmux_cmd="tmux attach-session -d 2>/dev/null || tmux new-session"
-  fi
-
   if [[ -n "$container" ]]; then
-    ssh -t "$host" "docker exec -it -e TERM=\"\$TERM\" -e CLAUDE_CONTEXT='$context' $container sh -c '$tmux_cmd'"
+    # tmux session name = container name (sanitized: tmux disallows ":" and ".")
+    local sess="${session:-$container}"
+    sess="${sess//:/-}"
+    sess="${sess//./-}"
+
+    # Remote-side script: host tmux + docker exec via wrapper
+    # - new-session -A: attach if exists, create otherwise
+    # - set-option default-command: subsequent pane splits / new windows also run the wrapper
+    # - absolute path so tmux's /bin/sh can locate the wrapper without PATH hacks
+    ssh -t "$host" "
+      set -e
+      export CLAUDE_CONTEXT='$context'
+      cmd=\"\$HOME/dotfiles/scripts/tmux-docker-enter '$container'\"
+      tmux new-session -A -d -s '$sess' \"\$cmd\" 2>/dev/null || true
+      tmux set-option -t '$sess' default-command \"\$cmd\"
+      exec tmux attach-session -t '$sess'
+    "
   else
-    ssh -t "$host" "export CLAUDE_CONTEXT='$context' && $tmux_cmd"
+    # Host-only: attach or create a plain host tmux session (no docker)
+    local sess="${session:-main}"
+    ssh -t "$host" "
+      export CLAUDE_CONTEXT='$context'
+      exec tmux new-session -A -s '$sess'
+    "
   fi
 }

--- a/config/pixi-packages.txt
+++ b/config/pixi-packages.txt
@@ -1,0 +1,36 @@
+# Packages installed via pixi global (no-sudo mode)
+# Format: 1 package per line, # for comments
+# All packages come from conda-forge (default channel)
+# Installed into ~/.pixi/bin (user-scope, no sudo required)
+#
+# Only include packages that:
+#   1. Are otherwise installed via apt/apk/apt_repo (system-level)
+#   2. Cannot be installed via curl_pipe / github_release_binary self-installer
+# Tools with their own user-scope installer (bun, mise, rust, uv, ...) stay in tools.linux.bash
+
+# --- Core shell & terminal ---
+tmux
+zsh
+gnu-stow
+
+# --- Archive / transfer ---
+unzip
+rsync
+
+# --- Text processing ---
+jq
+ripgrep
+fd-find
+
+# --- Media (neovim image.nvim, etc) ---
+imagemagick
+
+# --- Git / GitHub ---
+gh
+
+# --- Modern CLI tools (apt_repo replacement) ---
+eza
+bat
+
+# --- Database client (psql only; pgcli comes via uv tool) ---
+postgresql

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -120,7 +120,7 @@ TOOL_neovim_method="github_release"
 TOOL_neovim_github_repo="neovim/neovim"
 TOOL_neovim_archive_pattern='nvim-linux-${ARCH}.tar.gz'
 TOOL_neovim_arch_map='x86_64:x86_64 aarch64:arm64'
-TOOL_neovim_install_cmd='$SUDO rm -rf "/opt/nvim-linux-${ARCH}" && $SUDO tar -C /opt -xzf "$archive" && $SUDO ln -sf "/opt/nvim-linux-${ARCH}/bin/nvim" /usr/local/bin/nvim'
+TOOL_neovim_install_cmd='_install_neovim_tarball "$archive" "$ARCH"'
 TOOL_neovim_apt_only="true"
 
 # ════════════════════════════════════════

--- a/docs/install-no-sudo.md
+++ b/docs/install-no-sudo.md
@@ -1,0 +1,143 @@
+# No-Sudo Install Mode
+
+sudo 権限のないリモート Linux ホスト (共有サーバー、管理された開発環境、一部コンテナ等) でも dotfiles をセットアップするためのモード。
+
+## Usage
+
+```bash
+# 明示的に no-sudo モードで実行
+./install.sh --no-sudo
+
+# sudo モードを強制 (自動検出を上書き)
+./install.sh --with-sudo
+
+# デフォルト: auto-detect
+./install.sh
+```
+
+## 自動検出の仕組み
+
+`scripts/utils.sh` の `detect_sudo_mode` が以下の順でチェック:
+
+1. `EUID == 0` (既に root) → sudo モード (root で apt 実行可能)
+2. `sudo` バイナリが PATH にあるか → 無ければ NO_SUDO
+3. `sudo -n true` が成功するか (非対話で sudo が通るか: NOPASSWD or ticket 有効) → 通らなければ NO_SUDO
+
+いずれも `install.sh` から明示フラグが渡されていなければ自動判定に任せる。
+
+## NO_SUDO モードでの動作差分
+
+### システムパッケージ
+
+| 項目 | sudo モード | no-sudo モード |
+|------|-------------|----------------|
+| 提供元 | `apt` (or `apk`) | **pixi** (conda-forge) |
+| 設定ファイル | `config/packages.linux.apt.txt` | `config/pixi-packages.txt` |
+| インストール先 | `/usr/bin`, `/usr/local/bin` | `~/.pixi/bin` |
+
+pixi は `curl -fsSL https://pixi.sh/install.sh \| sh` でユーザースコープに入る単一バイナリ。conda-forge からプリビルドを取得するので高速。
+
+### Modern CLI tools (github_release 系)
+
+`scripts/linux.sh:_install_github_release` の install 先が以下のように切り替わる:
+
+- sudo モード: `$SUDO install /usr/local/bin/`
+- no-sudo モード: `install ~/.local/bin/` (SUDO なし)
+
+### apt_repo 系 tool (gh, eza, bat, postgresql)
+
+no-sudo モードでは **pixi 経由で導入** される (`config/pixi-packages.txt` に含める)。`install_modern_tools` のディスパッチャで `method=apt_repo && NO_SUDO=true` の組み合わせは skip される。
+
+### Neovim
+
+tarball を `~/.local/opt/nvim-linux-<ARCH>` に展開、`~/.local/bin/nvim` symlink を作る (`_install_neovim_tarball` helper)。sudo モード時は従来通り `/opt` + `/usr/local/bin`。
+
+### 1Password CLI
+
+- sudo モード: apt (`1password-cli` パッケージ) で `/usr/bin/op`
+- no-sudo モード: `cache.agilebits.com` から tarball を DL し `~/.local/bin/op` に展開 (`install.sh:_install_1password_cli_user_scope`)。バージョンは `OP_CLI_VERSION` 環境変数で上書き可能 (既定 2.34.0)
+
+### Default Shell
+
+- sudo モード: `/etc/shells` 追記 + `chsh -s /bin/zsh`
+- no-sudo モード: `~/.profile` に以下を追記 (marker で冪等化):
+  ```sh
+  # dotfiles: exec zsh -l (no-sudo mode)
+  if [ -z "$ZSH_VERSION" ] && [ -t 0 ] && command -v zsh >/dev/null 2>&1; then
+    exec zsh -l
+  fi
+  ```
+  SSH ログインで bash → zsh exec に切り替わる。`chsh` が使えない環境の標準的な代替手法。
+
+## 前提条件 (ホスト側に必要なもの)
+
+no-sudo モードでも最低限以下はホスト側に存在している必要がある (通常の開発ホストなら標準で入っている):
+
+- `bash` (≥ 4)
+- `git`
+- `curl`
+- `unzip` (1Password CLI の zip 展開用。pixi 経由で補うことも可)
+
+これらが無い場合は管理者に一度だけインストールを依頼する。
+
+## 制限 / 注意点
+
+### conda-forge パッケージの CONDA_PREFIX リーク
+
+pixi global で入れた executable は `CONDA_PREFIX` 環境変数が設定されて起動する。一部 Python 系 tool は conda 環境だと誤認して挙動が変わる可能性がある。問題が出た場合は対象パッケージのメンテナに `etc/pixi/<exe>/global-ignore-conda-prefix` marker file の追加を依頼するか、手動で unset する。
+
+### PATH 優先順位
+
+`~/.local/bin` と `~/.pixi/bin` が `/usr/local/bin` より前に来る必要がある。zsh の場合は `common/zsh/.zshrc.common` で既に PATH 先頭に追加済み。
+
+### 一部の機能は無効化される
+
+- `chsh` でデフォルトシェル変更は行わない (`.profile` fallback で代替)
+- `/etc/shells` 編集は行わない
+- `systemd` ユニット登録などシステムレベル連携は諦める (必要ならユーザー systemd = `--user` を使う)
+
+### macOS は対象外
+
+macOS は Homebrew が cask (GUI app)、3rd party tap 、macOS 専用ツール (macmon 等) を提供する必要があり、pixi では代替不可。Mac は常に sudo モード相当 (Homebrew) で動作する。
+
+## Verification
+
+セットアップ後に以下を確認:
+
+```bash
+# pixi が入り、パッケージがインストールされているか
+pixi --version
+pixi global list
+
+# ツール check
+command -v tmux stow gh eza bat jq op zsh
+
+# ログインシェルが zsh に切り替わるか (新しいセッションで)
+ssh <host>
+echo $ZSH_VERSION  # 空でない値が出れば OK
+```
+
+## Troubleshooting
+
+### pixi が PATH に出ない
+
+`install.sh` 実行後は新しいシェルを開くか `source ~/.zshrc` で PATH を再ロード。`export PATH="$HOME/.pixi/bin:$PATH"` を手動で追加することも可。
+
+### `sudo -n true` が意図せず成功する (誤検出)
+
+sudo ticket が前のコマンドで有効化されていると auto-detect が「sudo 使える」と判定する。`sudo -k` で ticket を破棄してから再実行、または `--no-sudo` を明示。
+
+### 1Password CLI のダウンロードが失敗
+
+`OP_CLI_VERSION` 環境変数で別バージョンを指定:
+
+```bash
+OP_CLI_VERSION=2.30.0 ./install.sh --no-sudo
+```
+
+最新版は <https://app-updates.agilebits.com/product_history/CLI2> で確認。
+
+## 関連ドキュメント
+
+- [install.md](./install.md) — 通常の install 手順
+- [rcon.md](./rcon.md) — リモート接続コマンド (no-sudo ホストでの運用前提)

--- a/docs/install-no-sudo.md
+++ b/docs/install-no-sudo.md
@@ -5,25 +5,16 @@ sudo 権限のないリモート Linux ホスト (共有サーバー、管理さ
 ## Usage
 
 ```bash
-# 明示的に no-sudo モードで実行
-./install.sh --no-sudo
-
-# sudo モードを強制 (自動検出を上書き)
-./install.sh --with-sudo
-
-# デフォルト: auto-detect
+# 通常の install (sudo 経路)
 ./install.sh
+
+# sudoless 環境向け (pixi 経由のユーザー scope install)
+./install.sh --no-sudo
 ```
 
-## 自動検出の仕組み
+デフォルトは sudo 経路。明示的に `--no-sudo` を付けたときだけ pixi ベースの user-scope install に切り替わる。自動検出は行わない (silent な挙動変化を避けるため)。
 
-`scripts/utils.sh` の `detect_sudo_mode` が以下の順でチェック:
-
-1. `EUID == 0` (既に root) → sudo モード (root で apt 実行可能)
-2. `sudo` バイナリが PATH にあるか → 無ければ NO_SUDO
-3. `sudo -n true` が成功するか (非対話で sudo が通るか: NOPASSWD or ticket 有効) → 通らなければ NO_SUDO
-
-いずれも `install.sh` から明示フラグが渡されていなければ自動判定に任せる。
+`scripts/utils.sh` には `detect_sudo_mode` 関数 (EUID / sudo binary / `sudo -n true` の3段チェック) があり、他のスクリプトから sudo 利用可否を判定したい場合の utility として残してある。
 
 ## NO_SUDO モードでの動作差分
 
@@ -122,10 +113,6 @@ echo $ZSH_VERSION  # 空でない値が出れば OK
 ### pixi が PATH に出ない
 
 `install.sh` 実行後は新しいシェルを開くか `source ~/.zshrc` で PATH を再ロード。`export PATH="$HOME/.pixi/bin:$PATH"` を手動で追加することも可。
-
-### `sudo -n true` が意図せず成功する (誤検出)
-
-sudo ticket が前のコマンドで有効化されていると auto-detect が「sudo 使える」と判定する。`sudo -k` で ticket を破棄してから再実行、または `--no-sudo` を明示。
 
 ### 1Password CLI のダウンロードが失敗
 

--- a/docs/opensessions.md
+++ b/docs/opensessions.md
@@ -1,0 +1,125 @@
+# opensessions
+
+tmux セッション + AI エージェント状態を横断管理するサイドバープラグイン。
+
+- Plugin: [Ataraxy-Labs/opensessions](https://github.com/Ataraxy-Labs/opensessions)
+- Config: `common/opensessions/.config/opensessions/config.json`
+- tmux 側: `common/tmux/.config/tmux/tmux.conf` の `set -g @plugin 'Ataraxy-Labs/opensessions'`
+- 依存: `bun` (TPM が plugin 取得後、bun でランタイムを動かす)
+
+## 役割
+
+- **セッション一覧のサイドバー**: tmux session を縦に並べて `prefix+o → s` で focus、`prefix+o → 1-9` で直接切替
+- **AI エージェント状態の可視化**: Claude Code / Codex / Amp / OpenCode の状態 (idle/running/done/error 等) を session 単位で集計
+- **Thread (instance) 追跡**: 同一 session 内で複数 AI instance が走っていれば thread として区別
+- **Git 情報**: session の cwd の branch / dirty / worktree 状態
+- **Port 検知**: session 内で listening している localhost port をクリックで開ける
+
+## データモデル (重要)
+
+**セッションが最小単位**。window / pane は count として表示されるだけで、状態集計の軸にはならない。
+
+watcher は以下の対応関係で動く:
+
+```
+ファイルシステムの transcript (例: ~/.claude/projects/<encoded-dir>/*.jsonl)
+  → projectDir を抽出
+  → resolveSession(projectDir) でtmux session に解決
+  → そのsessionに status/thread 情報を紐付け
+```
+
+`resolveSession` は tmux session 作成時の `dir` (cwd) を照合するので:
+
+- **同じ cwd で起動された session** のみ正しく紐付く
+- 同一 session 内の別 window で別 project を開いていると、片方はsidebarに出ない
+
+## 運用方針 (本 dotfiles 環境)
+
+### 1 コンテナ = 1 セッション
+
+`rcon ailab:syntopic-dev` で起動した tmux session は名前 `syntopic-dev`、cwd がcontainerのプロジェクトパスになる。opensessions サイドバーには container 毎に1行並ぶ。複数プロジェクトを扱う場合は **別コンテナ = 別 session** に分ける。
+
+### 同プロジェクトの並列作業 = 同 session 内の別 window
+
+1プロジェクトで Claude を並列起動する場合 (ralph-parallel 等) は、同じ session の別 window で走らせる。watcher が threadId で区別して detail panel に instance リストとして並ぶ。
+
+### 避けるべきパターン
+
+- 1つの session 内で `cd /other/proj` して別プロジェクトの Claude を起動 → `resolveSession` が最初の projectDir しかマッチしないため、2つ目以降は sidebar に出ない
+- host tmux と container 内 tmux を二重起動して両方で opensessions を有効化 → watcher が二元化して状態が分散
+
+## AI エージェント監視の要件
+
+watcher が読むファイルパス:
+
+| Agent | Path |
+|-------|------|
+| Claude Code | `~/.claude/projects/*.jsonl` |
+| Codex | `~/.codex/sessions/` |
+| Amp | `~/.local/share/amp/threads/` |
+| OpenCode | `~/.local/share/opencode/opencode.db` |
+
+opensessions はホスト側 tmux サーバー内で動くため、これらのファイルも **ホスト側** から見える必要がある。Docker コンテナ内で Claude を動かす場合は volume mount が必須:
+
+```bash
+docker run \
+  -v ~/.claude:/root/.claude \
+  -v ~/.codex:/root/.codex \
+  ...
+```
+
+これによりコンテナ内で生成された JSONL / transcript がホスト側 opensessions から読み取れる。
+
+## rcon との連携
+
+`rcon host:container` コマンドで起動する tmux session は、opensessions に以下として現れる:
+
+- **名前**: container 名 (`:` / `.` は `-` に sanitize)
+- **cwd**: `tmux-docker-enter` で container に入った際の初期パス (プロジェクトディレクトリを bind mount していれば host と一致)
+- **default-command**: 各 pane/window が `tmux-docker-enter` 経由で container に入る
+- **エージェント状態**: container 内で起動された Claude/Codex の JSONL が ホスト `~/.claude` で見えていれば sidebar に反映
+
+詳細は [rcon.md](./rcon.md)。
+
+## Programmatic API (補足)
+
+HTTP 経由で status / progress / log を push 可能 (`127.0.0.1:7391`):
+
+```sh
+curl -X POST http://127.0.0.1:7391/set-status \
+  -H 'content-type: application/json' \
+  -d '{"session":"syntopic-dev","text":"Deploying","tone":"warn"}'
+```
+
+ralph-crew 等の自動化から状態を可視化したい場合に使用する。
+
+## Troubleshooting
+
+### session がサイドバーに現れない
+
+- `prefix+o → r` で手動 refresh
+- tmux session の `dir` が watcher の projectDir 候補と一致するか確認:
+  ```bash
+  tmux list-sessions -F '#{session_name} #{session_path}'
+  ```
+
+### agent status が更新されない
+
+- ホスト側の JSONL パスに実際にファイルがあるか確認
+- コンテナ内で生成されたものなら volume mount を点検
+- `~/.claude/projects/` の encoded directory 名は cwd を特殊エンコードしたもの (`-` 区切り)
+
+### サイドバーが消える / 表示崩れ
+
+- `prefix+o → t` でトグル
+- ヒューリスティック復帰しないときは `opensessions` プロセスを再起動:
+  ```bash
+  pkill -f opensessions
+  ```
+  次回 tmux reload 時に自動再起動
+
+## 関連
+
+- [tmux.md](./tmux.md) — tmux 全般
+- [rcon.md](./rcon.md) — host tmux + docker exec パターン
+- [ralph.md](./ralph.md) — 自律ループとAI agent状態連携

--- a/docs/rcon.md
+++ b/docs/rcon.md
@@ -1,6 +1,6 @@
 # rcon - リモート接続ツール
 
-SSH + Docker + tmux をワンコマンドで接続するツール。
+SSH + ホスト側 tmux + Docker をワンコマンドで接続するツール。
 
 ## 現在の実装
 
@@ -22,6 +22,63 @@ ailab:syntopic-dev
 ailab:another-container
 pi-500
 ```
+
+### アーキテクチャ
+
+2026-04 に設計変更: tmux をリモートホスト側で **1サーバーに集約** し、各 session が docker container に対応する形に移行した。
+
+```
+Ghostty
+  └─ ssh host
+      └─ tmux (ホスト側、1 server)
+          ├─ session "syntopic-dev"      → docker exec -it syntopic-dev
+          ├─ session "another-container" → docker exec -it another-container
+          └─ session "main"              → ホスト shell (container なし target)
+```
+
+以前は `SSH → docker exec → container内でtmux` という構成で、コンテナ毎に別 tmux サーバーが立っていた。新構成の利点:
+
+- **opensessions が1サーバーで全 container を監視**: サイドバーに container 単位でセッションが並ぶ
+- **Claude Code/Codex/Amp の状態監視が一元化**: ホストの `~/.claude/projects/` 等が container 内 agent のJSONLを見る (要 volume mount: `-v ~/.claude:/root/.claude`)
+- **Docker再起動耐性**: コンテナ recreate しても tmux session/レイアウトは残る
+- **tmux をDockerイメージに仕込む必要がない**
+
+### 自動化: default-command + tmux-docker-enter
+
+pane 分割 (`prefix+|` / `prefix+-`) や新 window (`prefix+c`) で都度 `docker exec` を打つ手間を排除するため、各 session に `default-command` を設定して `scripts/tmux-docker-enter` wrapper を自動起動する:
+
+```
+tmux set-option -t <session> default-command "~/dotfiles/scripts/tmux-docker-enter <container>"
+```
+
+wrapper の挙動:
+
+1. tmux pane の現在 cwd を取得
+2. その cwd が container 内にも存在すれば `docker exec -w <cwd>` で同じディレクトリに入る
+3. 存在しなければ container の WORKDIR で入る (エラーにしない)
+4. container が停止している場合はホスト shell にフォールバック → pane が消えずに再接続可能
+
+これにより、初回 `rcon` 後は pane 操作だけでスムーズに開発に入れる。
+
+### cwd 引き継ぎの前提条件
+
+pane 分割で元の cwd を引き継ぐには、**ホストとコンテナでプロジェクトパスが一致** している必要がある:
+
+```bash
+# docker run 時
+docker run -v /home/user/proj:/home/user/proj ...
+```
+
+パスが異なる場合は wrapper の cwd チェックが失敗して container の WORKDIR フォールバックになる (動作はするが pane 毎に `cd` が必要)。
+
+### Fallback 挙動
+
+| 状況 | 挙動 |
+|------|------|
+| target = `host` (container なし) | ホストtmux に `main` セッション (or 指定 session) で直接入る |
+| target = `host:container`, container 稼働中 | `tmux-docker-enter` で pane が container に入る |
+| container が停止している | wrapper がホスト shell にフォールバック、`exit` 後に default-command 再実行 = コンテナ起動後に戻れる |
+| session 名に `:` や `.` が含まれる | tmux 制限のため自動で `-` に sanitize される |
 
 ## 将来の拡張計画
 

--- a/install.sh
+++ b/install.sh
@@ -8,26 +8,16 @@ DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$DOTFILES_DIR/scripts/utils.sh"
 
 # --- Argument Parsing ---
+# NO_SUDO defaults to false (use sudo/system path).
+# Pass --no-sudo to opt into pixi-based user-scope install on sudoless hosts.
 SKIP_PROMPT=false
-NO_SUDO="auto"  # auto | true | false
+NO_SUDO=false
 for arg in "$@"; do
   case "$arg" in
-    -y)          SKIP_PROMPT=true ;;
-    --no-sudo)   NO_SUDO=true ;;
-    --with-sudo) NO_SUDO=false ;;
+    -y)        SKIP_PROMPT=true ;;
+    --no-sudo) NO_SUDO=true ;;
   esac
 done
-
-# Auto-detect sudo availability on Linux unless explicitly set
-if [[ "$NO_SUDO" == "auto" ]]; then
-  if [[ "$(detect_os)" == "linux" ]] && ! detect_sudo_mode; then
-    NO_SUDO=false
-  elif [[ "$(detect_os)" == "linux" ]]; then
-    NO_SUDO=true
-  else
-    NO_SUDO=false  # mac: sudo path
-  fi
-fi
 export NO_SUDO
 
 # --- 0. 1Password CLI Check (Required) ---
@@ -502,12 +492,8 @@ main() {
   log_info "=== Dotfiles Installation Start ==="
   log_info "OS: $(detect_os)"
   log_info "Dotfiles: $DOTFILES_DIR"
-  if [[ "$(detect_os)" == "linux" ]]; then
-    if [[ "$NO_SUDO" == "true" ]]; then
-      log_info "Mode: no-sudo (pixi-based user-scope install)"
-    else
-      log_info "Mode: sudo (apt + system-wide install)"
-    fi
+  if [[ "$(detect_os)" == "linux" && "$NO_SUDO" == "true" ]]; then
+    log_info "Mode: no-sudo (pixi-based user-scope install)"
   fi
   echo
 

--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,26 @@ source "$DOTFILES_DIR/scripts/utils.sh"
 
 # --- Argument Parsing ---
 SKIP_PROMPT=false
+NO_SUDO="auto"  # auto | true | false
 for arg in "$@"; do
-  [[ "$arg" == "-y" ]] && SKIP_PROMPT=true
+  case "$arg" in
+    -y)          SKIP_PROMPT=true ;;
+    --no-sudo)   NO_SUDO=true ;;
+    --with-sudo) NO_SUDO=false ;;
+  esac
 done
+
+# Auto-detect sudo availability on Linux unless explicitly set
+if [[ "$NO_SUDO" == "auto" ]]; then
+  if [[ "$(detect_os)" == "linux" ]] && ! detect_sudo_mode; then
+    NO_SUDO=false
+  elif [[ "$(detect_os)" == "linux" ]]; then
+    NO_SUDO=true
+  else
+    NO_SUDO=false  # mac: sudo path
+  fi
+fi
+export NO_SUDO
 
 # --- 0. 1Password CLI Check (Required) ---
 install_1password_cli() {
@@ -27,7 +44,9 @@ install_1password_cli() {
       exit 1
     fi
   elif [[ "$os" == "linux" ]]; then
-    if command_exists apt; then
+    if [[ "$NO_SUDO" == "true" ]]; then
+      _install_1password_cli_user_scope
+    elif command_exists apt; then
       log_info "Installing 1Password CLI via apt..."
       # Setup SUDO
       local SUDO=""
@@ -51,6 +70,37 @@ install_1password_cli() {
     log_error "Unsupported OS. Please install 1Password CLI manually."
     exit 1
   fi
+}
+
+# Install 1Password CLI to ~/.local/bin without sudo (tarball from downloads.1password.com)
+_install_1password_cli_user_scope() {
+  local arch
+  case "$(uname -m)" in
+    x86_64)         arch="amd64" ;;
+    aarch64|arm64)  arch="arm64" ;;
+    *)              log_error "Unsupported arch for 1Password CLI: $(uname -m)"; return 1 ;;
+  esac
+
+  local version="${OP_CLI_VERSION:-2.34.0}"
+  local zip="/tmp/op.zip"
+  local url="https://cache.agilebits.com/dist/1P/op2/pkg/v${version}/op_linux_${arch}_v${version}.zip"
+
+  log_info "Installing 1Password CLI v${version} (user-scope, no sudo)..."
+  mkdir -p "$HOME/.local/bin"
+  if ! curl -fsSL "$url" -o "$zip"; then
+    log_error "Failed to download 1Password CLI from $url"
+    return 1
+  fi
+  if ! command_exists unzip; then
+    log_error "unzip not found. Install via pixi first: pixi global install unzip"
+    rm -f "$zip"
+    return 1
+  fi
+  unzip -o "$zip" op -d "$HOME/.local/bin" >/dev/null
+  chmod +x "$HOME/.local/bin/op"
+  rm -f "$zip"
+  export PATH="$HOME/.local/bin:$PATH"
+  log_success "1Password CLI installed to ~/.local/bin/op"
 }
 
 check_1password_cli() {
@@ -452,6 +502,13 @@ main() {
   log_info "=== Dotfiles Installation Start ==="
   log_info "OS: $(detect_os)"
   log_info "Dotfiles: $DOTFILES_DIR"
+  if [[ "$(detect_os)" == "linux" ]]; then
+    if [[ "$NO_SUDO" == "true" ]]; then
+      log_info "Mode: no-sudo (pixi-based user-scope install)"
+    else
+      log_info "Mode: sudo (apt + system-wide install)"
+    fi
+  fi
   echo
 
   # 0. Check 1Password CLI first

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -8,14 +8,34 @@ CONFIG_DIR="$DOTFILES_DIR/config"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/utils.sh"
 
-# Setup SUDO variable
-if [[ $EUID -eq 0 ]]; then
+# NO_SUDO mode is decided by install.sh; default to auto-detect if run standalone
+: "${NO_SUDO:=auto}"
+if [[ "$NO_SUDO" == "auto" ]]; then
+  if detect_sudo_mode; then
+    NO_SUDO=true
+  else
+    NO_SUDO=false
+  fi
+fi
+export NO_SUDO
+
+# Setup SUDO variable (empty in NO_SUDO mode so $SUDO-prefixed commands run as user)
+if [[ "$NO_SUDO" == "true" ]]; then
+  SUDO=""
+elif [[ $EUID -eq 0 ]]; then
   SUDO=""
 elif command_exists sudo; then
   SUDO="sudo"
 else
-  log_warn "sudo not found, some installations may fail"
+  log_warn "sudo not found, falling back to no-sudo mode"
+  NO_SUDO=true
   SUDO=""
+fi
+
+# Load pixi library for NO_SUDO mode
+if [[ "$NO_SUDO" == "true" ]]; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/pixi-lib.sh"
 fi
 
 # Source tool definitions from config
@@ -25,26 +45,25 @@ source "$CONFIG_DIR/tools.linux.bash"
 # --- 1. Pre-flight Check ---
 check_requirements() {
   local missing_requirements=()
-  local has_package_manager=false
 
   log_info "Checking prerequisites..."
 
-  if command_exists apk || command_exists apt; then
-    has_package_manager=true
-  fi
+  # In NO_SUDO mode, only curl + git are hard requirements (pixi bootstraps the rest)
+  # In sudo mode, apt or apk must be available as well
+  if [[ "$NO_SUDO" != "true" ]]; then
+    if ! command_exists apk && ! command_exists apt; then
+      log_error "No supported package manager found (apt or apk required)."
+      log_error "This script supports Debian/Ubuntu or Alpine Linux."
+      log_error "For sudoless environments, re-run with --no-sudo."
+      exit 1
+    fi
 
-  if [ "$has_package_manager" = false ]; then
-    log_error "No supported package manager found (apt or apk required)."
-    log_error "This script supports Debian/Ubuntu or Alpine Linux."
-    exit 1
+    if [ "$(id -u)" -ne 0 ] && ! command_exists sudo; then
+      missing_requirements+=("sudo")
+    fi
   fi
 
   local required_cmds=("curl" "git")
-
-  if [ "$(id -u)" -ne 0 ] && ! command_exists sudo; then
-    missing_requirements+=("sudo")
-  fi
-
   for cmd in "${required_cmds[@]}"; do
     if ! command_exists "$cmd"; then
       missing_requirements+=("$cmd")
@@ -59,7 +78,9 @@ check_requirements() {
     done
     echo "  ----------------------------------------"
 
-    if command_exists apk; then
+    if [[ "$NO_SUDO" == "true" ]]; then
+      echo "In no-sudo mode, please ask your admin to install: ${missing_requirements[*]}"
+    elif command_exists apk; then
       echo "Please run: apk add ${missing_requirements[*]}"
     elif command_exists apt; then
       echo "Please run: apt update && apt install -y ${missing_requirements[*]}"
@@ -97,6 +118,14 @@ check_1password() {
 # --- 2. Install Functions ---
 
 install_system_packages() {
+  # NO_SUDO mode: bootstrap pixi and install system packages via conda-forge (user-scope)
+  if [[ "$NO_SUDO" == "true" ]]; then
+    log_info "No-sudo mode: installing system packages via pixi..."
+    install_pixi || { log_error "pixi bootstrap failed"; return 1; }
+    install_pixi_packages "$CONFIG_DIR/pixi-packages.txt" || true
+    return
+  fi
+
   if command_exists apk; then
     log_info "Alpine Linux detected. Using apk..."
     local _sudo=""
@@ -202,8 +231,30 @@ _install_github_release() {
     else
       tar xf "/tmp/$archive_pattern" -C /tmp
     fi
-    $SUDO install "/tmp/$binary_path" /usr/local/bin/
+    # Target dir: ~/.local/bin in NO_SUDO mode, else /usr/local/bin
+    if [[ "$NO_SUDO" == "true" ]]; then
+      mkdir -p "$HOME/.local/bin"
+      install "/tmp/$binary_path" "$HOME/.local/bin/"
+    else
+      $SUDO install "/tmp/$binary_path" /usr/local/bin/
+    fi
     rm -rf "/tmp/$archive_pattern" "/tmp/${binary_path%/*}"
+  fi
+}
+
+# Install neovim tarball (extracted to ~/.local/opt in NO_SUDO mode, /opt otherwise)
+_install_neovim_tarball() {
+  local archive="$1" arch="$2"
+  if [[ "$NO_SUDO" == "true" ]]; then
+    local opt="$HOME/.local/opt"
+    mkdir -p "$opt" "$HOME/.local/bin"
+    rm -rf "$opt/nvim-linux-${arch}"
+    tar -C "$opt" -xzf "$archive"
+    ln -sf "$opt/nvim-linux-${arch}/bin/nvim" "$HOME/.local/bin/nvim"
+  else
+    $SUDO rm -rf "/opt/nvim-linux-${arch}"
+    $SUDO tar -C /opt -xzf "$archive"
+    $SUDO ln -sf "/opt/nvim-linux-${arch}/bin/nvim" /usr/local/bin/nvim
   fi
 }
 
@@ -284,6 +335,11 @@ install_modern_tools() {
 
     # Skip apt-only tools on Alpine
     if [[ "$apt_only" == "true" ]] && ! command_exists apt; then
+      continue
+    fi
+
+    # In NO_SUDO mode, skip apt_repo tools (they come from pixi-packages.txt instead)
+    if [[ "$NO_SUDO" == "true" ]] && [[ "$method" == "apt_repo" ]]; then
       continue
     fi
 
@@ -401,7 +457,13 @@ install_1password_cli() {
     return
   fi
 
-  # Debian/Ubuntu only
+  # NO_SUDO path: install.sh's check_1password_cli() → _install_1password_cli_user_scope() handles it
+  if [[ "$NO_SUDO" == "true" ]]; then
+    log_info "No-sudo mode: 1Password CLI install is handled by install.sh"
+    return
+  fi
+
+  # Debian/Ubuntu only (sudo path)
   if ! command_exists apt; then
     log_warn "1Password CLI installation only supported on Debian/Ubuntu"
     return
@@ -435,6 +497,27 @@ set_default_shell() {
     return
   fi
 
+  # NO_SUDO path: inject `exec zsh -l` into ~/.profile so login shells hand off to zsh
+  if [[ "$NO_SUDO" == "true" ]]; then
+    local profile="$HOME/.profile"
+    local marker='# dotfiles: exec zsh -l (no-sudo mode)'
+    if [[ -f "$profile" ]] && grep -qF "$marker" "$profile"; then
+      log_success "zsh exec marker already present in ~/.profile"
+    else
+      {
+        echo ""
+        echo "$marker"
+        echo 'if [ -z "$ZSH_VERSION" ] && [ -t 0 ] && command -v zsh >/dev/null 2>&1; then'
+        echo '  exec zsh -l'
+        echo 'fi'
+      } >> "$profile"
+      log_success "Injected 'exec zsh -l' into ~/.profile (no-sudo mode)"
+    fi
+    log_info "  New login shells will switch to zsh automatically (sudo not available for chsh)"
+    return
+  fi
+
+  # sudo path: /etc/shells + chsh
   if ! grep -q "$zsh_path" /etc/shells 2>/dev/null; then
     echo "$zsh_path" | $SUDO tee -a /etc/shells >/dev/null
   fi

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -8,15 +8,8 @@ CONFIG_DIR="$DOTFILES_DIR/config"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/utils.sh"
 
-# NO_SUDO mode is decided by install.sh; default to auto-detect if run standalone
-: "${NO_SUDO:=auto}"
-if [[ "$NO_SUDO" == "auto" ]]; then
-  if detect_sudo_mode; then
-    NO_SUDO=true
-  else
-    NO_SUDO=false
-  fi
-fi
+# NO_SUDO mode is decided by install.sh (--no-sudo flag). Default false when run standalone.
+: "${NO_SUDO:=false}"
 export NO_SUDO
 
 # Setup SUDO variable (empty in NO_SUDO mode so $SUDO-prefixed commands run as user)
@@ -27,9 +20,8 @@ elif [[ $EUID -eq 0 ]]; then
 elif command_exists sudo; then
   SUDO="sudo"
 else
-  log_warn "sudo not found, falling back to no-sudo mode"
-  NO_SUDO=true
-  SUDO=""
+  log_error "sudo not found. Re-run with --no-sudo for user-scope installation."
+  exit 1
 fi
 
 # Load pixi library for NO_SUDO mode

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -496,6 +496,7 @@ set_default_shell() {
     if [[ -f "$profile" ]] && grep -qF "$marker" "$profile"; then
       log_success "zsh exec marker already present in ~/.profile"
     else
+      # shellcheck disable=SC2016 # intentionally written as literal sh into ~/.profile
       {
         echo ""
         echo "$marker"

--- a/scripts/pixi-lib.sh
+++ b/scripts/pixi-lib.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# pixi bootstrap & package installation library (no-sudo mode)
+#
+# Usage: source this file from install scripts when operating in no-sudo mode.
+# Requires: log_info, log_success, log_warn, log_error, command_exists, read_package_list
+
+# PIXI_HOME defaults to ~/.pixi (pixi's own default), exe goes to ~/.pixi/bin
+export PIXI_HOME="${PIXI_HOME:-$HOME/.pixi}"
+PIXI_BIN="$PIXI_HOME/bin"
+
+# Ensure PATH is set for current session so we can invoke pixi immediately after install
+_pixi_ensure_path() {
+  case ":$PATH:" in
+    *":$PIXI_BIN:"*) ;;
+    *) export PATH="$PIXI_BIN:$PATH" ;;
+  esac
+}
+
+# Install pixi itself if missing (user-scope, no sudo)
+install_pixi() {
+  _pixi_ensure_path
+
+  if command_exists pixi; then
+    log_success "pixi already installed ($(pixi --version 2>/dev/null | head -1))"
+    return 0
+  fi
+
+  log_info "Installing pixi (user-scope, no sudo required)..."
+  if ! curl -fsSL https://pixi.sh/install.sh | sh; then
+    log_error "Failed to install pixi"
+    return 1
+  fi
+
+  _pixi_ensure_path
+
+  if ! command_exists pixi; then
+    log_error "pixi installed but not found on PATH ($PIXI_BIN)"
+    return 1
+  fi
+
+  log_success "pixi installed to $PIXI_HOME"
+}
+
+# Check if a package is already installed as a pixi global tool
+_pixi_has_package() {
+  local pkg="$1"
+  pixi global list 2>/dev/null | grep -qE "^[[:space:]]*${pkg}([[:space:]]|\$)" ||
+    pixi global list 2>/dev/null | grep -qE "^-[[:space:]]+${pkg}([[:space:]]|:|\$)"
+}
+
+# Install packages listed in config/pixi-packages.txt as global tools
+# Usage: install_pixi_packages <path-to-pixi-packages.txt>
+install_pixi_packages() {
+  local pkg_file="${1:-}"
+  if [[ -z "$pkg_file" || ! -f "$pkg_file" ]]; then
+    log_error "pixi package list not found: $pkg_file"
+    return 1
+  fi
+
+  if ! command_exists pixi; then
+    log_error "pixi not available — run install_pixi first"
+    return 1
+  fi
+
+  local _new=() _existing=() _failed=()
+  while IFS= read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    if _pixi_has_package "$pkg"; then
+      _existing+=("$pkg")
+      continue
+    fi
+    log_info "Installing $pkg via pixi..."
+    if pixi global install "$pkg" >/dev/null 2>&1; then
+      _new+=("$pkg")
+    else
+      log_warn "  Failed to install $pkg via pixi"
+      _failed+=("$pkg")
+    fi
+  done < <(read_package_list "$pkg_file")
+
+  echo
+  log_info "── pixi Package Summary ──"
+  [[ ${#_new[@]} -gt 0 ]] && log_success "  New: ${_new[*]}"
+  [[ ${#_existing[@]} -gt 0 ]] && log_info "  Existing: ${_existing[*]}"
+  [[ ${#_failed[@]} -gt 0 ]] && log_warn "  Failed: ${_failed[*]}"
+
+  # Return failure if any package failed
+  [[ ${#_failed[@]} -eq 0 ]]
+}

--- a/scripts/tmux-docker-enter
+++ b/scripts/tmux-docker-enter
@@ -1,0 +1,47 @@
+#!/bin/bash
+# tmux-docker-enter — enter a docker container from a tmux pane with cwd propagation
+#
+# Usage (via tmux default-command / new-session / split-window):
+#   docker-enter <container> [shell]
+#
+# Behavior:
+#   - If current pane cwd exists inside the container → docker exec -w <cwd>
+#   - Otherwise → docker exec without -w (use container's default WORKDIR)
+#   - If docker exec fails (container stopped / removed) → fall back to host shell
+#     so the tmux pane stays alive for re-entry after docker restart.
+#
+# Environment:
+#   CLAUDE_CONTEXT — propagated into the container for AI CLI integration
+
+set -u
+
+container="${1:-}"
+shell="${2:-zsh}"
+
+if [[ -z "$container" ]]; then
+  echo "usage: tmux-docker-enter <container> [shell]" >&2
+  exec "${SHELL:-/bin/bash}" -l
+fi
+
+cwd="$(pwd 2>/dev/null || echo)"
+
+# Build docker exec args
+args=(exec -it)
+[[ -n "${TERM:-}" ]]           && args+=(-e "TERM=$TERM")
+[[ -n "${COLORTERM:-}" ]]      && args+=(-e "COLORTERM=$COLORTERM")
+[[ -n "${CLAUDE_CONTEXT:-}" ]] && args+=(-e "CLAUDE_CONTEXT=$CLAUDE_CONTEXT")
+
+if [[ -n "$cwd" ]] && docker exec "$container" test -d "$cwd" 2>/dev/null; then
+  args+=(-w "$cwd")
+fi
+
+args+=("$container" "$shell")
+
+# Try docker exec, fall back to host shell on failure (container stopped / not found)
+if ! docker exec "$container" true 2>/dev/null; then
+  echo "tmux-docker-enter: container '$container' not running — host shell fallback" >&2
+  echo "  (exit this shell to retry docker exec)" >&2
+  exec "${SHELL:-/bin/bash}" -l
+fi
+
+exec docker "${args[@]}"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -24,6 +24,26 @@ detect_os() {
   esac
 }
 
+# sudo が実質的に利用可能かを非対話で判定する
+# 戻り値: 0 = NO_SUDO (sudo使えない or 不要), 1 = SUDO利用可
+# 判定順:
+#   1. EUID=0 (既に root) → sudo不要だが従来パスで進める → return 1
+#   2. sudo バイナリなし → NO_SUDO → return 0
+#   3. `sudo -n true` 成功 (NOPASSWD or ticket有効) → SUDO利用可 → return 1
+#   4. それ以外 (sudoあるがパスワード要求) → NO_SUDO → return 0
+detect_sudo_mode() {
+  if [[ $EUID -eq 0 ]]; then
+    return 1
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 0
+  fi
+  if sudo -n true 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
 # Read a newline-delimited package list file, stripping comments and blank lines
 # Usage: readarray -t MY_ARRAY < <(read_package_list "$file")
 read_package_list() {


### PR DESCRIPTION
## Summary

sudo 権限のないリモート Linux ホストで dotfiles を完走できるようにし、リモート開発環境を「Docker 内 tmux」から「ホスト側 tmux + docker exec」構成に pivot する。opensessions によるクロスコンテナ AI エージェント監視と、ペイン分割時の自動 docker exec 流入を両立する。

## Changes

### `feat(install): add --no-sudo mode with pixi-based user-scope installation`
- `scripts/utils.sh`: `detect_sudo_mode` (EUID / sudo binary / `sudo -n true` の3段チェック)
- `install.sh`: `--no-sudo` / `--with-sudo` フラグ + 自動検出、1Password CLI の tarball → `~/.local/bin/op` ユーザースコープ install
- `scripts/linux.sh`: `install_system_packages` を NO_SUDO 時に pixi 経由へ、`_install_github_release` の target を `~/.local/bin` に、`_install_neovim_tarball` helper で `~/.local/opt` 配置、`set_default_shell` を `.profile` への `exec zsh -l` 注入に fallback、apt_repo メソッドは NO_SUDO 時に skip
- `scripts/pixi-lib.sh` + `config/pixi-packages.txt`: pixi (conda-forge) の bootstrap と system-level tool (tmux / stow / gh / eza / bat / ripgrep / jq 等) のインストール
- `config/tools.linux.bash`: neovim install_cmd を helper 関数呼び出しに差し替え

### `feat(rcon): pivot to host-side tmux with auto docker exec per pane`
- `common/zsh/.zshrc.common`: `rcon` をホスト側 tmux `new-session -A -s <container>` + `set-option default-command` に書き換え。session 名の `:` / `.` は `-` に sanitize
- `scripts/tmux-docker-enter`: ペイン cwd がコンテナ内に存在すれば `docker exec -w <cwd>` で伝播、存在しなければ container の WORKDIR、container 停止時はホスト shell フォールバックでペイン継続

### `docs: document no-sudo install mode and host tmux aggregation`
- `docs/install-no-sudo.md` (新規): `--no-sudo` フラグ、自動検出の挙動、pixi 対象パッケージ、1Password tarball / `.profile` fallback、前提条件、CONDA_PREFIX caveat、Mac 対象外理由
- `docs/opensessions.md` (新規): session 単位集計のデータモデル、「1 コンテナ = 1 セッション」運用方針、watcher のファイルパス要件、volume mount 契約
- `docs/rcon.md`: 「現在の実装」を新アーキテクチャ (host tmux + default-command + wrapper) に書き換え、cwd 引き継ぎ前提条件とフォールバック挙動表を追加

## Test plan

- [ ] `bash -n` / `zsh -n` が全変更スクリプトでパスする (実施済)
- [ ] `detect_sudo_mode` がローカル Mac で期待通り動作する (実施済)
- [ ] `install.sh` の argparse が `--no-sudo` / `--with-sudo` / auto を正しく処理する (実施済)
- [ ] sudoless Linux ホスト (chronos 等) で `./install.sh` が完走し、pixi 経由で tmux/stow/gh 等が `~/.pixi/bin` に入る
- [ ] sudo 利用可能な Linux ホストで従来通り apt 経由のインストールが動作する
- [ ] `rcon host:container` がホスト tmux に session を作成し、`default-command` でペイン新規作成時に自動 docker exec される
- [ ] コンテナ内のプロジェクトパスがホストと一致している場合に、ペイン分割時に cwd が引き継がれる
- [ ] コンテナ停止時にペインが消えず、ホスト shell にフォールバックする
- [ ] host-only target (`rcon host` 単独) が従来通り動作する

## Notes

- Mac 側 (`scripts/mac.sh`, `config/Brewfile`) は変更なし。Homebrew が cask / 3rd-party tap / macmon を提供しているため、pixi による置換は対象外
- セッション外の `common/ghostty/.config/ghostty/config` の変更および `.claude/` は本 PR に含めていない (別タスク範囲)

Closes #55