### PR TITLE
Add rcon setup guide and _setup-rcon-target skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ eval $(op signin)
 ./install.sh
 ```
 
+### Linux (sudo 権限のないリモートホスト)
+
+共有サーバーや管理された開発環境等、`apt` が使えない環境向け。pixi (conda-forge) でシステムパッケージを user-scope に展開:
+
+```bash
+# 前提: curl, git, bash, unzip がホスト側に既にある前提 (通常の開発ホストには揃っている)
+git clone https://github.com/shonenm/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install.sh --no-sudo
+```
+
+詳細は [`docs/install-no-sudo.md`](docs/install-no-sudo.md)。
+
 ### Docker環境
 
 ```bash
@@ -226,7 +239,7 @@ git pull
 
 - 1Password SSH Agentを使用
 - ホスト固有の設定は `~/.ssh/config.d/` に配置
-- `rcon` でリモート接続（SSH + Docker + tmux）をワンコマンド実行（引数なしで fzf 選択、`rcon host:container` で直接指定、既存セッションに自動アタッチ）
+- `rcon` でリモート接続（SSH + ホスト集約 tmux + docker exec）をワンコマンド実行。引数なしで fzf 選択、`rcon host:container` で直接指定、既存セッションに自動アタッチ。pane 分割/新 window で自動的に docker exec (cwd 引き継ぎ) される。セットアップ手順は [`docs/rcon-setup.md`](docs/rcon-setup.md)、動作原理は [`docs/rcon.md`](docs/rcon.md) を参照
 
 ## カスタマイズ
 

