### PR TITLE
Add tmux-swap-picker: visual pane-content swap via fzf popup

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -99,6 +99,15 @@ bind X confirm-before -p "kill-window #W? (y/n)" kill-window
 # Pane swap (by display number shown with prefix+q)
 bind W command-prompt -p "Swap pane:","with pane:" "swap-pane -s '%%.%1' -t '%%.%2'"
 
+# Visual pane swap: pick two panes via fzf popup; slot sizes preserved,
+# only contents swap. Uses fzf rather than display-panes so small panes
+# (below tmux's big-digit render threshold) remain selectable.
+# Overrides default prefix+m (select-pane -m).
+bind m display-popup -E -w 80% -h 40% "~/dotfiles/scripts/tmux-swap-picker"
+# Mark / unmark current pane (toggle). Replaces default mark role freed by
+# prefix+m above; keeps `{marked}` referenceable for cross-window swap-pane etc.
+bind M select-pane -m
+
 # Pane title
 bind t command-prompt -p "Pane title:" "select-pane -T '%%'"
 

--- a/scripts/tmux-swap-picker
+++ b/scripts/tmux-swap-picker
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# tmux-swap-picker — pick two panes via fzf popup and swap their contents.
+# Slot sizes are preserved (tmux swap-pane exchanges pane contents at the same
+# positions in the layout tree); only pane contents swap.
+#
+# Wired via tmux bind:
+#   bind m display-popup -E "~/dotfiles/scripts/tmux-swap-picker"
+#
+# fzf is used instead of `display-panes` because small panes (below tmux's
+# big-digit render threshold) don't show their pane number on screen, making
+# them unselectable in dense layouts.
+set -eu
+
+list_panes() {
+  tmux list-panes -F \
+    "#{pane_id}	#{window_index}.#{pane_index}	#{pane_width}x#{pane_height}	#{?pane_title,#{pane_title},-}	#{pane_current_command}"
+}
+
+pick() {
+  local prompt="$1"
+  local exclude="${2:-}"
+  local list
+  list="$(list_panes)"
+  if [ -n "$exclude" ]; then
+    list="$(printf '%s\n' "$list" | awk -F '\t' -v ex="$exclude" '$1 != ex')"
+  fi
+  printf '%s\n' "$list" |
+    fzf \
+      --prompt="$prompt" \
+      --delimiter=$'\t' \
+      --with-nth=2,3,4,5 \
+      --header="Enter=select  Esc=cancel" |
+    cut -f1
+}
+
+if ! command -v fzf >/dev/null 2>&1; then
+  echo "fzf is required" >&2
+  read -rp "Press Enter to close..." _
+  exit 1
+fi
+
+first="$(pick 'swap src > ')"
+if [ -z "$first" ]; then
+  exit 0
+fi
+
+second="$(pick 'swap dst > ' "$first")"
+if [ -z "$second" ]; then
+  exit 0
+fi
+
+tmux swap-pane -s "$first" -t "$second"
+tmux display-message "tmux-swap-picker: swapped"


### PR DESCRIPTION
## Summary

Adds `tmux-swap-picker`, a two-pane content swap tool that works regardless of
layout density. `prefix+m` opens an fzf popup, pick source → pick destination →
contents swap. Slot sizes in the layout tree remain identical; only pane
contents exchange positions.

## Changes

- **scripts/tmux-swap-picker**: bash script; lists all panes via `tmux list-panes`,
  uses fzf twice (source/destination) inside a single `display-popup -E`, then
  calls `tmux swap-pane -s <src> -t <dst>`.
- **tmux.conf**: `bind m` → swap picker popup; `bind M` → `select-pane -m` so the
  mark/unmark role freed by `m` remains reachable for cross-window
  `swap-pane`/`swap-window` workflows that use `{marked}`.

## Why fzf instead of `display-panes`?

tmux's `display-panes` draws a big-digit overlay in each pane but silently skips
panes smaller than the minimum render size (roughly 6x5 cells). In dense layouts
(e.g. 4 panes across half a window) this makes some panes unselectable because
no number appears. fzf lists every pane regardless of size, with pane title +
current command for context.

## Test plan

- [ ] Open a 7-pane layout, `prefix+m`, verify all panes appear in the fzf list
- [ ] Pick two panes, verify contents swap and slot sizes stay identical
- [ ] Esc mid-picker cancels cleanly with no side effects
- [ ] `prefix+M` toggles mark on current pane; `pane-border-style` reflects it

Closes #78