### PR TITLE
Integrate sesh with git worktree and enable Claude Code parallel execution

### DIFF
--- a/common/sesh/.config/sesh/sesh.toml
+++ b/common/sesh/.config/sesh/sesh.toml
@@ -45,8 +45,23 @@ pattern = "~/ghq/github.com/*/*"
 [[wildcard]]
 pattern = "~/workspace/*"
 
+# git worktree (scripts/wt で作成した `<main>--wt--<slug>` ディレクトリ)
+# ~/ 直下と ~/ghq/github.com/<owner>/ 直下の両方をカバー。
+# session 名は basename (`dotfiles--wt--feat-login` 等) となるため、
+# Claude Code 並列実行時に worker を session 単位で識別できる。
+[[wildcard]]
+pattern = "~/*--wt--*"
+
+[[wildcard]]
+pattern = "~/ghq/github.com/*/*--wt--*"
+
 # Example: Node.js プロジェクト専用のブートストラップを使いたいとき
 # 具体的な path を wildcard で絞って startup_command を上書きする。
 # [[wildcard]]
 # pattern = "~/ghq/github.com/shonenm/my-node-app"
 # startup_command = "~/.config/sesh/scripts/node-project.sh"
+
+# Example: worktree で Claude Code を自動起動したいとき
+# [[wildcard]]
+# pattern = "~/*--wt--*"
+# startup_command = "claude"

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -159,20 +159,22 @@ bind 9 run-shell "sesh connect --root '#{pane_current_path}'"
 # prefix+f はローカル tmux session のみの色付き picker (軽量)、
 # prefix+C-f はプロジェクトディレクトリ横断で新規セッション作成含むスーパーセット。
 # 注: prefix+C-s / prefix+C-t は opensessions 用 (focus / toggle) のため避ける。
-bind C-f display-popup -E -w 80% -h 70% 'sesh connect "$(
-  sesh list --icons | fzf-tmux -p --no-sort --ansi \
-    --border-label " sesh " --prompt "⚡  " \
-    --header "  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find" \
-    --bind "tab:down,btab:up" \
-    --bind "ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)" \
-    --bind "ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)" \
-    --bind "ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)" \
-    --bind "ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)" \
-    --bind "ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)" \
-    --bind "ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)" \
-    --preview-window "right:55%" \
-    --preview "sesh preview {}"
-)"'
+# 重要: display-popup でラップしない。内側の fzf-tmux -p が自前で popup を開くため、
+# 二重 popup になって入力が届かなくなる (旧実装のバグ)。run-shell に任せる。
+bind C-f run-shell "sesh connect \"\$(
+  sesh list --icons | fzf-tmux -p 80%,70% --no-sort --ansi \
+    --border-label ' sesh ' --prompt '⚡  ' \
+    --header '  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find' \
+    --bind 'tab:down,btab:up' \
+    --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)' \
+    --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)' \
+    --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)' \
+    --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)' \
+    --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)' \
+    --preview-window 'right:55%' \
+    --preview 'sesh preview {}'
+)\""
 
 # Sync mode toggle (with style change, reads @theme-* at runtime)
 bind S run-shell '\

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -147,6 +147,12 @@ bind -r ) switch-client -n
 # ときは黙らずメッセージを出す (コミュニティ標準のフォールバック)。
 bind L run-shell "sesh last || tmux display-message -d 1000 'Only one session'"
 
+# sesh root: 現在の session の "root" に相当する session にジャンプ。
+# worktree (`<main>--wt--<slug>`) 等のネストから親プロジェクトへ一撃で戻るとき便利。
+# #{pane_current_path} は tmux 側で invocation time に展開されるため、shell expansion ではなく
+# tmux format substitution を使う必要がある (shell expansion だと config load 時点で固定される)。
+bind 9 run-shell "sesh connect --root '#{pane_current_path}'"
+
 # sesh: fuzzy session picker (config + tmux + zoxide 横断) の多段フィルタ版。
 # 公式 README の配布レシピを採用。popup 内で Ctrl キーで ソース切替:
 #   ^a all / ^t tmux / ^g configs / ^x zoxide / ^f find (fd) / ^d kill session

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -214,14 +214,17 @@ fi
 # tmux 外: 新規ターミナル起動直後の素の zsh から既存 tmux session に直接 attach
 if command -v sesh &>/dev/null && command -v fzf &>/dev/null; then
   sesh-sessions() {
-    exec </dev/tty
-    exec <&1
     local session
+    # fzf の stdin を明示的に tty にリダイレクト (zle 経由では stdin が widget の
+    # buffer になっていて fzf のインタラクション不可になる)
     session=$(sesh list -i | fzf --height 40% --reverse \
-      --border-label ' sesh ' --border --prompt '⚡  ' --ansi)
-    [[ -z "$session" ]] && { zle reset-prompt 2>/dev/null; return; }
-    sesh connect "$session"
-    zle reset-prompt 2>/dev/null
+      --border-label ' sesh ' --border --prompt '⚡  ' --ansi < /dev/tty)
+    if [[ -n "$session" ]]; then
+      BUFFER="sesh connect \"$session\""
+      zle accept-line
+    else
+      zle reset-prompt 2>/dev/null
+    fi
   }
   zle -N sesh-sessions
   bindkey '\es' sesh-sessions  # Alt-s (ESC + s)