--- a/common/claude/.claude/skills/_setup-rcon-target/SKILL.md
+++ b/common/claude/.claude/skills/_setup-rcon-target/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: _setup-rcon-target
+description: 新しい rcon ターゲット (host もしくは host:container) をセットアップする。targets ファイル追加、SSH/dotfiles/tmux 接続検証、Docker volume mount スニペット生成を半自動化。
+user-invocable: true
+arguments: "<host> | <host>:<container>"
+argument-hint: "<host>[:<container>]"
+when_to_use: "Use when the user wants to register a new rcon target (remote host or remote-host:container pair) and verify everything is wired up for host-tmux + docker-exec operation. Automates the process described in docs/rcon-setup.md."
+---
+
+# Setup rcon Target
+
+新しい rcon ターゲットをセットアップし、すぐ使える状態にする。詳細原理は `docs/rcon-setup.md` を参照。
+
+## 引数
+
+| 引数 | 説明 |
+|------|------|
+| `<host>` | SSH 接続可能な host 名 (~/.ssh/config で解決可能) |
+| `<host>:<container>` | 上記 + docker container 指定 |
+
+### 使用例
+
+```
+/_setup-rcon-target chronos
+/_setup-rcon-target chronos:syntopic-dev
+/_setup-rcon-target ailab:another-container
+```
+
+## 手順
+
+### 1. 引数の解析
+
+- `:` を含むか: `host` と `container` に分離
+- 含まない: host のみ (container なし target)
+
+### 2. Mac 側: `~/.config/rcon/targets` に追加
+
+```bash
+mkdir -p ~/.config/rcon
+# 既存に同じ行があれば skip (idempotent)
+touch ~/.config/rcon/targets
+if ! grep -qxF "<target>" ~/.config/rcon/targets; then
+  echo "<target>" >> ~/.config/rcon/targets
+fi
+```
+
+追加前に現在の内容を表示してユーザーに確認を求めず、そのまま追加する。
+
+### 3. SSH 疎通確認
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=5 <host> true 2>&1
+```
+
+- 成功: 次へ
+- 失敗:
+  - 「`ssh-copy-id <host>` を実行して公開鍵を配置してください」と案内
+  - `~/.ssh/config` に `Host <host>` が無さそうなら追加も案内
+  - スキルはここで停止
+
+### 4. リモート dotfiles 存在確認
+
+```bash
+ssh <host> 'ls -la ~/dotfiles/scripts/tmux-docker-enter 2>/dev/null && command -v tmux'
+```
+
+- 両方揃っていれば OK
+- 揃ってなければ案内:
+  ```
+  リモートに dotfiles がセットアップされていません。リモートで以下を実行してください:
+    git clone git@github.com:shonenm/dotfiles.git ~/dotfiles
+    cd ~/dotfiles
+    ./install.sh --no-sudo   # sudoless なら
+    ./install.sh              # sudo 利用可なら
+  完了後に再度このコマンドを実行してください。
+  ```
+  スキルはここで停止
+
+### 5. container 指定時: docker 存在確認 + volume mount スニペット生成
+
+```bash
+ssh <host> "docker inspect <container> --format '{{json .Mounts}}' 2>&1"
+```
+
+- container が存在しない (stopped / 未作成): 新規作成用の `docker run` / `docker compose` スニペットを生成 (下記パターン参照)
+- 存在するが volume mount が不足: 追加すべき mount を差分表示
+- 全て揃っている: 「準備OK」と表示
+
+#### mount 必須項目
+
+以下が container 内で見えている必要がある:
+
+| mount | 用途 |
+|-------|------|
+| `~/.claude` → container 内 home の `.claude` | opensessions の Claude watcher |
+| `~/.codex` → 同 `.codex` | Codex watcher |
+| `~/.local/share/amp` → 同 `.local/share/amp` | Amp watcher |
+| プロジェクトディレクトリをホストと同じパスで | cwd 引き継ぎ (pane分割時) |
+
+container 内 user が root なら `/root/...`、それ以外なら `/home/<user>/...`。判定は `docker exec <container> id -un` で可能。
+
+#### docker run スニペット例
+
+```bash
+docker run -d \
+  --name <container> \
+  -v $HOME/.claude:<homedir>/.claude \
+  -v $HOME/.codex:<homedir>/.codex \
+  -v $HOME/.local/share/amp:<homedir>/.local/share/amp \
+  -v $HOME/proj/<project>:<homedir>/proj/<project> \
+  --workdir <homedir>/proj/<project> \
+  <image>
+```
+
+#### docker-compose.yml の追加スニペット例
+
+```yaml
+services:
+  <container>:
+    volumes:
+      - ~/.claude:<homedir>/.claude
+      - ~/.codex:<homedir>/.codex
+      - ~/.local/share/amp:<homedir>/.local/share/amp
+      - ~/proj/<project>:<homedir>/proj/<project>
+    working_dir: <homedir>/proj/<project>
+```
+
+生成したスニペットはそのまま出力する (ユーザーが該当ファイルに反映)。
+
+### 6. 完了報告
+
+以下をまとめて出力:
+
+```
+Target added: <target>
+  Targets file: ~/.config/rcon/targets
+  SSH: OK
+  Dotfiles on remote: OK
+  Docker container: <status>
+
+Next steps:
+  [container なしの場合]
+    rcon <host>
+  [container ありで mount 揃っている場合]
+    rcon <host>:<container>
+  [container が未作成 / mount 不足の場合]
+    上記スニペットを <docker-compose.yml or 起動スクリプト> に反映し、container を recreate:
+      docker compose down && docker compose up -d
+    その後: rcon <host>:<container>
+```
+
+## エラー時の挙動
+
+- どのステップで失敗したかを明確に表示
+- 必要な手動作業を案内
+- targets への追記は行った状態で停止 (再実行時に idempotent)
+
+## 注意事項
+
+- container 作成 / recreate はスキルでは行わない (ユーザー責任で compose 設定 or 起動スクリプトを調整)
+- 既存 container の volume mount を変更するには recreate が必要 (差分更新不可) — ユーザーに明示
+- target が既に存在する場合はスキップしつつ、残りの検証は実施
+- `/_setup-rcon-target` は冪等: 何度実行しても安全

--- a/docs/claude-skills.md
+++ b/docs/claude-skills.md
@@ -9,6 +9,7 @@ Claude Code で使用可能なカスタムスキルのリファレンス。
 | `/_beacon` | Aerospace ワークスペースに環境を紐付け |
 | `/_commit` | セッション内の変更を分析してコミット作成 |
 | `/_news` | プロファイルベースのパーソナライズドニュース収集 |
+| `/_setup-rcon-target` | rcon ターゲットの登録 + 接続検証 + docker mount スニペット生成 |
 | `/_update-md` | セッション内の変更に関連するドキュメント更新 |
 
 Ralph 系スキルは [`ralph.md`](ralph.md) を参照。
@@ -140,6 +141,34 @@ interests:
 ### プロファイルテンプレート
 
 `common/claude/.claude/news-profile.example.yaml` を `~/.claude/news-profile.yaml` にコピーして編集。
+
+## /_setup-rcon-target
+
+新しい rcon ターゲット (リモートホスト or ホスト + docker container) を登録し、接続前提条件を検証する。
+
+### 使い方
+
+```
+/_setup-rcon-target chronos
+/_setup-rcon-target chronos:syntopic-dev
+/_setup-rcon-target ailab:another-container
+```
+
+### 動作
+
+1. `~/.config/rcon/targets` に target を追記 (冪等)
+2. SSH 疎通確認 (`ssh -o BatchMode=yes <host> true`)
+3. リモート側の dotfiles / tmux / `scripts/tmux-docker-enter` の存在確認
+4. container 指定時: docker 上の存在確認 + 必須 volume mount (`~/.claude`, `~/.codex`, `~/.local/share/amp`, プロジェクトパス) の diff
+5. 不足している mount は docker-compose / docker run の追記スニペットとして出力
+
+### 前提
+
+- Mac: zsh + `rcon` コマンドが有効 (`common/zsh/.zshrc.common`)
+- リモート: dotfiles install済 (`~/dotfiles` に clone + `./install.sh [--no-sudo]`)
+- container: docker daemon と docker CLI 利用可能
+
+詳細は [rcon-setup.md](./rcon-setup.md)。
 
 ## /_update-md
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,16 +5,22 @@ dotfiles のセットアップスクリプト。
 ## 使い方
 
 ```bash
