### PR TITLE
Improve tmux session navigation with alpha sort and naming convention (Phase 1)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -128,6 +128,15 @@ set -g repeat-time 1000  # リピート可能時間を1秒に
 bind -r p select-window -t :-
 bind -r n select-window -t :+
 
+# Session navigation
+# choose-tree を名前順 (アルファベット) 固定にして命名規約 (rcon-*, proj-*, pers-*, ops-*)
+# による擬似グルーピングを成立させる。switch-client -p/-n も内部的に名前順で走査するため、
+# choose-tree の表示順と ( / ) の巡回順が一致する。
+bind s choose-tree -Zs -O name
+bind Tab switch-client -l
+bind -r ( switch-client -p
+bind -r ) switch-client -n
+
 # Sync mode toggle (with style change, reads @theme-* at runtime)
 bind S run-shell '\
   off=$(tmux show-option -gqv @theme-border-inactive); \

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -57,6 +57,17 @@ TokyoNight Night テーマ + 透過背景。Ghostty / Neovim 統合対応。
 | `S` | SYNC モード切替 |
 | `F12` | ネストセッション切替（**prefix 不要**） |
 
+### Session 操作
+
+| キー | 動作 |
+|------|------|
+| `s` | セッション選択（choose-tree、**名前順固定**） |
+| `Tab` | 直前のセッションへトグル切替（`switch-client -l`） |
+| `(` | 前のセッション（名前順、リピート可） |
+| `)` | 次のセッション（名前順、リピート可） |
+
+`choose-tree` と `( / )` は共に名前順で巡回するため、後述の命名規約 (`rcon-*`, `proj-*`, `pers-*`, `ops-*`) に従うとカテゴリ単位で束ねて見える／辿れる。
+
 ### Floating Window (display-popup)
 
 | キー | 動作 | サイズ |
@@ -227,6 +238,21 @@ OFF 中の視覚的変化:
 - Window タブがグレー一色
 
 参考: [samoshkin/tmux-config](https://github.com/samoshkin/tmux-config)
+
+## Session 命名規約
+
+セッションが増えた際に `choose-tree -O name` と `switch-client -p/-n` がカテゴリ単位で束ねて見える／辿れるようにするための規約。tmux 本体に session tag / group の概念はないため、名前のプレフィックスでグルーピングを表現する。
+
+| プレフィックス | 用途 | 例 |
+|---------------|------|-----|
+| `rcon-` | `rcon host[:container]` で起動したリモート/コンテナ作業 | `rcon-ailab-syntopic-dev`、`rcon-prod1` |
+| `proj-` | ローカルのプロジェクト作業 | `proj-syntopic-api`、`proj-growth` |
+| `pers-` | dotfiles / 雑務 / 個人メモ | `pers-dotfiles`、`pers-notes` |
+| `ops-` | 監視・運用・インシデント対応 | `ops-grafana`、`ops-oncall` |
+
+プレフィックスがアルファベット順で並ぶため、`prefix s` の choose-tree でも `prefix+( / )` の巡回でも近い用途のセッションが隣接する。rcon 由来のセッション名は既に `host-container` 形式で sanitize されているため `rcon-` プレフィックスを足すだけで整合する。
+
+固定セッション（`scratch`、`MAIN`）はプレフィックスなしで運用しても構わないが、choose-tree ではリスト末尾にまとめて並ぶ（大文字 → 小文字、プレフィックスあり → なしの順で分かれる）。
 
 ## Per-session アクセントカラー
 


### PR DESCRIPTION
## Summary

Session navigation Phase 1 of the tmux multi-session management plan. Adds alpha-sorted session keybindings and naming convention to improve grouping, ordering, and navigation without introducing new dependencies.

## Changes

- **tmux.conf**: Add `prefix s` (choose-tree -Zs -O name), `prefix Tab` (switch-client -l), `prefix (/)` (repeatable prev/next session)
- **docs/tmux.md**: Document Session operation keybindings and introduce naming convention (`rcon-`, `proj-`, `pers-`, `ops-` prefixes)

## Test plan

- [ ] `prefix s` opens choose-tree with sessions sorted alphabetically
- [ ] `prefix Tab` toggles between two most recent sessions
- [ ] `prefix (` and `prefix )` cycle through sessions in alphabetical order
- [ ] All keybindings are repeatable within repeat-time window
- [ ] `tmux source-file ~/.config/tmux/tmux.conf` succeeds without errors

Closes #95

Generated with Claude Code