--- a/docs/sesh.md
+++ b/docs/sesh.md
@@ -143,6 +143,40 @@ bindkey '\es' sesh-sessions  # Alt-s
 - tmux 内: `prefix+C-f` と同じ体験を prefix なしで (1 チョード)
 - tmux 外: ターミナルを新規で開いた直後、`tmux attach` 前に `Alt-s` で直接 sesh picker → 既存 session に attach
 
+## git worktree + Claude Code 並列実行
+
+dotfiles には [`scripts/wt`](../scripts/wt) (git worktree + tmux window 統合 CLI) が同梱されている。`wt new feat/login` で `<main>--wt--<slug>` 形式のサイドカーディレクトリを作り、現在 session の **新規 window** を開いてそこに cd する仕組み。
+
+sesh 側には下記のワイルドカードを入れており、既存の `wt` で作られた worktree ディレクトリはそのまま sesh picker に現れる:
+
+```toml
+[[wildcard]]
+pattern = "~/*--wt--*"
+
+[[wildcard]]
+pattern = "~/ghq/github.com/*/*--wt--*"
+```
+
+### 運用パターン
+
+| 目的 | 手順 |
+|------|------|
+| 同一 session で並列作業 (window per worktree) | `wt new <branch>` — 既存の `wt` フロー、高速。opensessions サイドバーでは 1 session として集約 |
+| 独立 session で並列 Claude Code | `wt new <branch>` で worktree を作った後、`prefix C-f` → ワイルドカード経由で **別 session** として attach。各 worktree が独立した opensessions 行になる |
+| worktree から親プロジェクトへ戻る | `prefix 9` → `sesh connect --root`。現在の `pane_current_path` を sesh に渡し、親相当の session にジャンプ |
+
+### Claude Code 自動起動 (opt-in)
+
+特定の worktree で Claude を毎回自動起動したい場合、sesh.toml に `startup_command = "claude"` を付けたワイルドカードを追加する:
+
+```toml
+[[wildcard]]
+pattern = "~/*--wt--*"
+startup_command = "claude"
+```
+
+ただし全 worktree で強制されると非 Claude ワークでも claude プロセスが立つため、デフォルトでは未適用 (コメント例のみ)。`ralph-parallel` 等で強制したい場合だけ opt-in。
+
 ## rcon との関係
 
 sesh はローカル tmux サーバーでのみ動作する。rcon で接続する remote tmux のセッションは local sesh の対象外。remote 側でも sesh を使いたい場合は、接続先ホストに個別に sesh をインストールする (別 Phase)。

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -64,6 +64,7 @@ TokyoNight Night テーマ + 透過背景。Ghostty / Neovim 統合対応。
 | `s` | セッション選択（choose-tree、**名前順固定**） |
 | `Tab` | 直前のセッションへトグル切替（`switch-client -l`、sesh 非依存） |
 | `L` | 直前のセッションへ（`sesh last`、picker 履歴を参照） |
+| `9` | 親プロジェクト session へジャンプ（`sesh connect --root`、worktree 等のネストから復帰） |
 | `(` | 前のセッション（名前順、リピート可） |
 | `)` | 次のセッション（名前順、リピート可） |
 | `f` | 色付きセッション picker（既存 tmux session のみ、`tmux-session-color.sh`）|


### PR DESCRIPTION
## Summary

Final piece of the sesh Phase 2 series. Make sesh aware of `scripts/wt`-created worktrees and enable session-per-worktree workflows (useful for Claude Code parallel execution), while preserving the existing window-per-worktree behavior of `wt`.

## Changes

- `sesh.toml`:
  - `[[wildcard]] pattern = "~/*--wt--*"` — detect top-level worktree dirs
  - `[[wildcard]] pattern = "~/ghq/github.com/*/*--wt--*"` — detect ghq-nested worktree dirs
  - Opt-in example for auto-claude-on-worktree-creation (commented)
- `tmux.conf`:
  - `prefix 9` → `sesh connect --root '#{pane_current_path}'` — jumps to the project root session from a nested one (e.g. a worktree session)
- `docs/sesh.md`: new "git worktree + Claude Code 並列実行" section covering both the wt/window path and the sesh/session path
- `docs/tmux.md`: Session operation table updated with `prefix 9`

## Non-changes

- `scripts/wt` untouched. Users continue to use `wt new/list/delete` as before. sesh adds a **complementary** path, not a replacement.

## Test plan

- [ ] After `wt new test-branch` in a project, `sesh list` shows `<project>--wt--test-branch`
- [ ] Selecting that entry creates/attaches an independent session
- [ ] `prefix 9` from a worktree session jumps back to parent project session
- [ ] `wt new/list/delete/clean` behavior unchanged

## Depends on

PR #101 (I-A) → PR #103 (I-B) → this PR (I-C). Base branch is `102-sesh-startup-scripts`.

Closes #104