### PR TITLE
Add claude-mem to install scripts for persistent memory

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -443,6 +443,21 @@ install_npm_packages() {
   done < <(read_package_list "$npm_file")
 }
 
+install_claude_mem() {
+  if ! command_exists npx; then
+    log_warn "npx not found, skipping claude-mem"
+    return
+  fi
+
+  if [[ -f "$HOME/.claude-mem/settings.json" ]]; then
+    log_success "claude-mem already installed"
+    return
+  fi
+
+  log_info "Installing claude-mem..."
+  npx -y claude-mem install
+}
+
 install_1password_cli() {
   if command_exists op; then
     log_success "1Password CLI already installed"
@@ -609,6 +624,7 @@ check_requirements
 install_system_packages
 install_modern_tools
 install_npm_packages
+install_claude_mem
 link_ai_scripts
 install_gh_extensions
 install_ghostty_terminfo

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -42,6 +42,21 @@ install_npm_packages() {
   done < <(read_package_list "$npm_file")
 }
 
+install_claude_mem() {
+  if ! command_exists npx; then
+    log_warn "npx not found, skipping claude-mem"
+    return
+  fi
+
+  if [[ -f "$HOME/.claude-mem/settings.json" ]]; then
+    log_success "claude-mem already installed"
+    return
+  fi
+
+  log_info "Installing claude-mem..."
+  npx -y claude-mem install
+}
+
 install_dops() {
   if command_exists dops; then
     log_success "dops already installed"
@@ -153,6 +168,7 @@ link_ai_scripts() {
 install_brew_bundle
 install_mise_tools
 install_npm_packages
+install_claude_mem
 install_dops
 install_quay
 install_cargo_update


### PR DESCRIPTION
## Summary

Integrate [claude-mem](https://github.com/thedotmack/claude-mem) into dotfiles install flow. New machines now get persistent cross-session memory for Claude Code with a single `install.sh` run, enabling automatic context injection across sessions.

## Changes

- Add `install_claude_mem()` function to `scripts/mac.sh` and `scripts/linux.sh`
- Idempotent guard checks `~/.claude-mem/settings.json` existence to prevent reinstalls
- Gracefully skip with warning if `npx` unavailable
- Integrate into main execution sequence immediately after `install_npm_packages`

## Test plan

- [ ] Run `install.sh` on macOS with `npx` available - verify claude-mem installs and hook fires
- [ ] Run `install.sh` on Linux with `npx` available - verify claude-mem installs and hook fires
- [ ] Re-run `install.sh` on same host - verify claude-mem reports "already installed" and skips reinstall
- [ ] Run on host without `npx` - verify warning logged and script continues
- [ ] Verify Claude Code claude-mem plugin loads on next session startup

Closes #61