### PR TITLE
Integrate sesh as primary tmux session manager (community standards + zsh binding)

### DIFF
--- a/common/aerospace/.config/aerospace/aerospace.toml
+++ b/common/aerospace/.config/aerospace/aerospace.toml
@@ -205,7 +205,10 @@ on-mode-changed = ['exec-and-forget sketchybar --trigger aerospace_mode_change']
     alt-shift-f = 'fullscreen'
 
     # Toggle sketchybar visibility with dynamic padding
-    alt-s = 'exec-and-forget ~/.config/sketchybar/plugins/toggle_bar.sh'
+    # NOTE: alt-s was moved to alt-shift-s to free Alt-s for the zsh sesh widget
+    # (see common/zsh/.zshrc.common). aerospace's alt-shift-s was unused (only
+    # the commented move-node-to-workspace S).
+    alt-shift-s = 'exec-and-forget ~/.config/sketchybar/plugins/toggle_bar.sh'
 
     # Swap windows between monitors
     alt-m = 'exec-and-forget ~/dotfiles/scripts/swap-monitors.sh'

--- a/common/sesh/.config/sesh/sesh.toml
+++ b/common/sesh/.config/sesh/sesh.toml
@@ -1,0 +1,42 @@
+#:schema https://github.com/joshmedeski/sesh/raw/main/sesh.schema.json
+#
+# sesh - smart tmux session manager
+# https://github.com/joshmedeski/sesh
+#
+# 選択ソース順序:
+#   config  — 下記 [[session]] / [[wildcard]] の定義に合致した path
+#   tmux    — 既にアクティブなローカル tmux セッション
+#   zoxide  — 最近 cd したディレクトリ (ghq 配下も含む)
+#
+# 命名規約は Phase 1 で定義: rcon- / proj- / pers- / ops-
+# zoxide 経由で起動したセッション名は basename が使われるため命名規約から外れる。
+# 頻用プロジェクトは [[session]] に事前登録、プロジェクト群は [[wildcard]] で拾う。
+
+sort_order = ["config", "tmux", "zoxide"]
+dir_length = 2
+cache = true
+
+# popup / scratch など一時セッションはリストから除外
+blacklist = ["scratch"]
+
+[default_session]
+preview_command = "eza --all --git --icons --color=always {}"
+
+# --- 固定エントリ (特別扱いしたい path だけ) ---
+
+[[session]]
+name = "pers-dotfiles"
+path = "~/dotfiles"
+
+[[session]]
+name = "pers-config"
+path = "~/.config"
+
+# --- ワイルドカード (プロジェクト群を丸ごと拾う) ---
+# ghq 配下のリポジトリ = ~/ghq/github.com/<owner>/<repo>
+[[wildcard]]
+pattern = "~/ghq/github.com/*/*"
+
+# ~/workspace 配下の作業ディレクトリ
+[[wildcard]]
+pattern = "~/workspace/*"

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -57,6 +57,11 @@ set -s escape-time 0
 setw -g monitor-activity on
 set -g renumber-windows on
 
+# Session lifecycle
+# detach-on-destroy off: セッション閉鎖時に tmux クライアントを放り出さず、
+# 別のセッションに自動切替する。sesh last / choose-tree ワークフロー成立に必須。
+set -g detach-on-destroy off
+
 # Status bar update interval (reduce for remote sessions)
 set -g status-interval 5
 
@@ -136,6 +141,32 @@ bind s choose-tree -Zs -O name
 bind Tab switch-client -l
 bind -r ( switch-client -p
 bind -r ) switch-client -n
+
+# sesh last: 直前のセッションに戻る。switch-client -l と比べて sesh 側の履歴を
+# 参照するので fzf picker 経由で切り替えた履歴も拾える。セッション 1 つだけの
+# ときは黙らずメッセージを出す (コミュニティ標準のフォールバック)。
+bind L run-shell "sesh last || tmux display-message -d 1000 'Only one session'"
+
+# sesh: fuzzy session picker (config + tmux + zoxide 横断) の多段フィルタ版。
+# 公式 README の配布レシピを採用。popup 内で Ctrl キーで ソース切替:
+#   ^a all / ^t tmux / ^g configs / ^x zoxide / ^f find (fd) / ^d kill session
+# prefix+f はローカル tmux session のみの色付き picker (軽量)、
+# prefix+C-f はプロジェクトディレクトリ横断で新規セッション作成含むスーパーセット。
+# 注: prefix+C-s / prefix+C-t は opensessions 用 (focus / toggle) のため避ける。
+bind C-f display-popup -E -w 80% -h 70% 'sesh connect "$(
+  sesh list --icons | fzf-tmux -p --no-sort --ansi \
+    --border-label " sesh " --prompt "⚡  " \
+    --header "  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find" \
+    --bind "tab:down,btab:up" \
+    --bind "ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)" \
+    --bind "ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)" \
+    --bind "ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)" \
+    --bind "ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)" \
+    --bind "ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)" \
+    --bind "ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)" \
+    --preview-window "right:55%" \
+    --preview "sesh preview {}"
+)"'
 
 # Sync mode toggle (with style change, reads @theme-* at runtime)
 bind S run-shell '\

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -208,6 +208,25 @@ if command -v ghq &>/dev/null && command -v fzf &>/dev/null; then
   }
 fi
 
