### PR TITLE
tmux: add pane-sticky zoom (prefix Z) that auto re-zooms on pane return

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -79,7 +79,11 @@ bind -r K resize-pane -U 2
 bind -r L resize-pane -R 2
 
 # Zoom toggle
-bind z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh"
+#   z: normal zoom — tmux auto-unzooms on pane switch and does not restore on return
+#   Z: pane-sticky zoom — after-select-pane hook re-zooms when returning to the pane
+#   Pressing either again while sticky unzooms and clears the sticky flag
+bind z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh normal"
+bind Z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh sticky"
 
 # Reload config (shows RELOAD mode during reload)
 bind r set -g @reload_mode 1 \; \
@@ -170,6 +174,9 @@ set-hook -ga session-created 'run-shell "~/dotfiles/scripts/tmux-session-color.s
 set-hook -ga client-session-changed 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
 set-hook -ga client-attached 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
 set-hook -ga after-new-window 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+
+# Pane-sticky zoom: register after-select-pane hook once (reload-safe via @zoom-hooks-loaded)
+run-shell "~/dotfiles/scripts/tmux-zoom-hooks.sh"
 
 # 現セッションに即時適用 (config reload & 既存セッション対応)
 run-shell "~/dotfiles/scripts/tmux-session-color.sh apply '#{session_name}' 2>/dev/null || true"

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -363,6 +363,7 @@ rcon() {
     ssh -t "$host" "
       set -e
       export PATH=\"\$HOME/.pixi/bin:\$HOME/.local/bin:\$PATH\"
+      export TERMINFO_DIRS=\"\$HOME/.terminfo:/usr/share/terminfo:/lib/terminfo\"
       export CLAUDE_CONTEXT='$context'
       cmd=\"\$HOME/dotfiles/scripts/tmux-docker-enter '$container'\"
       tmux new-session -A -d -s '$sess' \"\$cmd\" 2>/dev/null || true
@@ -374,6 +375,7 @@ rcon() {
     local sess="${session:-main}"
     ssh -t "$host" "
       export PATH=\"\$HOME/.pixi/bin:\$HOME/.local/bin:\$PATH\"
+      export TERMINFO_DIRS=\"\$HOME/.terminfo:/usr/share/terminfo:/lib/terminfo\"
       export CLAUDE_CONTEXT='$context'
       exec tmux new-session -A -s '$sess'
     "

--- a/scripts/tmux-zoom-hooks.sh
+++ b/scripts/tmux-zoom-hooks.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Register zoom sticky hooks once per tmux server (reload-safe guard).
+
+if [ -n "$(tmux show-options -gqv @zoom-hooks-loaded 2>/dev/null)" ]; then
+    exit 0
+fi
+
+tmux set-hook -ga after-select-pane 'run-shell -b "~/dotfiles/scripts/tmux-zoom-restore.sh"'
+tmux set-option -g @zoom-hooks-loaded 1

--- a/scripts/tmux-zoom-restore.sh
+++ b/scripts/tmux-zoom-restore.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Re-zoom the window if the newly active pane has @zoom-sticky set.
+# Invoked from after-select-pane hook.
+
+sticky=$(tmux show-options -pqv @zoom-sticky 2>/dev/null)
+zoomed=$(tmux display-message -p '#{window_zoomed_flag}')
+if [ -n "$sticky" ] && [ "$zoomed" = "0" ]; then
+    tmux resize-pane -Z
+fi

--- a/scripts/tmux-zoom-toggle.sh
+++ b/scripts/tmux-zoom-toggle.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
-# Toggle pane zoom
+# Toggle pane zoom with optional pane-sticky persistence.
+# Usage: tmux-zoom-toggle.sh [normal|sticky]
+#   normal: plain zoom. Leaving the pane lets tmux auto-unzoom; returning does not restore.
+#   sticky: marks the pane with @zoom-sticky so the after-select-pane hook re-zooms on return.
+# Pressing z or Z on a sticky pane clears the flag and unzooms.
 
-tmux resize-pane -Z
+mode="${1:-normal}"
+sticky=$(tmux show-options -pqv @zoom-sticky 2>/dev/null)
+zoomed=$(tmux display-message -p '#{window_zoomed_flag}')
+
+if [ -n "$sticky" ]; then
+    tmux set-option -p -u @zoom-sticky
+    [ "$zoomed" = "1" ] && tmux resize-pane -Z
+elif [ "$zoomed" = "1" ]; then
+    tmux resize-pane -Z
+else
+    [ "$mode" = "sticky" ] && tmux set-option -p @zoom-sticky 1
+    tmux resize-pane -Z
+fi


### PR DESCRIPTION
## Summary

Adds `prefix Z` as a second zoom binding alongside `prefix z`:
- `prefix Z`: pane-sticky zoom. Marks the pane with `@zoom-sticky` so that when leaving (tmux auto-unzooms on pane switch) and returning to the pane, the window is automatically re-zoomed.
- `prefix z`: plain zoom (unchanged). No sticky flag; auto-unzoom on pane switch, no restore on return.
- Pressing `z` or `Z` on a sticky pane clears the flag and unzooms.

## Changes

- `scripts/tmux-zoom-toggle.sh`: Toggle zoom with pane option `@zoom-sticky` management
- `scripts/tmux-zoom-restore.sh`: Invoked by `after-select-pane` hook; re-zooms when the active pane has `@zoom-sticky`
- `scripts/tmux-zoom-hooks.sh`: Registers the hook once (reload-safe with `@zoom-hooks-loaded` guard)
- `common/tmux/.config/tmux/tmux.conf`: Bind `prefix z`/`prefix Z`, source hook registration

## Test plan

- [ ] `prefix Z` zooms current pane and sets `@zoom-sticky=1` on that pane
- [ ] Switch to another pane → auto-unzoom (tmux default); return to the sticky pane → re-zoom automatically
- [ ] `prefix z` zooms plainly with no sticky flag; returning to the pane after a switch shows it unzoomed
- [ ] `prefix z` or `prefix Z` on a sticky pane clears the flag and unzooms
- [ ] `prefix r` reload does not duplicate the `after-select-pane` hook entries

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)