### PR TITLE
feat: streamline new-environment setup (container install + prebuilt binaries + docs)

### DIFF
--- a/common/claude/.claude/skills/_setup-rcon-target/SKILL.md
+++ b/common/claude/.claude/skills/_setup-rcon-target/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: _setup-rcon-target
-description: 新しい rcon ターゲット (host もしくは host:container) をセットアップする。targets ファイル追加、SSH/dotfiles/tmux 接続検証、Docker volume mount スニペット生成を半自動化。
+description: 新しい rcon ターゲット (host もしくは host:container) をセットアップする。targets ファイル追加、SSH/dotfiles/tmux 接続検証、Docker volume mount スニペット生成を半自動化。--apply で compose 編集 + container recreate + container 内 dotfiles install まで完遂。
 user-invocable: true
-arguments: "<host> | <host>:<container>"
-argument-hint: "<host>[:<container>]"
-when_to_use: "Use when the user wants to register a new rcon target (remote host or remote-host:container pair) and verify everything is wired up for host-tmux + docker-exec operation. Automates the process described in docs/rcon-setup.md."
+arguments: "<host> | <host>:<container> [--apply]"
+argument-hint: "<host>[:<container>] [--apply]"
+when_to_use: "Use when the user wants to register a new rcon target (remote host or remote-host:container pair) and verify everything is wired up for host-tmux + docker-exec operation. Automates the process described in docs/rcon-setup.md. Pass --apply to also execute compose mount edit + force-recreate + container-side dotfiles install automatically."
 ---
 
 # Setup rcon Target
@@ -17,13 +17,14 @@ when_to_use: "Use when the user wants to register a new rcon target (remote host
 |------|------|
 | `<host>` | SSH 接続可能な host 名 (~/.ssh/config で解決可能) |
 | `<host>:<container>` | 上記 + docker container 指定 |
+| `--apply` | snippet 生成で止めず、実際に compose.yml 編集 / container recreate / install-in-container.sh 実行まで行う |
 
 ### 使用例
 
 ```
 /_setup-rcon-target chronos
 /_setup-rcon-target chronos:syntopic-dev
-/_setup-rcon-target ailab:another-container
+/_setup-rcon-target ailab:another-container --apply
 ```
 
 ## 手順
@@ -157,7 +158,64 @@ Next steps:
 
 ## 注意事項
 
-- container 作成 / recreate はスキルでは行わない (ユーザー責任で compose 設定 or 起動スクリプトを調整)
-- 既存 container の volume mount を変更するには recreate が必要 (差分更新不可) — ユーザーに明示
+- `--apply` なしのデフォルト: container 作成 / recreate は行わない (ユーザー責任で compose 設定 or 起動スクリプトを調整)
+- `--apply` 指定時: 下記「--apply 実行フロー」に従い、破壊的操作を含めて自動実行する
+- 既存 container の volume mount を変更するには recreate が必要 (差分更新不可) — `--apply` では force-recreate で実行
 - target が既に存在する場合はスキップしつつ、残りの検証は実施
 - `/_setup-rcon-target` は冪等: 何度実行しても安全
