### PR TITLE
feat: unified env-context resolver + migrate fragile tools to @rcon-* options

### DIFF
--- a/common/claude/.claude/skills/_crew-setup/SKILL.md
+++ b/common/claude/.claude/skills/_crew-setup/SKILL.md
@@ -30,7 +30,7 @@ when_to_use: "Use when the user wants to set up ralph-crew autonomous dispatch o
 
 ## 手順
 
-### 1. プロジェクトパスの解決
+### 1. プロジェクトパスの解決 + 環境コンテキスト
 
 引数があれば絶対パスに正規化、無ければ `pwd -P` をデフォルトに。
 存在しないディレクトリなら即終了し作成を促す。
@@ -39,7 +39,31 @@ when_to_use: "Use when the user wants to set up ralph-crew autonomous dispatch o
 PROJECT="$(cd "${1:-$PWD}" 2>/dev/null && pwd -P)" \
   || { echo "directory not found"; exit 1; }
 PROJECT_NAME="$(basename "$PROJECT")"
+eval "$(${DOTFILES_DIR:-$HOME/dotfiles}/scripts/env-context)"
 ```
+
+`env-context` 出力の `$ENV_TYPE` と `$TMUX_LOCATION` / `$TMUX_ACCESS_CMD` でその後の分岐を決める。
+
+### 1.5. container 内で呼ばれた場合は host にリダイレクト
+
+`$ENV_TYPE == "linux-container"` (= `/.dockerenv` あり) の場合、`ralph-crew init` を **container-local tmux** に着地させてはいけない (opensessions が観察できず、container 再起動で消える)。以下の案内だけ出してスキルは終了する:
+
+```
+このプロジェクトは container 内にあります (container=$CONTAINER_NAME).
+ralph-crew は $HOST_MACHINE の host tmux で起動する必要があります。
+
+次のコマンドを host で実行してください:
+  ssh $HOST_MACHINE '
+    cd <project path on host> &&
+    ~/dotfiles/scripts/ralph-crew init --config <path>/.claude/crew.json &&
+    tmux new-window -d -t crew-$PROJECT_NAME -n scheduler \
+      "exec ralph-crew daemon --interval <sec> --config <path>/.claude/crew.json"
+  '
+```
+
+crew.json 自体は container 内 (bind mount 経由で host からも見える) に置いて構わない。起動だけが host で行われれば OK。
+
+**このステップで止まれば以降の step 2-8 はスキップ**。
 
 ### 2. 前提チェック (並列実行)
 

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -381,23 +381,26 @@ rcon() {
     # We deliberately avoid pixi's conda-forge tmux 3.6 because it crashes
     # on attach under xterm-ghostty ("server exited unexpectedly"), and the
     # Ubuntu 22.04 system tmux 3.2a lacks allow-passthrough / 3.3+ options.
+    # Propagate rcon provenance so downstream tools (env-context inside
+    # container, tmux-pane-context on host, opensessions, etc.) never have
+    # to guess:
+    #   - RCON_* env vars travel with ssh → docker exec into the container.
+    #   - tmux user options @rcon-* attach to the session for host-side
+    #     tools that don't inherit env (popup wrappers, pane-context).
     ssh -t "$host" "
       set -e
       export PATH=\"\$HOME/.local/bin:\$PATH\"
       export TERMINFO_DIRS=\"\$HOME/.terminfo:/usr/share/terminfo:/lib/terminfo\"
       export CLAUDE_CONTEXT='$context'
+      export RCON_HOST_MACHINE='$host'
+      export RCON_CONTAINER='$container'
+      export RCON_HOST_HOME=\"\$HOME\"
       cmd=\"\$HOME/dotfiles/scripts/tmux-docker-enter '$container'\"
-      # Set session dir to container's WorkingDir so opensessions watchers
-      # (Claude/Codex/Amp) can match JSONL project dirs (which are encoded
-      # from container-side cwd). tmux accepts non-existent -c paths.
       container_wd=\$(docker inspect '$container' --format '{{.Config.WorkingDir}}' 2>/dev/null)
       [ -z \"\$container_wd\" ] && container_wd=\"/\"
-      # Drift guard: tmux new-session -A attaches to an existing session without
-      # updating session_path. If a prior invocation (older dotfiles version or
-      # manual creation) left session_path pointing somewhere other than the
-      # container cwd, opensessions' resolveSession silently stops matching the
-      # container's claude JSONL dir. Kill+recreate in that case so the state
-      # is always correct regardless of how the session was first born.
+      # Drift guard: kill+recreate if session_path mismatches container cwd.
+      # tmux new-session -A attaches without updating session_path, so
+      # opensessions' resolveSession silently stops matching. See env-context.
       existing_path=\$(tmux list-sessions -F '#{session_path}' -f \"#{==:#{session_name},$sess}\" 2>/dev/null | head -1 || true)
       if [ -n \"\$existing_path\" ] && [ \"\$existing_path\" != \"\$container_wd\" ]; then
         echo \"rcon: recreating session '$sess' (session_path was '\$existing_path', should be '\$container_wd')\" >&2
@@ -405,6 +408,9 @@ rcon() {
       fi
       tmux new-session -A -d -s '$sess' -c \"\$container_wd\" \"\$cmd\" 2>/dev/null || true
       tmux set-option -t '$sess' default-command \"\$cmd\"
+      tmux set-option -t '$sess' '@rcon-host' '$host'
+      tmux set-option -t '$sess' '@rcon-container' '$container'
+      tmux set-option -t '$sess' '@rcon-container-home' \"\$container_wd\"
       exec tmux attach-session -t '$sess'
     "
   else

--- a/scripts/env-context
+++ b/scripts/env-context
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# env-context — authoritative "where am I?" resolver for dotfiles tooling.
+#
+# Emits shell-eval'able variables so any tool can:
+#   eval "$(env-context)"
+# and get a consistent, source-of-truth answer to questions like:
+#   - What kind of environment is this? (mac / linux-host / linux-container)
+#   - Which machine hosts the "canonical" tmux server?
+#   - How do I invoke that tmux from here?
+#   - Where is the container's $HOME vs. the host's $HOME?
+#   - Where does ~/.claude/projects live from my perspective?
+#
+# Design principle: each tool should NOT reinvent environment detection.
+# This script is the single place that makes those judgments; tools
+# consume its output and stay narrow.
+#
+# Information flow for rcon-managed docker containers:
+#   rcon (Mac) → ssh remote → docker exec (-e RCON_*)
+# The RCON_* env vars propagate the origin context into the container so
+# env-context inside the container can reconstruct "I am syntopic-dev
+# on ailab, the tmux I should target is ailab's host tmux". Without those
+# vars (e.g. someone ran `docker exec` manually), env-context reports
+# `unknown` for the missing dimensions — tools should fail loudly rather
+# than silently guess.
+#
+# Output format: one KEY=VALUE per line, shell-quoted. Always safe to
+# `eval "$(env-context)"`. All keys are always present; empty string
+# means "not applicable / unknown".
+
+set -euo pipefail
+
+# --- detection ---
+
+os_name="$(uname -s)"
+
+env_type=""
+host_machine=""
+container_name=""
+container_home=""
+host_home=""
+project_root=""
+claude_projects_dir=""
+tmux_location=""
+tmux_access_cmd=""
+dotfiles_dir="${DOTFILES_DIR:-$HOME/dotfiles}"
+
+# --- case: docker container (Linux with /.dockerenv marker file) ---
+if [[ -f /.dockerenv ]] || [[ -n "${DEVCONTAINER_NAME:-}" ]]; then
+  env_type="linux-container"
+  container_home="$HOME"
+  container_name="${RCON_CONTAINER:-${DEVCONTAINER_NAME:-$(cat /etc/hostname 2>/dev/null || true)}}"
+  host_machine="${RCON_HOST_MACHINE:-unknown}"
+  host_home="${RCON_HOST_HOME:-unknown}"
+  claude_projects_dir="$HOME/.claude/projects"
+
+  if [[ "$host_machine" == "unknown" ]]; then
+    tmux_location="unknown"
+    tmux_access_cmd="unknown"
+  elif [[ "$host_machine" == "local" ]]; then
+    # Shouldn't normally happen (container has no "local" parent tmux) but
+    # handle for completeness.
+    tmux_location="local"
+    tmux_access_cmd="tmux"
+  else
+    tmux_location="$host_machine"
+    tmux_access_cmd="ssh $host_machine ${RCON_TMUX_BIN:-tmux}"
+  fi
+
+# --- case: macOS (always local) ---
+elif [[ "$os_name" == "Darwin" ]]; then
+  env_type="mac"
+  host_machine="local"
+  host_home="$HOME"
+  tmux_location="local"
+  tmux_access_cmd="tmux"
+  claude_projects_dir="$HOME/.claude/projects"
+
+# --- case: Linux host (e.g. ailab, run directly) ---
+else
+  env_type="linux-host"
+  host_machine="$(hostname -s 2>/dev/null || hostname || echo "unknown")"
+  host_home="$HOME"
+  # On the linux host, the canonical tmux is this very machine's tmux.
+  tmux_location="local"
+  tmux_access_cmd="tmux"
+  claude_projects_dir="$HOME/.claude/projects"
+fi
+
+# Project root: git toplevel if in a repo, else cwd.
+if project_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  project_root="$PWD"
+fi
+
+# --- emit ---
+printf 'ENV_TYPE=%q\n'                 "$env_type"
+printf 'HOST_MACHINE=%q\n'             "$host_machine"
+printf 'CONTAINER_NAME=%q\n'           "$container_name"
+printf 'CONTAINER_HOME=%q\n'           "$container_home"
+printf 'HOST_HOME=%q\n'                "$host_home"
+printf 'PROJECT_ROOT=%q\n'             "$project_root"
+printf 'CLAUDE_PROJECTS_DIR=%q\n'      "$claude_projects_dir"
+printf 'TMUX_LOCATION=%q\n'            "$tmux_location"
+printf 'TMUX_ACCESS_CMD=%q\n'          "$tmux_access_cmd"
+printf 'DOTFILES_DIR=%q\n'             "$dotfiles_dir"

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -502,7 +502,33 @@ _run_init() {
   _log "init completed: $worker_count workers"
 }
 
+_ensure_host_tmux_or_die() {
+  # ralph-crew creates long-lived tmux sessions that opensessions observes
+  # and that survive across reboots. These MUST live on the canonical host
+  # tmux (typically ailab) — NOT on a container-local tmux server, which
+  # would be invisible to opensessions and die with the container.
+  #
+  # If we detect we're inside a container, refuse with an actionable error
+  # unless the user explicitly opts in via RCON_ALLOW_CONTAINER_TMUX=1.
+  [[ -f /.dockerenv ]] || return 0
+  [[ "${RCON_ALLOW_CONTAINER_TMUX:-0}" == "1" ]] && return 0
+
+  local host="${RCON_HOST_MACHINE:-<host>}"
+  _error "ralph-crew must be invoked from the canonical host tmux, not inside a container."
+  cat >&2 <<EOF
+
+  Run this on ${host} instead:
+    ssh ${host} 'env RCON_CONTAINER=<container> ralph-crew $_orig_subcmd <args>'
+
+  Or override (not recommended — session will be invisible to opensessions):
+    RCON_ALLOW_CONTAINER_TMUX=1 ralph-crew $_orig_subcmd <args>
+EOF
+  return 2
+}
+
 cmd_init() {
+  local _orig_subcmd="init"
+  _ensure_host_tmux_or_die || return $?
   local config_file="$DEFAULT_CONFIG"
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -819,6 +845,8 @@ cmd_teardown() {
 # previous launchd/cron integration so ralph-crew runs portably without any
 # OS-level scheduler dependency.
 cmd_daemon() {
+  local _orig_subcmd="daemon"
+  _ensure_host_tmux_or_die || return $?
   local config_file="$DEFAULT_CONFIG"
   local interval_seconds=60
   while [[ $# -gt 0 ]]; do

--- a/scripts/tmux-docker-enter
+++ b/scripts/tmux-docker-enter
@@ -32,6 +32,13 @@ args=(exec -it)
 [[ -n "${CLAUDE_CONTEXT:-}" ]] && args+=(-e "CLAUDE_CONTEXT=$CLAUDE_CONTEXT")
 # Pass TMUX_PANE so container-side zshrc chpwd hook can write per-pane cwd state
 [[ -n "${TMUX_PANE:-}" ]]      && args+=(-e "TMUX_PANE=$TMUX_PANE")
+# Propagate rcon provenance so env-context inside the container can reconstruct
+# where it came from (host machine, container name, host $HOME). Without these
+# the container-side env-context returns "unknown" and tools fail loudly
+# rather than silently misroute.
+args+=(-e "RCON_HOST_MACHINE=${RCON_HOST_MACHINE:-$(hostname -s 2>/dev/null || hostname || echo unknown)}")
+args+=(-e "RCON_CONTAINER=$container")
+[[ -n "${RCON_HOST_HOME:-}" ]] && args+=(-e "RCON_HOST_HOME=$RCON_HOST_HOME")
 
 if [[ -n "$cwd" ]] && docker exec "$container" test -d "$cwd" 2>/dev/null; then
   args+=(-w "$cwd")

--- a/scripts/tmux-pane-context
+++ b/scripts/tmux-pane-context
@@ -38,10 +38,18 @@ container=""
 cwd=""
 
 if [[ -n "$session" ]]; then
-  default_cmd=$(tmux show-option -t "$session" -qv default-command 2>/dev/null || true)
-  if [[ "$default_cmd" == *tmux-docker-enter* ]]; then
-    # Extract container name from default-command: "... tmux-docker-enter '<name>' ..."
-    container=$(printf '%s' "$default_cmd" | sed -n "s/.*tmux-docker-enter '\\([^']*\\)'.*/\\1/p")
+  # Primary signal: tmux user option @rcon-container, set by rcon at session
+  # creation. This is the authoritative source — keeps host-side tools out of
+  # the business of parsing default-command strings (brittle to format changes).
+  container=$(tmux show-option -t "$session" -qv '@rcon-container' 2>/dev/null || true)
+
+  # Backcompat: older sessions created before @rcon-container was set still
+  # have the container name embedded in default-command. Fall through to that.
+  if [[ -z "$container" ]]; then
+    default_cmd=$(tmux show-option -t "$session" -qv default-command 2>/dev/null || true)
+    if [[ "$default_cmd" == *tmux-docker-enter* ]]; then
+      container=$(printf '%s' "$default_cmd" | sed -n "s/.*tmux-docker-enter '\\([^']*\\)'.*/\\1/p")
+    fi
   fi
 fi
 
@@ -64,9 +72,14 @@ if [[ -n "$container" ]] && docker exec "$container" true 2>/dev/null; then
     cwd="$pane_cwd"
   fi
 
-  # Priority 3: container's configured WorkingDir
+  # Priority 3: @rcon-container-home tmux option (captured at rcon time from
+  # docker inspect WorkingDir). Falls through to fresh docker inspect if the
+  # option isn't set (e.g. older sessions pre env-context migration).
   if [[ -z "$cwd" ]]; then
-    wd=$(docker inspect "$container" --format '{{.Config.WorkingDir}}' 2>/dev/null || true)
+    wd=$(tmux show-option -t "$session" -qv '@rcon-container-home' 2>/dev/null || true)
+    if [[ -z "$wd" ]]; then
+      wd=$(docker inspect "$container" --format '{{.Config.WorkingDir}}' 2>/dev/null || true)
+    fi
     if [[ -n "$wd" ]] && docker exec "$container" test -d "$wd" 2>/dev/null; then
       cwd="$wd"
     fi


### PR DESCRIPTION
## Summary

Introduce `scripts/env-context` as the single source of truth for
"where am I running?" and migrate tools to consume it + tmux
`@rcon-*` user options set by rcon at session creation.

Closes #80

## Change list

- `scripts/env-context` (new) — env detection + origin reconstruction
- `common/zsh/.zshrc.common` — rcon exports RCON_* + sets @rcon-* tmux options
- `scripts/tmux-docker-enter` — propagate RCON_* via docker exec -e
- `scripts/tmux-pane-context` — @rcon-container primary source (default-command fallback kept)
- `scripts/ralph-crew` — guard refuses container tmux with actionable error
- `common/claude/.claude/skills/_crew-setup/SKILL.md` — container redirect step

## Test plan

- [x] shellcheck pass all touched scripts
- [x] env-context output verified in 3 envs (Mac / ailab / container ± RCON_*)
- [x] tmux @rcon-* options observed set on session creation
- [x] tmux-pane-context resolves via @rcon-container
- [x] ralph-crew guard fires from container, passes on host
- [ ] user-level post-merge verification: rcon → sidebar / popup / clipboard / crew

🤖 Generated with [Claude Code](https://claude.com/claude-code)