### PR TITLE
tmux-layout menu: support save cancel and preset delete in popup

### DIFF
--- a/scripts/tmux-layout-menu.sh
+++ b/scripts/tmux-layout-menu.sh
@@ -14,51 +14,68 @@ if ! command -v fzf >/dev/null 2>&1; then
   exit 1
 fi
 
-# Build menu: first line = save action, rest = existing presets
-CURRENT_SIG="$("$TMUX_LAYOUT" _current-sig 2>/dev/null || echo "?")"
 SAVE_TAG="<save current layout as...>"
 
-lines=()
-lines+=("$(printf '+\t%s\t%s' "$SAVE_TAG" "$CURRENT_SIG")")
-while IFS=$'\t' read -r name sig; do
-  if [ "$sig" = "$CURRENT_SIG" ]; then
-    marker="*"
-  else
-    marker=" "
+while true; do
+  CURRENT_SIG="$("$TMUX_LAYOUT" _current-sig 2>/dev/null || echo "?")"
+
+  lines=()
+  lines+=("$(printf '+\t%s\t%s' "$SAVE_TAG" "$CURRENT_SIG")")
+  while IFS=$'\t' read -r name sig; do
+    if [ "$sig" = "$CURRENT_SIG" ]; then
+      marker="*"
+    else
+      marker=" "
+    fi
+    lines+=("$(printf '%s\t%s\t%s' "$marker" "$name" "$sig")")
+  done < <("$TMUX_LAYOUT" list 2>/dev/null)
+
+  selected="$(
+    printf '%s\n' "${lines[@]}" |
+      fzf \
+        --prompt='layout> ' \
+        --header='enter=apply/save   ctrl-d=delete   esc=close   * matches current   + save' \
+        --delimiter=$'\t' \
+        --with-nth=1,2,3 \
+        --expect=ctrl-d
+  )" || exit 0
+
+  [ -z "$selected" ] && exit 0
+
+  key="$(printf '%s\n' "$selected" | sed -n '1p')"
+  row="$(printf '%s\n' "$selected" | sed -n '2p')"
+  [ -z "$row" ] && exit 0
+
+  picked_name="$(printf '%s' "$row" | awk -F '\t' '{print $2}')"
+
+  if [ "$key" = "ctrl-d" ]; then
+    if [ "$picked_name" = "$SAVE_TAG" ]; then
+      continue
+    fi
+    printf 'delete preset %q? [y/N]: ' "$picked_name"
+    read -r answer
+    case "${answer:-}" in
+      y|Y|yes|YES)
+        "$TMUX_LAYOUT" delete "$picked_name" || true
+        ;;
+    esac
+    continue
   fi
-  lines+=("$(printf '%s\t%s\t%s' "$marker" "$name" "$sig")")
-done < <("$TMUX_LAYOUT" list 2>/dev/null)
 
-selected="$(
-  printf '%s\n' "${lines[@]}" |
-    fzf \
-      --prompt='layout> ' \
-      --header='* = matches current topology   + = save current' \
-      --delimiter=$'\t' \
-      --with-nth=1,2,3
-)" || exit 0
-
-[ -z "$selected" ] && exit 0
-
-picked_name="$(printf '%s' "$selected" | awk -F '\t' '{print $2}')"
-
-if [ "$picked_name" = "$SAVE_TAG" ]; then
-  # stdin is the popup PTY — plain `read` works
-  printf 'preset name: '
-  read -r new_name
-  if [ -z "${new_name:-}" ]; then
+  if [ "$picked_name" = "$SAVE_TAG" ]; then
+    printf 'preset name (empty to cancel): '
+    read -r new_name
+    if [ -z "${new_name:-}" ]; then
+      continue
+    fi
+    "$TMUX_LAYOUT" save -f "$new_name"
     exit 0
   fi
-  "$TMUX_LAYOUT" save -f "$new_name"
+
+  if "$TMUX_LAYOUT" apply "$picked_name"; then
+    exit 0
+  fi
   echo
   read -rp "Press Enter to close..." _
-  exit 0
-fi
-
-if "$TMUX_LAYOUT" apply "$picked_name"; then
-  exit 0
-fi
-# Apply failed — let user read the error
-echo
-read -rp "Press Enter to close..." _
-exit 1
+  exit 1
+done


### PR DESCRIPTION
## Summary
Added menu loop and delete keybind to `scripts/tmux-layout-menu.sh` fzf popup.
Users can now cancel save input (empty enter) and delete presets (ctrl-d with confirmation).
Menu redraw-loops after cancel/delete instead of exiting.

## Changes
- Wrap fzf menu in `while true` loop for reusable invocation
- Add `--expect=ctrl-d` to fzf; handle delete action with confirmation prompt
- Support `ctrl-d` to delete selected preset (except `<save>` action)
- Change save prompt from `preset name:` to `preset name (empty to cancel):` with continue on empty
- Update fzf header to show keybinds: `enter=apply/save   ctrl-d=delete   esc=close`
- Recalculate `CURRENT_SIG` on each menu re-render loop

## Test plan
- [ ] Run `tmux-layout menu` popup
- [ ] Select a preset and press `enter` → applies layout
- [ ] Select `<save>` and press `enter` → prompts for name
- [ ] At name prompt, press enter with no text → returns to menu
- [ ] At name prompt, enter name → saves and exits
- [ ] Select preset (not `<save>`) and press `ctrl-d` → confirms delete
- [ ] Confirm delete → menu redraw, preset gone
- [ ] Reject delete → menu redraw, preset unchanged
- [ ] Verify header displays keybind hints

Closes #89