+
+## --apply 実行フロー (container target のみ)
+
+`--apply` を付けて呼び出された時、ステップ 5 の後に以下を追加実行する:
+
+### 5.1 compose.yml の特定
+
+1. `ssh <host> 'ls ~/*/compose.yml ~/*/docker-compose.yml ~/ws-*/compose.yml 2>/dev/null'` で候補を列挙
+2. `docker inspect <container> --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}'` で compose project dir を取得 (container 稼働中の場合)
+3. 両方を突き合わせて 1 ファイルに絞り込み、ユーザーに `<path>` を報告
+
+### 5.2 dotfiles bind mount の追加
+
+```bash
+# compose.yml の対象 service volumes に追記 (末尾ではなく、目視しやすい位置)
+- $HOME/dotfiles:/home/${USERNAME:-devuser}/dotfiles:ro
+```
+
+- `grep -qF "dotfiles:/home" <path>` で既存チェック、冪等に
+- `.bak-bindmount` として元を退避
+
+### 5.3 container force-recreate
+
+```bash
+ssh <host> "cd <compose_dir> && docker compose up -d --force-recreate <service_name>"
+```
+
+`service_name` は `docker inspect <container> --format '{{index .Config.Labels "com.docker.compose.service"}}'` で取得 (container_name とは別物)
+
+### 5.4 container 内で dotfiles install を 1 発
+
+```bash
+ssh <host> "docker exec <container> ~/dotfiles/scripts/install-in-container.sh"
+```
+
+このスクリプトは:
+- sudo apt で `build-essential pkg-config libssl-dev luarocks` を install
+- `~/dotfiles/install.sh --no-sudo --skip-prompt --skip-1p` を実行
+- symlinks と主要 tool の検証
+
+出力は行数が多いので、末尾 30 行だけ表示し、エラーあれば全文表示する判断にすること。
+
+### 5.5 検証
+
+```bash
+ssh <host> "docker exec <container> zsh -i -c 'command -v starship eza mise bun' 2>&1 | grep -v 'zle'"
+```
+
+すべて path が返れば OK。欠けていれば `exec zsh` で再読み込みしてから再検証、それでも駄目なら install-in-container.sh のログを再表示。
+
+## --apply 失敗時の挙動
+
+- 5.1 で compose.yml 特定失敗: snippet 生成モードへ fallback (手動適用を案内)
+- 5.2 で既に mount 済み: skip + 続行
+- 5.3 で recreate 失敗: container 状態そのまま / エラー全文表示 / 停止
+- 5.4 で install 失敗: エラー表示 / container は残す / 5.5 skip

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -142,45 +142,62 @@ TOOL_tokei_method="cargo"
 TOOL_tokei_cargo_crate="tokei"
 TOOL_tokei_depends_on="rust"
 
+# tealdeer: single binary, renamed to `tldr` at $install_dir via check_cmd
 TOOL_tealdeer_check_cmd="tldr"
-TOOL_tealdeer_method="cargo"
-TOOL_tealdeer_cargo_crate="tealdeer"
-TOOL_tealdeer_depends_on="rust"
+TOOL_tealdeer_method="github_release_binary"
+TOOL_tealdeer_github_repo="tealdeer-rs/tealdeer"
+TOOL_tealdeer_binary_map='x86_64:tealdeer-linux-x86_64-musl aarch64:tealdeer-linux-aarch64-musl'
+TOOL_tealdeer_install_dir="$HOME/.local/bin"
 
 TOOL_procs_check_cmd="procs"
 TOOL_procs_method="cargo"
 TOOL_procs_cargo_crate="procs"
 TOOL_procs_depends_on="rust"
 
+# sd: tarball, binary under sd-VERSION-ARCH-unknown-linux-musl/sd
 TOOL_sd_check_cmd="sd"
-TOOL_sd_method="cargo"
-TOOL_sd_cargo_crate="sd"
-TOOL_sd_depends_on="rust"
+TOOL_sd_method="github_release"
+TOOL_sd_github_repo="chmln/sd"
+TOOL_sd_archive_pattern='sd-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz'
+TOOL_sd_binary_path='sd-${VERSION}-${ARCH}-unknown-linux-musl/sd'
+TOOL_sd_arch_map='x86_64:x86_64 aarch64:aarch64'
 
+# dust: tarball, binary under dust-VERSION-ARCH-unknown-linux-musl/dust
 TOOL_dust_check_cmd="dust"
-TOOL_dust_method="cargo"
-TOOL_dust_cargo_crate="du-dust"
-TOOL_dust_depends_on="rust"
+TOOL_dust_method="github_release"
+TOOL_dust_github_repo="bootandy/dust"
+TOOL_dust_archive_pattern='dust-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz'
+TOOL_dust_binary_path='dust-${VERSION}-${ARCH}-unknown-linux-musl/dust'
+TOOL_dust_arch_map='x86_64:x86_64 aarch64:aarch64'
 
