### PR TITLE
Enable Claude Code auto mode as default across all environments

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -505,6 +505,26 @@ install_genshijin() {
   log_success "genshijin SessionStart hook registered"
 }
 
+install_auto_mode() {
+  if ! command_exists jq; then
+    log_warn "jq not found, skipping auto mode default"
+    return
+  fi
+
+  local settings="$HOME/.claude/settings.json"
+  [[ -f "$settings" ]] || echo '{}' > "$settings"
+
+  if [[ "$(jq -r '.permissions.defaultMode // ""' "$settings" 2>/dev/null)" == "auto" ]]; then
+    log_success "Claude auto mode already set as default"
+    return
+  fi
+
+  log_info "Setting Claude auto mode as default..."
+  local tmp="${settings}.tmp"
+  jq '.permissions //= {} | .permissions.defaultMode = "auto"' "$settings" > "$tmp" && mv "$tmp" "$settings"
+  log_success "Claude auto mode set as default"
+}
+
 install_1password_cli() {
   if command_exists op; then
     log_success "1Password CLI already installed"
@@ -736,6 +756,7 @@ install_modern_tools
 install_npm_packages
 install_claude_mem
 install_genshijin
+install_auto_mode
 configure_claude_remote_control_autostart
 link_ai_scripts
 install_gh_extensions

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -99,6 +99,26 @@ install_genshijin() {
   log_success "genshijin SessionStart hook registered"
 }
 
+install_auto_mode() {
+  if ! command_exists jq; then
+    log_warn "jq not found, skipping auto mode default"
+    return
+  fi
+
+  local settings="$HOME/.claude/settings.json"
+  [[ -f "$settings" ]] || echo '{}' > "$settings"
+
+  if [[ "$(jq -r '.permissions.defaultMode // ""' "$settings" 2>/dev/null)" == "auto" ]]; then
+    log_success "Claude auto mode already set as default"
+    return
+  fi
+
+  log_info "Setting Claude auto mode as default..."
+  local tmp="${settings}.tmp"
+  jq '.permissions //= {} | .permissions.defaultMode = "auto"' "$settings" > "$tmp" && mv "$tmp" "$settings"
+  log_success "Claude auto mode set as default"
+}
+
 install_dops() {
   if command_exists dops; then
     log_success "dops already installed"
@@ -212,6 +232,7 @@ install_mise_tools
 install_npm_packages
 install_claude_mem
 install_genshijin
+install_auto_mode
 configure_claude_remote_control_autostart
 install_dops
 install_quay


### PR DESCRIPTION
## Summary

Adds `install_auto_mode()` function to `scripts/mac.sh` and `scripts/linux.sh` to set `permissions.defaultMode = "auto"` in `~/.claude/settings.json` using jq. Follows the same idempotent pattern as `install_genshijin()`, allowing auto mode to be deployed across all environments (Mac / ailab / containers) on the next `install.sh` run.

Auto mode reduces permission prompts for long-running autonomous work (e.g. ralph-crew workers) while maintaining classifier-based safety—force-push, production deploys, and `curl | bash` remain blocked. Environments with unmet requirements (old Claude CLI, Pro plan, non-Anthropic-API provider) silently fall back to default mode.

## Changes

- `scripts/mac.sh`: added `install_auto_mode()` function (L100-120) + call from main (L235)
- `scripts/linux.sh`: added `install_auto_mode()` function (L508-528) + call from main (L759)
- jq filters `.permissions.defaultMode` for detection; creates missing `.permissions` object automatically
- logs success/warn/info messages consistent with existing install functions

## Test plan

- [x] Mac: `install_auto_mode()` idempotent when already set to "auto"
- [x] Mac: `install_auto_mode()` correctly adds "auto" when unset or file missing
- [x] Preserves existing `.permissions.allow` rules when adding defaultMode
- [x] Bash syntax check on both scripts
- [x] jq-missing fallback tested (logs warn, returns early)

Closes #93