### PR TITLE
Fix sesh prefix C-f popup nesting and Alt-s widget stdin handling

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -159,20 +159,22 @@ bind 9 run-shell "sesh connect --root '#{pane_current_path}'"
 # prefix+f はローカル tmux session のみの色付き picker (軽量)、
 # prefix+C-f はプロジェクトディレクトリ横断で新規セッション作成含むスーパーセット。
 # 注: prefix+C-s / prefix+C-t は opensessions 用 (focus / toggle) のため避ける。
-bind C-f display-popup -E -w 80% -h 70% 'sesh connect "$(
-  sesh list --icons | fzf-tmux -p --no-sort --ansi \
-    --border-label " sesh " --prompt "⚡  " \
-    --header "  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find" \
-    --bind "tab:down,btab:up" \
-    --bind "ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)" \
-    --bind "ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)" \
-    --bind "ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)" \
-    --bind "ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)" \
-    --bind "ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)" \
-    --bind "ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)" \
-    --preview-window "right:55%" \
-    --preview "sesh preview {}"
-)"'
+# 重要: display-popup でラップしない。内側の fzf-tmux -p が自前で popup を開くため、
+# 二重 popup になって入力が届かなくなる (旧実装のバグ)。run-shell に任せる。
+bind C-f run-shell "sesh connect \"\$(
+  sesh list --icons | fzf-tmux -p 80%,70% --no-sort --ansi \
+    --border-label ' sesh ' --prompt '⚡  ' \
+    --header '  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find' \
+    --bind 'tab:down,btab:up' \
+    --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)' \
+    --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)' \
+    --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)' \
+    --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)' \
+    --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)' \
+    --preview-window 'right:55%' \
+    --preview 'sesh preview {}'
+)\""
 
 # Sync mode toggle (with style change, reads @theme-* at runtime)
 bind S run-shell '\

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -214,14 +214,17 @@ fi
 # tmux 外: 新規ターミナル起動直後の素の zsh から既存 tmux session に直接 attach
 if command -v sesh &>/dev/null && command -v fzf &>/dev/null; then
   sesh-sessions() {
-    exec </dev/tty
-    exec <&1
     local session
+    # fzf の stdin を明示的に tty にリダイレクト (zle 経由では stdin が widget の
+    # buffer になっていて fzf のインタラクション不可になる)
     session=$(sesh list -i | fzf --height 40% --reverse \
-      --border-label ' sesh ' --border --prompt '⚡  ' --ansi)
-    [[ -z "$session" ]] && { zle reset-prompt 2>/dev/null; return; }
-    sesh connect "$session"
-    zle reset-prompt 2>/dev/null
+      --border-label ' sesh ' --border --prompt '⚡  ' --ansi < /dev/tty)
+    if [[ -n "$session" ]]; then
+      BUFFER="sesh connect \"$session\""
+      zle accept-line
+    else
+      zle reset-prompt 2>/dev/null
+    fi
   }
   zle -N sesh-sessions
   bindkey '\es' sesh-sessions  # Alt-s (ESC + s)


### PR DESCRIPTION
## Summary

Fix two bugs in the sesh integration (#100) that surfaced during actual use on this dotfiles environment.

## Changes

### 1. `prefix C-f` popup nesting (tmux.conf)

Replace outer `display-popup -E -w 80% -h 70% '...'` with plain `run-shell "..."`. The inner `fzf-tmux -p 80%,70%` now manages popup sizing itself (matches Josh Medeski's official recipe). Previously, nesting two popups caused an empty inner popup that swallowed key input.

### 2. `Alt-s` zsh widget stdin (zshrc.common)

Replace `exec </dev/tty; exec <&1` (which corrupted the widget's FDs and silently failed) with explicit `< /dev/tty` on the fzf command. Switch to `BUFFER=...; zle accept-line` pattern instead of calling `sesh connect` inline — integrates cleanly with zsh-abbr's accept-line replacement and the rest of the widget chain.

## Stacking

Targets `104-sesh-worktree-claude` (I-C's branch). Merge order: #101 → #103 → #105 → #107.

## Test plan

- [ ] In tmux, `prefix C-f` opens fzf-tmux popup at 80%×70% with sesh list
- [ ] Popup's `Ctrl-a/t/g/x/f/d` filter/kill keys all work
- [ ] Popup's `Esc` closes it cleanly
- [ ] In fresh zsh, `Alt-s` opens sesh picker
- [ ] Selecting a session runs `sesh connect` and switches (not stuck at prompt)
- [ ] Empty picker (no selection) returns to prompt cleanly

Closes #106