-./install.sh      # 対話モード
-./install.sh -y   # 自動モード（確認スキップ）
+./install.sh            # 対話モード (sudo 利用可前提)
+./install.sh -y         # 自動モード（確認スキップ）
+./install.sh --no-sudo  # sudoless 環境 (pixi ベースの user-scope install)
 ```
+
+sudoless 環境 (共有サーバー等) での運用詳細は [install-no-sudo.md](./install-no-sudo.md) を参照。
 
 ## 実行内容
 
 ### 1. 1Password CLI チェック
 
 - `op` コマンドがインストールされているか確認
-- 未インストールの場合は自動インストール（Mac: Homebrew / Linux: apt）
+- 未インストールの場合は自動インストール
+  - Mac: Homebrew
+  - Linux + sudo: apt
+  - Linux + `--no-sudo`: tarball を `~/.local/bin/op` に展開 (`cache.agilebits.com` から最新版取得、失敗時は 2.33.1 fallback)
 - サインイン状態を確認（未サインインの場合は中断）
 
 ### 2. Homebrew インストール (Mac のみ)
@@ -28,7 +34,8 @@ OS に応じたセットアップスクリプトを実行:
 | OS | スクリプト | 内容 |
 |----|-----------|------|
 | Mac | `scripts/mac.sh` | Homebrew パッケージ (Brewfile)、cargo ツール (quay, cargo-update)、gh 拡張機能、Aerospace、SketchyBar 等 |
-| Linux | `scripts/linux.sh` | apt/apk パッケージ、GitHub release バイナリ、cargo ツール等（`config/tools.linux.bash` で定義） |
+| Linux (sudo) | `scripts/linux.sh` | apt/apk パッケージ、GitHub release バイナリを `/usr/local/bin` に、cargo ツール等 |
+| Linux (`--no-sudo`) | `scripts/linux.sh` | **pixi (conda-forge) でシステムパッケージ** (`config/pixi-packages.txt`)、GitHub release バイナリを `~/.local/bin` に、その他は curl_pipe や user-scope cargo 等 |
 
 ### 4. Dotfiles リンク (stow)
 

--- a/docs/rcon-setup.md
+++ b/docs/rcon-setup.md
@@ -1,0 +1,245 @@
+# rcon Setup Guide
+
+ホスト集約 tmux + docker exec 構成でリモート開発環境をセットアップする手順。
+
+`rcon` の動作原理は [rcon.md](./rcon.md)、opensessions の運用方針は [opensessions.md](./opensessions.md) を参照。本ドキュメントは「新しいターゲットを追加するときに何を設定すればよいか」のレシピ集。
+
+## アーキテクチャ前提
+
+```
+Mac (Ghostty)
+  └─ ssh chronos
+      └─ host tmux server (chronos 上)
+          ├─ session "syntopic-dev"      → docker exec syntopic-dev
+          ├─ session "another-container" → docker exec another-container
+          └─ session "main"              → host shell (container なし target)
+```
+
+- tmux はリモートホスト側で **1サーバーに集約**
+- 各 session が docker container と1対1対応
+- pane分割 / 新window で `default-command` 経由で自動 docker exec
+- opensessions が複数 container を1つのサイドバーに集約表示
+
+## セットアップ層別の責務
+
+| レイヤ | 何を設定するか |
+|-------|---------------|
+| Mac 側 | `~/.config/rcon/targets` に target を1行追加 |
+| リモートホスト (chronos等) | dotfiles install 済 + tmux 起動可 + docker CLI 利用可 |
+| Docker container | **volume mount** で `~/.claude` 等をホストと共有 |
+
+## 1. Mac 側: target 追加
+
+```bash
+mkdir -p ~/.config/rcon
+cat >> ~/.config/rcon/targets <<'EOF'
+chronos
+chronos:syntopic-dev
+chronos:another-container
+EOF
+```
+
+形式: `<host>` または `<host>:<container>`。`<host>` は `~/.ssh/config` で解決可能な名前。コメントは `#` で開始。
+
+`rcon` (引数なし) で fzf 選択、`rcon chronos:syntopic-dev` で直接指定。
+
+## 2. リモートホスト (chronos 等): 一度だけのセットアップ
+
+新しいリモートホストを使う初回:
+
+```bash
+# Mac 側で SSH 公開鍵を配置 (パスワードなし接続)
+ssh-copy-id chronos
+
+# リモート側で dotfiles を clone & install
+ssh chronos
+git clone git@github.com:shonenm/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install.sh --no-sudo   # sudoless ホストの場合
+# あるいは sudo 利用可ホストでは
+./install.sh
+```
+
+これで以下が揃う:
+- `tmux` (pixi 経由で `~/.pixi/bin/tmux`)
+- `~/.config/tmux/tmux.conf` (stow symlink)
+- `~/dotfiles/scripts/tmux-docker-enter` (wrapper)
+- TPM + opensessions plugin
+- zsh / stow / その他 CLI ツール
+
+確認:
+```bash
+ssh chronos
+which tmux                                    # ~/.pixi/bin/tmux
+ls -la ~/dotfiles/scripts/tmux-docker-enter   # 実行可能
+ls ~/.tmux/plugins/opensessions               # plugin 展開済
+which docker                                   # docker CLI 存在
+```
+
+詳細は [install-no-sudo.md](./install-no-sudo.md)。
+
+## 3. Docker container: volume mount を追加
+
+opensessions の AI agent watcher (Claude Code / Codex / Amp) はホスト側のファイルシステムを読む。コンテナ内で agent を動かすなら `~/.claude` 等を mount しておく必要がある。
+
+### docker-compose.yml の場合
+
+```yaml
+services:
+  syntopic-dev:
+    volumes:
+      # AI agent state (opensessions 連携用)
+      - ~/.claude:/home/devuser/.claude
+      - ~/.codex:/home/devuser/.codex
+      - ~/.local/share/amp:/home/devuser/.local/share/amp
+
+      # プロジェクトファイル (cwd 引き継ぎを動かすため、ホストとパス揃える)
+      - ~/proj/syntopic:/home/devuser/proj/syntopic
+
+    working_dir: /home/devuser/proj/syntopic
+```
+
+container 内 user が `root` なら `/root/.claude` 等。
+
+反映:
+```bash
+docker compose down syntopic-dev
+docker compose up -d syntopic-dev
+```
+
+### docker run の場合
+
+```bash
+docker stop syntopic-dev && docker rm syntopic-dev
+docker run -d \
+  --name syntopic-dev \
+  -v ~/.claude:/root/.claude \
+  -v ~/.codex:/root/.codex \
+  -v ~/proj/syntopic:/root/proj/syntopic \
+  --workdir /root/proj/syntopic \
+  <image>
+```
+
+> ⚠️ container を recreate するとファイルシステム差分は失われる。永続化したいデータは別 volume に切り出しておく。
+
+## 4. 接続テスト
+
+```bash
+# Mac 側で
+rcon chronos                    # host のみ (sanity check)
+# → host tmux session "main" に attach
+
+rcon chronos:syntopic-dev       # container 接続
+# → host tmux session "syntopic-dev" 作成、最初の pane が container 内 zsh
+
+# 動作確認
+hostname    # container のホスト名 (= short container ID 等)
+pwd         # mount したプロジェクトパス
+
+# pane 分割で自動 docker exec + cwd 引き継ぎ
+prefix+|    # 右に分割
+hostname    # 同じ container
+pwd         # 同じディレクトリ
+
+# detach
+prefix+d
+exit        # ssh 抜ける
+```
+
+## 5. opensessions サイドバー確認
+
+attach 中の host tmux で:
+
+```
+prefix+o → s    # サイドバー focus
+prefix+o → t    # トグル
+prefix+o → 1-9  # 番号で session切替
+```
+
+期待:
+- container 名で session が並ぶ
+- container 内で Claude/Codex を起動 → status が反映 (volume mount 効いてれば)
+
+詳細は [opensessions.md](./opensessions.md)。
+
+## 日常運用フロー
+
+```
+朝:
+  Mac: rcon chronos:syntopic-dev
+  作業 (nvim, server起動, claude起動 等)
+  prefix+d で detach (tmux session は host 側で生き続ける)
+
+別 container に切替:
+  Mac: rcon chronos:another-container
+  または既存接続中なら prefix+o → s → 別 session 選択
+
+夜:
+  prefix+d で detach
+  ssh 切断
+  → host tmux server は生き続け、翌朝 rcon で即復帰
+```
+
+## トラブルシューティング
+
+### `rcon: command not found` (Mac)
+
+zsh が再起動されてない。新 terminal を開く or `source ~/.zshrc`。
+
+### `tmux: command not found` (リモート)
+
+pixi の PATH (`~/.pixi/bin`) が反映されてない。
+- 新 ssh セッションを開く (`~/.profile` → `exec zsh -l` で `~/.bashrc` 経由 PATH 設定)
+- もしくは `source ~/.bashrc` で現セッションに反映
+
+### `tmux-docker-enter: No such file`
+
+リモートに dotfiles が clone されてない、または `~/dotfiles` 以外に展開されている。`ls -la ~/dotfiles/scripts/tmux-docker-enter` で確認。
+
+### pane 分割しても host shell に戻る
+
+container が稼働してない。
+```bash
+docker ps -a | grep <container>   # 状態確認
+docker start <container>            # 起動
+```
+container 起動後、pane を `exit` で閉じて新規分割するか `tmux respawn-pane`。
+
+### pane 分割で cwd が引き継がれない
+
+ホストとコンテナで対応するパスが存在しない。docker run の `-v` で同じパスでマウントする (例: `-v ~/proj/syntopic:~/proj/syntopic` ではなく `-v ~/proj/syntopic:/root/proj/syntopic` のときは host の `/home/user/proj/syntopic` と container の `/root/proj/syntopic` が異なるパスになる)。
+
+cwd 完全一致が難しい場合は wrapper の fallback で container の WORKDIR で開くが、毎回 `cd` が必要になる。
+
+### opensessions に AI status が出ない
+
+container 内で動いてる Claude が ホスト `~/.claude/projects/` に書き込めていない (volume mount 不足)。
+
+```bash
+# host 側
+ls -la ~/.claude/projects/          # JSONL が増えているか
+# container 側
+ls -la /root/.claude/projects/      # 同じ内容が見えるか (mount 効いてればホストと同じ)
+```
+
+mount 設定を見直して container を recreate。
+
+### session 名に `:` `.` がある
+
+tmux 制限のため `rcon` 内で自動的に `-` に sanitize される (`syntopic.dev` → `syntopic-dev`)。混乱を避けるなら container 名にこれらを使わない方が良い。
+
+## 自動化
+
+`/_setup-rcon-target` skill を使うと target 追加 + 接続検証 + docker mount スニペット生成を半自動化できる。
+
+```
+/_setup-rcon-target chronos:new-container
+```
+
+詳細はスキル定義 (`common/claude/.claude/skills/_setup-rcon-target/SKILL.md`) 参照。
+
+## 関連ドキュメント
+
+- [rcon.md](./rcon.md) — rcon コマンド本体の動作原理
+- [opensessions.md](./opensessions.md) — opensessions 運用方針
+- [install-no-sudo.md](./install-no-sudo.md) — sudoless 環境向け install