+# --- sesh (smart tmux session manager) ---
+# Alt-s でシェル (tmux 内外) から sesh picker を起動する widget。
+# tmux 内: prefix+C-f と同じ体験を prefix なしで
+# tmux 外: 新規ターミナル起動直後の素の zsh から既存 tmux session に直接 attach
+if command -v sesh &>/dev/null && command -v fzf &>/dev/null; then
+  sesh-sessions() {
+    exec </dev/tty
+    exec <&1
+    local session
+    session=$(sesh list -i | fzf --height 40% --reverse \
+      --border-label ' sesh ' --border --prompt '⚡  ' --ansi)
+    [[ -z "$session" ]] && { zle reset-prompt 2>/dev/null; return; }
+    sesh connect "$session"
+    zle reset-prompt 2>/dev/null
+  }
+  zle -N sesh-sessions
+  bindkey '\es' sesh-sessions  # Alt-s (ESC + s)
+fi
+
 # --- Claude Code fallback wrapper ---
 # Anthropic API障害時にOpenRouter経由で動作させる
 # 切替: claude-fallback.sh on/off

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -13,6 +13,7 @@ brew "starship"
 brew "sheldon"
 brew "atuin"
 brew "zoxide"
+brew "joshmedeski/sesh/sesh"  # Smart tmux session manager (fuzzy finder + zoxide/ghq integration)
 brew "stow"
 brew "aerc"
 

