### PR TITLE
Add sesh startup_script templates for project bootstrap layouts

### DIFF
--- a/common/sesh/.config/sesh/scripts/generic-project.sh
+++ b/common/sesh/.config/sesh/scripts/generic-project.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# generic-project.sh — Minimal single-pane bootstrap with nvim
+#
+# Usage: sesh.toml の [[wildcard]] / [[session]] の startup_command から参照:
+#   startup_command = "~/.config/sesh/scripts/generic-project.sh"
+#
+# Layout: 単一ペインで nvim を起動するだけ。追加の pane/window は作らない。
+# lazygit などの popup は tmux 側の既存キーバインド (prefix+g) で即起動できるため、
+# このスクリプトでは pre-launch しない (プロセスを無駄に立てない)。
+
+set -e
+
+# Git リポジトリ内であれば、nvim 起動前に status を確認しやすいように
+# 2 行分のヒントを表示してから nvim へ
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  tmux send-keys 'git status --short && echo && nvim' Enter
+else
+  tmux send-keys 'nvim' Enter
+fi

--- a/common/sesh/.config/sesh/scripts/node-project.sh
+++ b/common/sesh/.config/sesh/scripts/node-project.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# node-project.sh — Node.js project bootstrap layout
+#
+# Usage: sesh.toml の [[wildcard]] / [[session]] の startup_command から参照:
+#   startup_command = "~/.config/sesh/scripts/node-project.sh"
+#
+# Layout:
+#   +----------------------------+
+#   |                            |
+#   |   nvim (current window)    |
+#   |                            |
+#   +----------------------------+
+#   | $ npm run dev (30% height) |
+#   +----------------------------+
+
+set -e
+
+# 下 30% に dev server 用 pane を分割
+tmux split-window -v -p 30
+
+# 上のペイン (エディタ) に戻って nvim 起動
+tmux select-pane -U
+tmux send-keys 'nvim' Enter
+
+# 下のペインにフォーカスを移し、dev server コマンドを入力した状態で待機
+# (Enter は送らない → ユーザーが確認してから起動)
+tmux select-pane -D
+if [ -f package.json ]; then
+  if grep -q '"dev"' package.json 2>/dev/null; then
+    tmux send-keys 'npm run dev'
+  elif grep -q '"start"' package.json 2>/dev/null; then
+    tmux send-keys 'npm start'
+  fi
+fi

--- a/common/sesh/.config/sesh/sesh.toml
+++ b/common/sesh/.config/sesh/sesh.toml
@@ -23,10 +23,14 @@ blacklist = ["scratch"]
 preview_command = "eza --all --git --icons --color=always {}"
 
 # --- 固定エントリ (特別扱いしたい path だけ) ---
+#
+# startup_command は session が新規作成されたときだけ走る (再 attach では再実行されない)。
+# ~/.config/sesh/scripts/ の bash スクリプトを呼び出してブートストラップレイアウトを組む。
 
 [[session]]
 name = "pers-dotfiles"
 path = "~/dotfiles"
+startup_command = "~/.config/sesh/scripts/generic-project.sh"
 
 [[session]]
 name = "pers-config"
@@ -40,3 +44,9 @@ pattern = "~/ghq/github.com/*/*"
 # ~/workspace 配下の作業ディレクトリ
 [[wildcard]]
 pattern = "~/workspace/*"
+
+# Example: Node.js プロジェクト専用のブートストラップを使いたいとき
+# 具体的な path を wildcard で絞って startup_command を上書きする。
+# [[wildcard]]
+# pattern = "~/ghq/github.com/shonenm/my-node-app"
+# startup_command = "~/.config/sesh/scripts/node-project.sh"

--- a/docs/sesh.md
+++ b/docs/sesh.md
@@ -95,6 +95,36 @@ pattern = "~/ghq/github.com/*/*"
 pattern = "~/workspace/*"
 ```
 
+### startup_script によるプロジェクトブートストラップ
+
+`startup_command` は session が新規作成されたときに実行される1行コマンド、または実行可能スクリプトへのパス。`common/sesh/.config/sesh/scripts/` に典型的なレイアウト用スクリプトを用意している (新規シェル script は `chmod +x` 必須)。
+
+| スクリプト | 用途 |
+|-----------|------|
+| `generic-project.sh` | Git 状態を表示してから nvim を起動（単一ペイン、軽量） |
+| `node-project.sh`    | 上下 2 ペイン: 上 nvim / 下 30% で `npm run dev` 待機 |
+
+設定例:
+
+```toml
+# 全ての dotfiles セッションでは generic-project.sh を走らせる
+[[session]]
+name = "pers-dotfiles"
+path = "~/dotfiles"
+startup_command = "~/.config/sesh/scripts/generic-project.sh"
+
+# 特定の Node プロジェクトだけ node-project.sh を適用
+[[wildcard]]
+pattern = "~/ghq/github.com/shonenm/my-node-app"
+startup_command = "~/.config/sesh/scripts/node-project.sh"
+```
+
+ポイント:
+
+- **再 attach では走らない**: `startup_command` は "create" 時のみ。既存セッションに戻っても副作用なし
+- **`--command/-c` 経由では走らない**: `sesh connect -c "..."` のように `--command` を渡すとスキップされるため、picker から普通に接続するのが前提
+- **より重いセットアップは別スクリプト化**: `scripts/` 配下に複数テンプレートを置いて使い分ける。プロジェクト固有のセットアップが必要になったら `[[session]]` で `startup_command` を指定
+
 ### zoxide を育てる
 
 sesh の `zoxide` ソースは `zoxide` の頻度スコア順で並ぶため、zoxide のデータベースを意図的に育てると picker の有用性が上がる:


### PR DESCRIPTION
## Summary

Build on #101 by adding reusable `startup_command` scripts that sesh runs when a session is first created. Enables one-command project bootstrap for nvim + dev server layouts.

## Changes

- `common/sesh/.config/sesh/scripts/` (new, stow-managed):
  - `generic-project.sh` — nvim + git status (minimal, single pane)
  - `node-project.sh` — 70/30 vertical split, nvim + dev server pane with `npm run dev` pre-typed
- `sesh.toml`:
  - `pers-dotfiles` now uses `generic-project.sh` as demo
  - Commented-out `[[wildcard]]` example for opting node-project.sh into specific paths
- `docs/sesh.md`: new "startup_script によるプロジェクトブートストラップ" section

## Test plan

- [ ] Scripts are executable (`ls -la common/sesh/.config/sesh/scripts/`)
- [ ] `shellcheck` passes on both scripts
- [ ] Creating a new `pers-dotfiles` session via sesh runs `generic-project.sh` (nvim opens with git status shown)
- [ ] Re-attaching to existing `pers-dotfiles` does NOT re-run the script
- [ ] `sesh list -c` still returns pers-dotfiles and pers-config

## Depends on

PR #101 (stacked — base: `100-sesh-integration`)

Closes #102