### PR DESCRIPTION
## Summary

PR #56 で実装した no-sudo install + host-tmux + docker exec 構成に対応するセットアップ手順のリファレンス文書と自動化スキルを追加し、既存ドキュメントを新アーキテクチャに合わせて更新する。新しい rcon ターゲットを追加するたびに手順を再構成する負荷を軽減する。

## Changes

### 新規

- **`docs/rcon-setup.md`**: Mac / リモートホスト / Docker container の3層セットアップ手順、日常運用フロー、トラブルシューティング表 (PATH 反映漏れ / pixi / wrapper / cwd 引き継ぎ失敗 / opensessions の mount 不足)
- **`common/claude/.claude/skills/_setup-rcon-target/SKILL.md`**: `<host>` / `<host>:<container>` を引数に取る user-invocable skill
  - `~/.config/rcon/targets` に冪等追記
  - SSH 疎通確認 (`ssh -o BatchMode=yes`)
  - リモート dotfiles / tmux / `scripts/tmux-docker-enter` の存在検証
  - container 指定時は `docker inspect` で現状 mount を確認し、必須 mount (`~/.claude`, `~/.codex`, `~/.local/share/amp`, プロジェクトパス) の差分を docker-compose / docker run スニペットとして出力

### 既存更新

- **`docs/install.md`**: `--no-sudo` フラグの使用例追加、1Password CLI install 経路に tarball fallback (`cache.agilebits.com`) を明記、Linux セットアップ表を sudo / no-sudo で分割して `~/.local/bin` 配置を明示
- **`docs/claude-skills.md`**: `/_setup-rcon-target` をスキル一覧表と詳細セクションに追加
- **`README.md`**: rcon の one-liner を「SSH + Docker + tmux」から「SSH + ホスト集約 tmux + docker exec」に書き換え、Linux sudoless インストールセクションを追加 (`./install.sh --no-sudo`)、`docs/install-no-sudo.md` へのリンクを追加

## Test plan

- [ ] `docs/rcon-setup.md` のみを読んで chronos に target 追加が実行可能
- [ ] `/_setup-rcon-target chronos:<container>` で idempotent に targets 追記できる
- [ ] SSH 未疎通 / dotfiles 未 install / container 停止 時に skill が適切なガイダンスで停止する
- [ ] `docs/install.md` の Linux 表が `./install.sh --no-sudo` の経路を説明している
- [ ] `README.md` から `docs/install-no-sudo.md` / `docs/rcon-setup.md` / `docs/rcon.md` が辿れる
- [ ] CI (ShellCheck / Stow Dry Run) が pass する (shell変更なし、docs-only + skill md のみ)

Closes #59