### PR TITLE
Enable genshijin plugin globally via SessionStart hook

### DIFF
--- a/common/claude/.claude/hooks/genshijin-session-start.sh
+++ b/common/claude/.claude/hooks/genshijin-session-start.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# genshijin SessionStart Hook
+# プラグイン同梱 SKILL.md を additionalContext に注入し、
+# 通常レベルの圧縮を全セッションで既定化する。
+# プラグイン未インストール時はサイレントに exit。
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+SKILL_FILE=""
+for candidate in \
+  "$HOME"/.claude/plugins/cache/genshijin/genshijin/*/skills/genshijin/SKILL.md \
+  "$HOME"/.claude/plugins/marketplaces/genshijin/skills/genshijin/SKILL.md
+do
+  [[ -f "$candidate" ]] || continue
+  SKILL_FILE="$candidate"
+  break
+done
+
+[[ -z "$SKILL_FILE" ]] && exit 0
+
+instruction="以降このセッションの全応答に genshijin 通常レベルの圧縮ルールを既定適用する。コード・エラーメッセージ・コミット/PR 本文は圧縮対象外。ユーザーが「原始人やめて」「通常モード」と言うか /genshijin 丁寧|極限 で明示的に切り替えるまで維持。ルール本文:"
+
+printf '%s\n\n%s' "$instruction" "$(cat "$SKILL_FILE")" \
+  | jq -Rs '{additionalContext: .}'

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -463,6 +463,48 @@ install_claude_mem() {
   npx -y claude-mem install
 }
 
+install_genshijin() {
+  if ! command_exists claude; then
+    log_warn "claude CLI not found, skipping genshijin"
+    return
+  fi
+
+  if claude plugin list 2>/dev/null | grep -q "genshijin@genshijin"; then
+    log_success "genshijin plugin already installed"
+  else
+    log_info "Installing genshijin Claude Code plugin..."
+    if ! claude plugin marketplace list 2>/dev/null | grep -q "^  ❯ genshijin$"; then
+      claude plugin marketplace add InterfaceX-co-jp/genshijin
+    fi
+    claude plugin install genshijin@genshijin
+  fi
+
+  if ! command_exists jq; then
+    log_warn "jq not found, skipping genshijin SessionStart hook"
+    return
+  fi
+
+  local settings="$HOME/.claude/settings.json"
+  local hook_cmd="$DOTFILES_DIR/common/claude/.claude/hooks/genshijin-session-start.sh"
+
+  [[ -f "$settings" ]] || echo '{}' > "$settings"
+
+  if jq -r '.hooks.SessionStart // [] | .[]?.hooks[]?.command' "$settings" 2>/dev/null \
+      | grep -qxF "$hook_cmd"; then
+    log_success "genshijin SessionStart hook already registered"
+    return
+  fi
+
+  log_info "Registering genshijin SessionStart hook..."
+  local tmp="${settings}.tmp"
+  jq --arg cmd "$hook_cmd" '
+    .hooks //= {}
+    | .hooks.SessionStart //= []
+    | .hooks.SessionStart += [{hooks: [{type: "command", command: $cmd}]}]
+  ' "$settings" > "$tmp" && mv "$tmp" "$settings"
+  log_success "genshijin SessionStart hook registered"
+}
+
 install_1password_cli() {
   if command_exists op; then
     log_success "1Password CLI already installed"
@@ -693,6 +735,7 @@ install_tmux_source
 install_modern_tools
 install_npm_packages
 install_claude_mem
+install_genshijin
 configure_claude_remote_control_autostart
 link_ai_scripts
 install_gh_extensions

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -57,6 +57,48 @@ install_claude_mem() {
   npx -y claude-mem install
 }
 
+install_genshijin() {
+  if ! command_exists claude; then
+    log_warn "claude CLI not found, skipping genshijin"
+    return
+  fi
+
+  if claude plugin list 2>/dev/null | grep -q "genshijin@genshijin"; then
+    log_success "genshijin plugin already installed"
+  else
+    log_info "Installing genshijin Claude Code plugin..."
+    if ! claude plugin marketplace list 2>/dev/null | grep -q "^  ❯ genshijin$"; then
+      claude plugin marketplace add InterfaceX-co-jp/genshijin
+    fi
+    claude plugin install genshijin@genshijin
+  fi
+
+  if ! command_exists jq; then
+    log_warn "jq not found, skipping genshijin SessionStart hook"
+    return
+  fi
+
+  local settings="$HOME/.claude/settings.json"
+  local hook_cmd="$DOTFILES_DIR/common/claude/.claude/hooks/genshijin-session-start.sh"
+
+  [[ -f "$settings" ]] || echo '{}' > "$settings"
+
+  if jq -r '.hooks.SessionStart // [] | .[]?.hooks[]?.command' "$settings" 2>/dev/null \
+      | grep -qxF "$hook_cmd"; then
+    log_success "genshijin SessionStart hook already registered"
+    return
+  fi
+
+  log_info "Registering genshijin SessionStart hook..."
+  local tmp="${settings}.tmp"
+  jq --arg cmd "$hook_cmd" '
+    .hooks //= {}
+    | .hooks.SessionStart //= []
+    | .hooks.SessionStart += [{hooks: [{type: "command", command: $cmd}]}]
+  ' "$settings" > "$tmp" && mv "$tmp" "$settings"
+  log_success "genshijin SessionStart hook registered"
+}
+
 install_dops() {
   if command_exists dops; then
     log_success "dops already installed"
@@ -169,6 +211,7 @@ install_brew_bundle
 install_mise_tools
 install_npm_packages
 install_claude_mem
+install_genshijin
 configure_claude_remote_control_autostart
 install_dops
 install_quay


### PR DESCRIPTION
## Summary
genshijin プラグインを全セッションで常時有効化。SessionStart フックで SKILL.md を自動注入し、毎回の `/genshijin` 呼び出しを不要化。新環境は `scripts/install.sh` 実行で完全自動化。

## Changes
- **feat(claude)**: SessionStart フック本体 (`genshijin-session-start.sh`)
  - プラグインキャッシュから SKILL.md を glob 解決
  - additionalContext JSON に統合
  - プラグイン/jq 不在時はサイレントスキップ

- **feat(install)**: インストーラー両スクリプト拡張
  - `install_genshijin()` 関数を scripts/mac.sh と scripts/linux.sh に追加
  - プラグイン marketplace 登録 + plugin install 自動化
  - ~/.claude/settings.json への SessionStart フック登録 (jq idempotent patch)
  - 既存 settings.json キー (Stop/Notification/MCP) の破壊回避

## Test plan
- [ ] ローカル: `scripts/install.sh` 実行後、新セッション起動で原始人モード応答が得られる
- [ ] idempotency: `scripts/install.sh` を再実行しても既存設定が重複登録されない
- [ ] fallback: jq/claude CLI 未導入環境での実行が fail しない (warn スキップ)
- [ ] coexistence: 既存 SessionStart フック有無にかかわらず共存する

Closes #91