### PR TITLE
Tune tmux pane dimming and Ghostty background opacity

### DIFF
--- a/common/ghostty/.config/ghostty/config
+++ b/common/ghostty/.config/ghostty/config
@@ -17,7 +17,7 @@ selection-foreground = #c0caf5
 # --- Background Image ---
 background-image = ~/.config/ghostty/backgrounds/background.jpeg
 background-image-fit = cover
-background-image-opacity = 0.2
+background-image-opacity = 0.35
 background-opacity = 1.0
 
 # --- Window (macOS) ---

--- a/common/tmux/.config/tmux/syntopic.tmux
+++ b/common/tmux/.config/tmux/syntopic.tmux
@@ -32,7 +32,7 @@ set -g pane-border-format " #P: #{?pane_title,#{pane_title},#{pane_current_comma
 set -g pane-border-indicators both
 
 # --- Window Style ---
-set -g window-style 'fg=colour244,bg=default'
+set -g window-style 'fg=colour248,bg=default'
 set -g window-active-style 'fg=colour255,bg=default'
 
 # --- Status Bar (transparent) ---

--- a/common/tmux/.config/tmux/tokyonight.tmux
+++ b/common/tmux/.config/tmux/tokyonight.tmux
@@ -32,7 +32,7 @@ set -g pane-border-format " #P: #{?pane_title,#{pane_title},#{pane_current_comma
 set -g pane-border-indicators both
 
 # --- Window Style ---
-set -g window-style 'fg=colour244,bg=default'
+set -g window-style 'fg=colour248,bg=default'
 set -g window-active-style 'fg=colour255,bg=default'
 
 # --- Status Bar (transparent) ---

--- a/scripts/regenerate-tmux-theme.sh
+++ b/scripts/regenerate-tmux-theme.sh
@@ -138,7 +138,7 @@ set -g pane-border-format " #P: #{?pane_title,#{pane_title},#{pane_current_comma
 set -g pane-border-indicators both
 
 # --- Window Style ---
-set -g window-style 'fg=colour244,bg=default'
+set -g window-style 'fg=colour248,bg=default'
 set -g window-active-style 'fg=colour255,bg=default'
 
 # --- Status Bar (transparent) ---


### PR DESCRIPTION
## Summary

Improve visual balance between tmux pane highlighting and background image visibility:
- Relax inactive pane text dimming (colour244 → colour248) for better readability
- Raise Ghostty background-image-opacity (0.2 → 0.35) to make the background more visible
- Keep active pane emphasis via border and foreground color only (no opaque background overlay)

## Changes

- `common/ghostty/.config/ghostty/config`: background-image-opacity 0.2 → 0.35
- `scripts/regenerate-tmux-theme.sh`: window-style fg colour244 → colour248
- `common/tmux/.config/tmux/tokyonight.tmux`: generated changes (same as above)
- `common/tmux/.config/tmux/syntopic.tmux`: generated changes (same as above)

## Rationale

Tmux `window-active-style` does not support alpha transparency (tmux/tmux#2767), so visual hierarchy relies on border color and foreground contrast. Ghostty's `background-opacity-cells` affects the whole window, not individual panes. This solution balances visibility of both active and inactive panes while keeping the background image present.

## Test plan

- [ ] Reload Ghostty config (`cmd+shift+r`) and verify background image is more visible
- [ ] Reload tmux config (`prefix+r`) and verify inactive pane text is more readable (dimming is gentler)
- [ ] Verify active pane stands out via border color and white text
- [ ] No visual regression on other UI elements

Closes #57