### PR TITLE
feat(claude): auto-name sessions via branch name and initial prompt

### DIFF
--- a/common/claude/.claude/hooks/claude-session-title.sh
+++ b/common/claude/.claude/hooks/claude-session-title.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: 初回ユーザープロンプトでセッション名を自動生成する。
+# プロンプト先頭行を切り出して sessionTitle に設定。一度設定したら再実行しない。
+# zsh ラッパー側で付与する --name (ブランチ名) を、初回プロンプト後にタスク内容で上書きする役割。
+
+set -euo pipefail
+
+# jq 不在ならフェイルオープン
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+input="$(cat)"
+session_id="$(jq -r '.session_id // ""' <<<"$input")"
+[[ -z "$session_id" ]] && exit 0
+
+state_dir="${HOME}/.claude/state"
+marker="${state_dir}/session-titled-${session_id}"
+[[ -f "$marker" ]] && exit 0
+
+prompt="$(jq -r '.prompt // ""' <<<"$input")"
+[[ -z "$prompt" ]] && exit 0
+
+output_json="$(jq -n --arg prompt "$prompt" '
+  def clean: split("\n")[0] | sub("^\\s+"; "") | sub("\\s+$"; "");
+  def maybe_truncate: if length > 50 then .[0:50] + "…" else . end;
+  ($prompt | clean) as $line
+  | if ($line | length) >= 5 and (($line | startswith("/")) | not) then
+      { hookSpecificOutput: { hookEventName: "UserPromptSubmit", sessionTitle: ($line | maybe_truncate) } }
+    else
+      empty
+    end
+')"
+
+if [[ -n "$output_json" ]]; then
+  mkdir -p "$state_dir"
+  touch "$marker"
+  printf '%s' "$output_json"
+fi

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -211,6 +211,24 @@ fi
 # --- Claude Code fallback wrapper ---
 # Anthropic API障害時にOpenRouter経由で動作させる
 # 切替: claude-fallback.sh on/off
+# 対話セッション起動時にのみ --name を自動注入する判定
+# --name/--resume/--continue 指定時、または subcommand 実行時はスキップ
+_claude_should_auto_name() {
+  # 先頭が既知 subcommand ならスキップ
+  case "${1:-}" in
+    agents|auth|auto-mode|doctor|install|mcp|plugin|plugins|setup-token|update|upgrade)
+      return 1
+      ;;
+  esac
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      -n|--name|--name=*|-r|--resume|--resume=*|--continue) return 1 ;;
+    esac
+  done
+  return 0
+}
+
 claude() {
   # Disable bracketed paste while claude runs so Cmd+V in its auth prompts
   # (`claude auth login`, `claude setup-token`) delivers plain keystrokes
@@ -218,14 +236,21 @@ claude() {
   # Restore after so the zsh prompt keeps bracketed-paste protections.
   printf '\033[?2004l'
   local rc
+  local -a name_args=()
+  if _claude_should_auto_name "$@"; then
+    local auto_name
+    auto_name="$(git -C "$PWD" branch --show-current 2>/dev/null)"
+    [[ -z "$auto_name" ]] && auto_name="$(basename "$PWD")"
+    [[ -n "$auto_name" ]] && name_args=(--name "$auto_name")
+  fi
   if [[ -f "$HOME/.local/share/claude-fallback/active" ]]; then
     local fallback_env="$HOME/.local/share/claude-fallback/env"
     source "$fallback_env"
     ANTHROPIC_BASE_URL="https://openrouter.ai/api" \
     ANTHROPIC_API_KEY="$OPENROUTER_API_KEY" \
-    command claude "$@"
+    command claude "${name_args[@]}" "$@"
   else
-    command claude "$@"
+    command claude "${name_args[@]}" "$@"
   fi
   rc=$?
   printf '\033[?2004h'

--- a/templates/claude-settings.json
+++ b/templates/claude-settings.json
@@ -35,6 +35,16 @@
     ]
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/common/claude/.claude/hooks/claude-session-title.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

Claude Code sessions are now auto-named with zero user interaction:
- On startup: zsh wrapper injects `--name` using the current git branch name (fallback: PWD basename)
- After first prompt: `UserPromptSubmit` hook extracts the prompt's first line (max 50 codepoints) and replaces the initial session name

Users get meaningful session identifiers without manually calling `/rename`.

## Changes

- **common/zsh/.zshrc.common**: Add `_claude_should_auto_name()` helper and integrate auto-naming into the `claude()` wrapper
  - Injects `--name` for interactive sessions only
  - Skips when: subcommand detected (auth, mcp, setup-token, etc), --name/--resume/--continue flags present
  
- **common/claude/.claude/hooks/claude-session-title.sh** (new): UserPromptSubmit hook for dynamic renaming
  - Triggers only once per session (via marker file)
  - Extracts first line of user prompt, truncates to 50 chars, uses as new session title
  - Skips slash commands, empty prompts, prompts shorter than 5 characters
  
- **templates/claude-settings.json**: Register UserPromptSubmit hook so new installations include the feature

## Test plan

- [ ] Launch `claude` in a git repo with branch name `feature-x`: session title appears as "feature-x"
- [ ] In a non-git directory: session title appears as directory basename
- [ ] After entering first prompt (e.g., "Add authentication to the login form"): title changes to "add authentication to the login form" (truncated to 50 chars if needed)
- [ ] Running `claude auth login` does NOT get `--name` injected (subcommand skip works)
- [ ] Running `claude --name "custom"` respects the user's explicit name (flag skip works)
- [ ] Running `claude /help` (slash command) does NOT get renamed on first prompt (slash command skip works)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)