### PR TITLE
feat(install): auto-enable Claude Code remote control via install.sh

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -693,6 +693,7 @@ install_tmux_source
 install_modern_tools
 install_npm_packages
 install_claude_mem
+configure_claude_remote_control_autostart
 link_ai_scripts
 install_gh_extensions
 install_ghostty_terminfo

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -169,6 +169,7 @@ install_brew_bundle
 install_mise_tools
 install_npm_packages
 install_claude_mem
+configure_claude_remote_control_autostart
 install_dops
 install_quay
 install_cargo_update

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -54,3 +54,35 @@ read_package_list() {
   fi
   grep -v '^\s*#' "$file" | grep -v '^\s*$'
 }
+
+# Enable Claude Code Remote Control auto-start by patching ~/.claude.json.
+# ~/.claude.json is a runtime file (not dotfile-managed), so this is applied at
+# install time to make mobile control work on every fresh environment.
+configure_claude_remote_control_autostart() {
+  local claude_json="$HOME/.claude.json"
+
+  if ! command_exists jq; then
+    log_warn "jq not found; skipping Claude remote control auto-start"
+    return
+  fi
+
+  if [[ ! -f "$claude_json" ]]; then
+    log_info "$claude_json not present yet; run 'claude' once, then rerun install"
+    return
+  fi
+
+  local current
+  current="$(jq -r '.remoteControlAtStartup // false' "$claude_json" 2>/dev/null)"
+  if [[ "$current" == "true" ]]; then
+    log_success "Claude remote control auto-start already enabled"
+    return
+  fi
+
+  local tmp="${claude_json}.tmp.$$"
+  if jq '.remoteControlAtStartup = true' "$claude_json" > "$tmp" && mv "$tmp" "$claude_json"; then
+    log_success "Claude remote control auto-start enabled"
+  else
+    rm -f "$tmp"
+    log_warn "Failed to patch $claude_json"
+  fi
+}


### PR DESCRIPTION
## Summary

Enable Claude Code Remote Control auto-startup during dotfiles installation, making mobile control work on every fresh environment (new Mac, Linux container) without manual setup.

## Changes

- **scripts/utils.sh**: Added `configure_claude_remote_control_autostart()` function
  - Idempotently patches `~/.claude.json` with `remoteControlAtStartup = true`
  - Handles edge cases: missing jq, file not yet created, already enabled
  - Logs appropriately for each scenario

- **scripts/mac.sh**: Call RC auto-start after `install_claude_mem`
- **scripts/linux.sh**: Call RC auto-start after `install_claude_mem`

## Why

Previously, Remote Control required manual `jq` invocation on every new environment, violating the CLAUDE.md portability requirement: "変更は install.sh でリモート Linux 環境に再現可能であること". This fix makes it fully automatic.

## Test plan

- [x] Function is idempotent: already-enabled case returns success without changes
- [x] Patch path works: can patch false to true
- [x] No-file case: gracefully skips if ~/.claude.json doesn't exist yet
- [x] No-jq case: gracefully skips if jq is not installed
- [x] shellcheck: passes with no warnings

Closes #76