+# bottom (btm): tarball is flat, binary name is `btm`
 TOOL_bottom_check_cmd="btm"
-TOOL_bottom_method="cargo"
-TOOL_bottom_cargo_crate="bottom"
-TOOL_bottom_depends_on="rust"
+TOOL_bottom_method="github_release"
+TOOL_bottom_github_repo="ClementTsang/bottom"
+TOOL_bottom_archive_pattern='bottom_${ARCH}-unknown-linux-musl.tar.gz'
+TOOL_bottom_binary_path='btm'
+TOOL_bottom_arch_map='x86_64:x86_64 aarch64:aarch64'
 
+# rip2 (rip): tarball is flat, binary name is `rip`
 TOOL_rip2_check_cmd="rip"
-TOOL_rip2_method="cargo"
-TOOL_rip2_cargo_crate="rm-improved"
-TOOL_rip2_depends_on="rust"
+TOOL_rip2_method="github_release"
+TOOL_rip2_github_repo="MilesCranmer/rip2"
+TOOL_rip2_archive_pattern='rip-Linux-${ARCH}-musl.tar.gz'
+TOOL_rip2_binary_path='rip'
+TOOL_rip2_arch_map='x86_64:x86_64 aarch64:aarch64'
 
 TOOL_quay_check_cmd="quay"
 TOOL_quay_method="cargo"
 TOOL_quay_cargo_crate="quay-tui"
 TOOL_quay_depends_on="rust"
 
+# lsd: tarball, binary under lsd-VERSION-ARCH-unknown-linux-musl/lsd
 TOOL_lsd_check_cmd="lsd"
-TOOL_lsd_method="cargo"
-TOOL_lsd_cargo_crate="lsd"
-TOOL_lsd_depends_on="rust"
+TOOL_lsd_method="github_release"
+TOOL_lsd_github_repo="lsd-rs/lsd"
+TOOL_lsd_archive_pattern='lsd-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz'
+TOOL_lsd_binary_path='lsd-${VERSION}-${ARCH}-unknown-linux-musl/lsd'
+TOOL_lsd_arch_map='x86_64:x86_64 aarch64:aarch64'
 
 TOOL_gitabsorb_check_cmd="git-absorb"
 TOOL_gitabsorb_method="cargo"

