### PR TITLE
Add sesh install support for Linux (install.sh)

### DIFF
--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -284,6 +284,13 @@ TOOL_doggo_archive_pattern='doggo_${VERSION_NOTAG}_Linux_${ARCH}.tar.gz'
 TOOL_doggo_binary_path='doggo_${VERSION_NOTAG}_Linux_${ARCH}/doggo'
 TOOL_doggo_arch_map='x86_64:x86_64 aarch64:arm64'
 
+TOOL_sesh_check_cmd="sesh"
+TOOL_sesh_method="github_release"
+TOOL_sesh_github_repo="joshmedeski/sesh"
+TOOL_sesh_archive_pattern='sesh_Linux_${ARCH}.tar.gz'
+TOOL_sesh_binary_path='sesh'
+TOOL_sesh_arch_map='x86_64:x86_64 aarch64:arm64'
+
 TOOL_topgrade_check_cmd="topgrade"
 TOOL_topgrade_method="github_release"
 TOOL_topgrade_github_repo="topgrade-rs/topgrade"
@@ -352,7 +359,7 @@ LINUX_TOOL_ORDER=(
   bun starship mise sheldon zoxide atuin dotenvx uv rust lazydocker direnv
   # GitHub releases (no deps)
   fzf fastfetch delta lazygit ghq dops yazi rainfrog typst
-  just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex
+  just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex sesh
   # APT-only (skipped on Alpine)
   gh neovim eza bat postgresql
   # Cargo tools (depend on rust)

--- a/docs/sesh.md
+++ b/docs/sesh.md
@@ -4,7 +4,8 @@
 
 - Plugin: [joshmedeski/sesh](https://github.com/joshmedeski/sesh)
 - Config: `common/sesh/.config/sesh/sesh.toml`
-- Install: `brew "joshmedeski/sesh/sesh"` (Brewfile)
+- Install (Mac): `brew "joshmedeski/sesh/sesh"` (`config/Brewfile`)
+- Install (Linux): `TOOL_sesh_*` in `config/tools.linux.bash` — GitHub release tarball を `~/.local/bin` (NO_SUDO モード) or `/usr/local/bin` に展開
 
 ## 役割分担
 


### PR DESCRIPTION
## Summary

Register sesh in `scripts/linux.sh`'s tool pipeline so `install.sh` on a Linux host (rcon target) also installs sesh. Previously only Mac was covered via the Brewfile entry added in #101.

## Changes

- `config/tools.linux.bash`:
  - `TOOL_sesh_*` (method=`github_release`, repo=`joshmedeski/sesh`)
  - archive pattern `sesh_Linux_${ARCH}.tar.gz`, binary `sesh`
  - arch_map `x86_64:x86_64 aarch64:arm64`
  - Added `sesh` to `LINUX_TOOL_ORDER` in the "GitHub releases (no deps)" section
- `docs/sesh.md`: Install line split into Mac (Brewfile) and Linux (tools.linux.bash) rows

## Stacking

Targets `106-sesh-fixes` (the sesh bugfix branch). Merge order: #101 → #103 → #105 → #107 → **this**.

## Test plan

- [ ] `bash -c 'source config/tools.linux.bash && echo "${LINUX_TOOL_ORDER[@]}"' | grep -w sesh` returns a hit
- [ ] On a Linux x86_64 host, `bash scripts/linux.sh` installs sesh to `$HOME/.local/bin` (NO_SUDO) or `/usr/local/bin`
- [ ] On aarch64, the arm64 tarball is selected correctly

Closes #108