--- a/docs/sesh.md
+++ b/docs/sesh.md
@@ -1,0 +1,151 @@
+# sesh
+
+ファジーファインダー型の tmux セッションマネージャー。zoxide / ghq / 既存 tmux セッションを横断して fuzzy 検索し、新規セッション作成または既存セッション切替を1アクションで行う「tmux のコマンドパレット」。
+
+- Plugin: [joshmedeski/sesh](https://github.com/joshmedeski/sesh)
+- Config: `common/sesh/.config/sesh/sesh.toml`
+- Install: `brew "joshmedeski/sesh/sesh"` (Brewfile)
+
+## 役割分担
+
+| 手段 | 対象 | 用途 |
+|------|------|------|
+| `prefix s` (choose-tree -O name) | ローカル tmux session (名前順) | 既存セッションの一覧閲覧と切替 |
+| `prefix Tab` (switch-client -l) | 直前のローカル session | sesh 非依存の素の tmux トグル |
+| `prefix L` (sesh last) | 直前の session (sesh 履歴) | picker 経由の履歴も拾う sesh 版 last |
+| `prefix ( / )` (switch-client -p/-n) | ローカル session (名前順) | 隣接セッションへの巡回 |
+| `prefix f` (tmux-session-color.sh) | ローカル session のみ | 色付き fzf picker + プレビュー |
+| **`prefix C-f` (sesh)** | **config + tmux + zoxide + fd 横断** | **多段フィルタ popup (公式 README 流)** |
+| **`Alt-s` (zsh widget)** | 同上、シェルから起動 | tmux 外からでも sesh へ |
+| opensessions サイドバー | ローカル session + AI agent 状態 | 永続的に見える横型一覧 + AI 状態可視化 |
+
+sesh の強みは「セッションが存在しない場合は zoxide/wildcard から新規作成する」機能。既存セッション切替のみなら `prefix s` / `prefix f` / opensessions サイドバーで十分。
+
+## tmux 側の土台
+
+`common/tmux/.config/tmux/tmux.conf` に入れてある sesh 運用の前提:
+
+```tmux
+set -g detach-on-destroy off   # セッション閉鎖時に tmux から放り出されない (sesh last 必須条件)
+
+bind L run-shell "sesh last || tmux display-message -d 1000 'Only one session'"
+bind C-f display-popup -E -w 80% -h 70% '...多段フィルタ popup...'
+```
+
+`detach-on-destroy off` が無いとセッションを閉じた際に tmux クライアント自体が終了してしまい、`sesh last` で戻る体験が成立しない。
+
+## 多段フィルタ popup のキー
+
+`prefix C-f` で popup を開いた後、popup 内で以下のキーでソースを切替:
+
+| キー | プロンプト | フィルタ |
+|------|-----------|----------|
+| `Ctrl-a` | ⚡ | すべて (default) |
+| `Ctrl-t` | 🪟 | tmux sessions のみ |
+| `Ctrl-g` | ⚙️ | sesh.toml の config entries のみ |
+| `Ctrl-x` | 📁 | zoxide ディレクトリのみ |
+| `Ctrl-f` | 🔎 | `fd` で `$HOME` 以下のディレクトリ検索 |
+| `Ctrl-d` |   | 現在ハイライト中の session を `tmux kill-session` |
+| `Tab` / `Shift+Tab` |   | 次/前の候補へ |
+| `Enter` |   | 選択して attach/connect |
+
+## 設定
+
+### ソース順序と基本
+
+```toml
+#:schema https://github.com/joshmedeski/sesh/raw/main/sesh.schema.json
+
+sort_order = ["config", "tmux", "zoxide"]
+dir_length = 2
+cache = true                 # v2 の 5 秒 TTL キャッシュ (popup 連打時に効く)
+blacklist = ["scratch"]      # popup/scratch セッションをリストから除外
+
+[default_session]
+preview_command = "eza --all --git --icons --color=always {}"
+```
+
+- `#:schema` ディレクティブで taplo LSP の補完と検証が効く
+- `dir_length = 2` で同名プロジェクト区別 (`projects/sesh` vs `tools/sesh`)
+- `blacklist` には dotfiles 環境で使う一時セッション名 (`scratch` は `prefix j` の scratchpad) を入れる
+
+### 固定エントリ (最小限)
+
+命名規約 (`pers-*` など) を守りたい頻用 path だけ `[[session]]` で定義。
+
+```toml
+[[session]]
+name = "pers-dotfiles"
+path = "~/dotfiles"
+
+[[session]]
+name = "pers-config"
+path = "~/.config"
+```
+
+### ワイルドカード (プロジェクト群を丸ごと)
+
+ghq 配下のリポジトリと `~/workspace` の作業ディレクトリを丸ごと拾う。新しく `ghq get` で増えたプロジェクトも自動で picker に現れる。
+
+```toml
+[[wildcard]]
+pattern = "~/ghq/github.com/*/*"
+
+[[wildcard]]
+pattern = "~/workspace/*"
+```
+
+### zoxide を育てる
+
+sesh の `zoxide` ソースは `zoxide` の頻度スコア順で並ぶため、zoxide のデータベースを意図的に育てると picker の有用性が上がる:
+
+- プロジェクトディレクトリには必ず一度 `cd` で入る (`cd` は zoxide に alias 済み: `zoxide init zsh --cmd cd`)
+- 浅いがよく飛ぶ場所 (`~/Downloads`, `~/.config/*`) も意識的に cd しておく
+
+## シェル側バインド (Alt-s)
+
+`common/zsh/.zshrc.common` に zle widget を登録している。
+
+```zsh
+bindkey '\es' sesh-sessions  # Alt-s
+```
+
+- tmux 内: `prefix+C-f` と同じ体験を prefix なしで (1 チョード)
+- tmux 外: ターミナルを新規で開いた直後、`tmux attach` 前に `Alt-s` で直接 sesh picker → 既存 session に attach
+
+## rcon との関係
+
+sesh はローカル tmux サーバーでのみ動作する。rcon で接続する remote tmux のセッションは local sesh の対象外。remote 側でも sesh を使いたい場合は、接続先ホストに個別に sesh をインストールする (別 Phase)。
+
+## Troubleshooting
+
+### `prefix L` が効かない (セッション間で戻れない)
+
+- `tmux show-options -g detach-on-destroy` が `off` になっているか確認
+- セッションが 1 個しかないと `Only one session` メッセージが 1 秒表示される (正常)
+
+### `[[session]]` に定義したエントリが picker に出ない
+
+- `sesh list -c` で config エントリのみ表示して TOML が読み込めているか確認
+- シンリンクが張れているか: `ls -la ~/.config/sesh/sesh.toml`
+- `sort_order` に `config` が含まれているか
+
+### wildcard に定義した path が picker に出ない
+
+- そのディレクトリに一度 `cd` したか (内部的に globbing + zoxide に似た解決)
+- `sesh list` で出ない場合は `sesh list -c` と `sesh list -z` を個別に確認
+
+### zoxide 候補が少ない
+
+- `zoxide query -l` でスコア順のディレクトリ一覧を確認
+- 一度も cd していないディレクトリは出ない
+
+### popup 内で誤って session を kill した
+
+- `Ctrl-d` でアクティブ session を kill している。復元するには sesh 経由で再作成
+- 惜しいなら `tmux-resurrect` で直近の save 時点から復元可能
+
+## 関連
+
+- [tmux.md](./tmux.md) — tmux 全般 + Phase 1 の session 命名規約とキーバインド
+- [opensessions.md](./opensessions.md) — 常駐型サイドバー + AI agent 状態監視

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -62,11 +62,14 @@ TokyoNight Night テーマ + 透過背景。Ghostty / Neovim 統合対応。
 | キー | 動作 |
 |------|------|
 | `s` | セッション選択（choose-tree、**名前順固定**） |
-| `Tab` | 直前のセッションへトグル切替（`switch-client -l`） |
+| `Tab` | 直前のセッションへトグル切替（`switch-client -l`、sesh 非依存） |
+| `L` | 直前のセッションへ（`sesh last`、picker 履歴を参照） |
 | `(` | 前のセッション（名前順、リピート可） |
 | `)` | 次のセッション（名前順、リピート可） |
+| `f` | 色付きセッション picker（既存 tmux session のみ、`tmux-session-color.sh`）|
+| `C-f` | sesh picker（多段フィルタ: `^a` all / `^t` tmux / `^g` config / `^x` zoxide / `^f` find / `^d` kill）|
 
-`choose-tree` と `( / )` は共に名前順で巡回するため、後述の命名規約 (`rcon-*`, `proj-*`, `pers-*`, `ops-*`) に従うとカテゴリ単位で束ねて見える／辿れる。
+`choose-tree` と `( / )` は共に名前順で巡回するため、後述の命名規約 (`rcon-*`, `proj-*`, `pers-*`, `ops-*`) に従うとカテゴリ単位で束ねて見える／辿れる。`prefix f` と `prefix C-f` の使い分けは [sesh.md](./sesh.md) 参照。
 
 ### Floating Window (display-popup)
 


### PR DESCRIPTION
## Summary

Introduce [sesh](https://github.com/joshmedeski/sesh) as the cross-cutting "tmux command palette" alongside existing Phase 1 navigation. Adopts Josh Medeski's community-recommended recipe: detach-on-destroy off, multi-filter popup, wildcard-based config, and shell-level Alt-s binding.

## Changes

- **Brewfile**: `joshmedeski/sesh/sesh`
- **tmux.conf**:
  - `set -g detach-on-destroy off` (required for sesh last workflow)
  - `prefix L` → `sesh last` with fallback message
  - `prefix C-f` → multi-filter popup (Ctrl-a/t/g/x/d/f source switching; Ctrl-d kill)
- **sesh.toml** (new, stow-managed at `common/sesh/.config/sesh/sesh.toml`):
  - `#:schema` directive for LSP completion
  - `cache = true` (v2 5-second TTL cache)
  - `blacklist = ["scratch"]`
  - `[[wildcard]]` for `~/ghq/github.com/*/*` and `~/workspace/*`
  - `[[session]]` kept minimal: `pers-dotfiles`, `pers-config`
- **zsh**: `Alt-s` widget (works inside and outside tmux)
- **docs**: new `docs/sesh.md` with multi-filter keybinds + wildcard operation + troubleshooting; `docs/tmux.md` Session table updated with `L` and revised `C-f` description

## Preserved

- Phase 1 bindings: `prefix s / Tab / ( / )`
- Existing `prefix f` (tmux-session-color.sh fzf-sessions)
- opensessions sidebar integration

## Test plan

- [ ] `brew install joshmedeski/sesh/sesh` installs sesh 2.25+
- [ ] `sesh list -c` outputs `pers-dotfiles`, `pers-config`
- [ ] `sesh list` orders: config → tmux → zoxide
- [ ] `tmux show-options -g detach-on-destroy` returns `off`
- [ ] `prefix L` triggers sesh last; displays "Only one session" when sole session
- [ ] `prefix C-f` opens popup; `Ctrl-a/t/g/x` change source, `Ctrl-d` kills, `Ctrl-f` invokes fd
- [ ] `Alt-s` opens sesh picker from shell (inside and outside tmux)
- [ ] Phase 1 bindings and `prefix f` still work

Closes #100

Follow-ups: #TBD (I-B: startup_script templates), #TBD (I-C: worktree + Claude Code integration)