--- a/docs/setup-new-environment.md
+++ b/docs/setup-new-environment.md
@@ -1,0 +1,143 @@
+# 新環境セットアップ
+
+どの環境 (Mac / Linux sudo / Linux no-sudo / Docker container) でも最短でこの dotfiles を立ち上げるためのレシピ集。AI アシスタントが読んで順に実行することを想定。
+
+## 環境別レシピ
+
+### Mac (新マシン)
+
+```bash
+xcode-select --install      # git / cc など前提ツール
+git clone git@github.com:shonenm/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install.sh
+eval $(op signin)           # 初回のみ 1P 対話ログイン (必要)
+```
+
+install.sh は Homebrew / Brewfile / stow / AI CLI 設定生成 / tmux plugins を一気に処理します。
+
+### Linux (sudo あり)
+
+```bash
+git clone git@github.com:shonenm/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install.sh
+eval $(op signin)
+```
+
+apt で system パッケージと apt_repo 系 (gh/eza/bat/psql) が入ります。
+
+### Linux (no-sudo / 共有ホスト)
+
+```bash
+git clone git@github.com:shonenm/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+./install.sh --no-sudo
+eval $(op signin)           # 対話ログイン、初回のみ
+```
+
+pixi (user-scope) でパッケージを取得。tmux は source build (gcc/make/libevent-dev/libncurses-dev が host に必要)。
+
+### Docker container
+
+前提: ホスト (Mac か ailab 等の Linux) にすでに dotfiles が入っている。
+
+#### Step 1 (AI 経由で自動化)
+
+```
+/_setup-rcon-target <host>:<container> --apply
+```
+
+これで以下が自動実行される:
+1. `~/.config/rcon/targets` に target 追記
+2. SSH 疎通確認
+3. compose.yml に dotfiles bind mount を追記
+4. `docker compose up -d --force-recreate <service>`
+5. container 内で `~/dotfiles/scripts/install-in-container.sh` 実行
+
+#### Step 1 (手動)
+
+```bash
+# ① compose.yml の対象 service の volumes に追記
+#    - $HOME/dotfiles:/home/${USERNAME:-devuser}/dotfiles:ro
+
+# ② recreate
+cd <project-dir> && docker compose up -d --force-recreate <service>
+
+# ③ container 内で install を 1 発
+docker exec <container> ~/dotfiles/scripts/install-in-container.sh
+
+# ④ shell 再起動で反映
+docker exec -it <container> zsh
+# container 内で: exec zsh
+```
+
+## 日々の同期
+
+1 箇所だけ編集して全環境に撒きたい:
+
+```bash
+dotsync   # Mac で: git push + ssh ailab git pull
+```
+
+- Mac → ailab: dotsync で自動
+- ailab → container: bind mount なので **何もしなくて良い** (ファイルはその場で新しくなる)
+- tmux config 変更: ailab 側の post-merge hook が pull 後に `tmux source-file` 自動 broadcast
+
+`install.sh` を再実行する必要があるのは **新しい system パッケージを追加した時だけ** (config 編集のみなら不要)。
+
+## 新ツール追加時の checklist
+
+dotfiles に新ツールを足す時、書く場所は install 経路で変わる:
+
+| ツールの性質 | 追加先 | 例 |
+|------------|-------|----|
+| Mac 専用 (brew) | `config/Brewfile` | macmon, aerospace, ghostty |
+| apt で入る標準パッケージ | `config/packages.linux.apt.txt` + `config/pixi-packages.txt` (**両方必須**) | jq, stow, zsh, ripgrep |
+| apt_repo 経由 (gh, eza, bat, psql) | `config/tools.linux.bash` の TOOL_* 宣言 + `config/pixi-packages.txt` | gh, eza, bat |
+| curl-pipe インストーラ | `config/tools.linux.bash` (curl_pipe 方式) | starship, bun, mise, atuin |
+| GitHub Releases のプリビルトバイナリ | `config/tools.linux.bash` (github_release / github_release_binary 方式) | fzf, delta, lazygit, sd, dust |
+| mise 管理 (言語ランタイム等) | `common/mise/.config/mise/config.toml` | node, go, uv, python |
+| npm | `config/packages.npm.txt` | — |
+
+**apt/pixi 二重管理を忘れないための CI チェック**: `scripts/check-package-duplication.sh` が `packages.linux.apt.txt` と `pixi-packages.txt` のミラー状態を検証。同期が崩れると CI が失敗する。追加時に片方忘れた場合は CI に教えてもらえる。
+
+## 各環境の把握している制約
+
+### Mac
+- 完成度が最も高い。特殊事情なし。
+
+### Linux sudo
+- `build-essential` 等は apt で入る。cargo-install 系 tool もビルド可能。
+- apt_repo 系 (gh/eza/bat/psql) のキー登録で多少の手数あり (install.sh で自動化済)。
+
+### Linux no-sudo
+- **1P signin が対話必須** (初回のみ)。自動化したいなら `~/.op-session-token` や launchd での signin 維持を検討。
+- **tmux source build は host に build-essential + libevent-dev + libncurses-dev が要る**。管理者に依頼できないなら system tmux 3.2a を使う (allow-passthrough 等未対応のため体験低下)。
+- CONDA_PREFIX リーク: pixi の一部 tool で Python env を conda 認識して挙動変化する可能性。
+
+### Docker container
+- **sudo (NOPASSWD) 前提**。install-in-container.sh は apt で build-essential を入れる。
+- **1P は container 内に signin しない**方針 (`--skip-1p`)。secret が必要な操作は host 側で行う。
+- **force-recreate で container layer の install 状態が消える**。install-in-container.sh を 1 発叩き直せば数分で復旧。
+- **bind mount を compose に書くまで host 側 dotfiles と接続されない**。`/_setup-rcon-target --apply` で自動化。
+
+## 将来検討
+
+### 統一 registry (未実装)
+
+現状、新ツール追加時は用途別に 3 箇所書く必要がある (apt + pixi + Brewfile)。`config/tools.toml` のような単一宣言ファイルに統合し、install.sh が環境 → 取得経路を自動選択する設計が検討候補。ただし:
+- 全面書き換えに数百行必要
+- 現時点の重複は 4 tool (gh/eza/bat/psql) のみで、validator で早期検出できるため緊急性は低い
+- 実装時は既存の `check_cmd` gate を維持し、既存インストールに影響しないこと
+
+### cargo 依存の完全撤廃
+
+cargo 方式 (gcc 必須) の残り tool: `procs` / `tokei` / `quay-tui` / `gitabsorb` / `cargoupdate` / `keifu`。主要な 6 つ (tealdeer/sd/dust/bottom/rip2/lsd) は prebuilt 移行済 (PR #XX)。残りもほとんどプリビルト入手可能なので段階移行予定。
+
+## 関連 docs
+
+- [install.md](./install.md) — Mac install 詳細
+- [install-no-sudo.md](./install-no-sudo.md) — no-sudo mode 詳細
+- [rcon-setup.md](./rcon-setup.md) — rcon / リモート接続
+- [dotfiles-sync.md](./dotfiles-sync.md) — 3 層同期 architecture

--- a/scripts/check-package-duplication.sh
+++ b/scripts/check-package-duplication.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# check-package-duplication.sh — ensure sudo (apt) and no-sudo (pixi) paths
+# stay in sync for packages that live in both install modes.
+#
+# Rationale:
+#   A handful of tools are installed via apt (sudo) AND via pixi (no-sudo).
+#   If someone adds a new one to packages.linux.apt.txt but forgets
+#   pixi-packages.txt (or vice versa), one environment will silently miss it.
+#
+# This check enforces: any package that appears in the apt list AND is known
+# to need user-scope equivalence must also appear in pixi-packages.txt.
+#
+# The "must mirror" set below is curated: it is the intersection of packages
+# we install via apt that are also available on conda-forge (where pixi pulls
+# from). If the apt list stays inside this set, the check is useful; if we
+# adopt truly sudo-only packages (e.g., kernel tools), add them to the
+# APT_SUDO_ONLY set at the bottom to mark them as intentionally-missing.
+#
+# Exit status: 0 if in sync, 1 otherwise.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+APT_FILE="$REPO_ROOT/config/packages.linux.apt.txt"
+PIXI_FILE="$REPO_ROOT/config/pixi-packages.txt"
+
+if [[ ! -f "$APT_FILE" ]] || [[ ! -f "$PIXI_FILE" ]]; then
+  echo "error: expected $APT_FILE and $PIXI_FILE to exist" >&2
+  exit 2
+fi
+
+# Normalize: strip comments + blanks, sort unique.
+apt_pkgs=$(grep -vE '^\s*#|^\s*$' "$APT_FILE" | sort -u)
+pixi_pkgs=$(grep -vE '^\s*#|^\s*$' "$PIXI_FILE" | sort -u)
+
+# Packages we *knowingly* install via apt that MUST also be in pixi for
+# no-sudo parity. Keep this list curated.
+declare -a MUST_MIRROR=(
+  zsh
+  stow
+  jq
+  unzip
+  rsync
+  ripgrep
+  fd-find
+  imagemagick
+)
+
+# Packages intentionally sudo-only (no pixi equivalent expected).
+declare -a APT_SUDO_ONLY=(
+  build-essential
+  pkg-config
+  libssl-dev
+  luarocks
+  tmux  # tmux comes from install_tmux_source in no-sudo mode, not pixi
+)
+
+missing=()
+for pkg in "${MUST_MIRROR[@]}"; do
+  if ! printf '%s\n' "$apt_pkgs" | grep -qxF "$pkg"; then
+    echo "warn: '$pkg' listed as MUST_MIRROR but missing from $APT_FILE"
+    continue
+  fi
+  if ! printf '%s\n' "$pixi_pkgs" | grep -qxF "$pkg"; then
+    missing+=("$pkg")
+  fi
+done
+
+# Also detect packages added to apt that aren't in MUST_MIRROR or APT_SUDO_ONLY
+# — these probably need a decision.
+declare -A known=()
+for p in "${MUST_MIRROR[@]}" "${APT_SUDO_ONLY[@]}"; do known[$p]=1; done
+
+unclassified=()
+while IFS= read -r pkg; do
+  [[ -z "$pkg" ]] && continue
+  if [[ -z "${known[$pkg]:-}" ]]; then
+    unclassified+=("$pkg")
+  fi
+done <<< "$apt_pkgs"
+
+fail=0
+if (( ${#missing[@]} > 0 )); then
+  echo "ERROR: packages in $APT_FILE missing from $PIXI_FILE:"
+  printf '  - %s\n' "${missing[@]}"
+  fail=1
+fi
+
+if (( ${#unclassified[@]} > 0 )); then
+  echo "WARN: packages in $APT_FILE not classified as MUST_MIRROR or APT_SUDO_ONLY:"
+  printf '  - %s\n' "${unclassified[@]}"
+  echo "  (update MUST_MIRROR or APT_SUDO_ONLY in $(basename "$0"))"
+  # Don't fail on unclassified — treat as warning so brand-new tools don't
+  # block CI before the classification is updated.
+fi
+
+if (( fail == 0 )); then
+  echo "OK: apt/pixi package lists are in sync."
+fi
+exit $fail

--- a/scripts/install-in-container.sh
+++ b/scripts/install-in-container.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# install-in-container.sh — one-command dotfiles bootstrap for a docker container
+#
+# Assumes:
+#   - This script lives at $DOTFILES_DIR/scripts/ and the dotfiles repo is
+#     bind-mounted into the container at $HOME/dotfiles.
+#   - The container has sudo NOPASSWD (per the project Dockerfile pattern).
+#   - install.sh supports --no-sudo --skip-prompt --skip-1p.
+#
+# What it does:
+#   1. Install build tools via apt (gcc / make / pkg-config / libssl-dev /
+#      luarocks — required for tmux source build and some nvim plugins).
+#   2. Run install.sh in no-sudo, non-interactive, no-1P mode.
+#   3. Verify key symlinks + tools are in place.
+#
+# Usage:
+#   From the host:
+#     docker exec -it <container> ~/dotfiles/scripts/install-in-container.sh
+#
+#   From inside the container:
+#     ~/dotfiles/scripts/install-in-container.sh
+
+set -euo pipefail
+
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
+APT_PACKAGES=(
+  build-essential
+  pkg-config
+  libssl-dev
+  luarocks
+)
+
+if [[ ! -f "$DOTFILES_DIR/install.sh" ]]; then
+  echo "error: dotfiles not found at $DOTFILES_DIR" >&2
+  echo "       Expected bind-mount from host. Check compose.yml volumes." >&2
+  exit 1
+fi
+
+if [[ ! -f /.dockerenv ]] && [[ -z "${container:-}" ]]; then
+  echo "warn: /.dockerenv missing; this script expects to run inside a container." >&2
+  echo "      Proceeding anyway, but behavior is not guaranteed." >&2
+fi
+
+log()   { printf '[install-in-container] %s\n' "$*"; }
+warn()  { printf '[install-in-container] WARN: %s\n' "$*" >&2; }
+fail()  { printf '[install-in-container] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ── Step 1: apt build tools ────────────────────────────────────────────────
+if command -v apt-get >/dev/null 2>&1; then
+  if ! sudo -n true 2>/dev/null; then
+    warn "sudo requires a password; skipping apt build tool install."
+    warn "  Expect cargo/luarocks-based tools and nvim native plugins to fail."
+  else
+    log "installing build tools via apt (${APT_PACKAGES[*]})..."
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq "${APT_PACKAGES[@]}"
+    log "build tools ready."
+  fi
+else
+  warn "apt-get not available; assuming build tools are present in the image."
+fi
+
+# ── Step 2: install.sh ────────────────────────────────────────────────────
+log "running dotfiles install.sh (--no-sudo --skip-prompt --skip-1p)..."
+"$DOTFILES_DIR/install.sh" --no-sudo --skip-prompt --skip-1p
+log "install.sh completed."
+
+# ── Step 3: verify ────────────────────────────────────────────────────────
+log "verifying symlinks and key tools..."
+fail_count=0
+
+check_symlink() {
+  local path="$1"
+  if [[ -L "$path" ]] && [[ -e "$path" ]]; then
+    log "  OK  symlink: $path"
+  else
+    warn "  MISS symlink: $path"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+check_tool() {
+  local tool="$1"
+  if "$DOTFILES_DIR/install.sh" --help 2>/dev/null; then :; fi  # ensure PATH
+  # shellcheck disable=SC2016
+  local path
+  path=$(zsh -i -c "command -v $tool" 2>/dev/null | tail -1)
+  if [[ -n "$path" ]]; then
+    log "  OK  tool: $tool ($path)"
+  else
+    warn "  MISS tool: $tool"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+check_symlink "$HOME/.zshrc"
+check_symlink "$HOME/.config/tmux/tmux.conf"
+check_symlink "$HOME/.config/starship.toml"
+
+for t in zsh starship mise sheldon eza bat fd rg fzf gh; do
+  check_tool "$t"
+done
+
+if [[ $fail_count -gt 0 ]]; then
+  warn "verify: $fail_count check(s) failed. Open a new zsh (exec zsh) and re-check."
+  # Don't exit 1 — partial success is common on first install (some tools appear after exec zsh).
+fi
+
+log "done. Open a new shell or run: exec zsh"


### PR DESCRIPTION
## Summary

新環境セットアップの AI 化に向けた統合 PR。

- `scripts/install-in-container.sh`: container 復旧を 1 コマンドに
- `scripts/check-package-duplication.sh`: apt/pixi 同期ずれを検出する script
- `docs/setup-new-environment.md`: 全環境レシピ集約 + 新ツール追加 checklist
- `config/tools.linux.bash`: cargo 方式 6 tool を prebuilt 取得に移行 (tealdeer/sd/dust/bottom/rip2/lsd)
- `_setup-rcon-target` skill: `--apply` mode 追加 (compose 編集 + recreate + install 自動)

## 影響範囲

- 既存環境: 影響なし (`check_cmd` gate で skip)
- 新環境: prebuilt 経由で gcc 依存消失 + 高速化
- container 復旧: `install-in-container.sh` 1 発で force-recreate 後も数分で戻る

## Follow-up (本 PR 範囲外)

- `.github/workflows/ci.yml` に check-package-duplication.sh を CI step 追加する変更はローカルに残っています (OAuth workflow scope 不足で別途 push 必要)。マージ後にユーザー側で手動で push してください。

## Test plan

- [x] shellcheck pass (new scripts)
- [x] check-package-duplication.sh OK locally
- [x] 移行した 6 tool の release asset 名を GitHub API で verify 済
- [ ] 実機で新 env セットアップ (skill --apply) は merge 後に検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)