### PR TITLE
Install fzf-tmux on Linux so sesh popup (prefix C-f) works

### DIFF
--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -87,6 +87,14 @@ TOOL_fzf_archive_pattern='fzf-${VERSION_NOTAG}-linux_${ARCH}.tar.gz'
 TOOL_fzf_binary_path='fzf'
 TOOL_fzf_arch_map='x86_64:amd64 aarch64:arm64'
 
+# fzf-tmux は fzf の release tarball に含まれておらず、master ブランチの単体スクリプト。
+# 独立 tool として登録しておくと、fzf が既に入っている環境でも post-add でこれだけ
+# 補完インストールできる (sesh の popup prefix+C-f が依存)。
+TOOL_fzftmux_check_cmd="fzf-tmux"
+TOOL_fzftmux_method="curl_pipe"
+TOOL_fzftmux_depends_on="fzf"
+TOOL_fzftmux_curl_cmd='if [[ "$NO_SUDO" == "true" ]]; then mkdir -p "$HOME/.local/bin"; curl -fsSL https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux -o "$HOME/.local/bin/fzf-tmux" && chmod +x "$HOME/.local/bin/fzf-tmux"; else curl -fsSL https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux -o /tmp/fzf-tmux && $SUDO install -m 0755 /tmp/fzf-tmux /usr/local/bin/fzf-tmux && rm -f /tmp/fzf-tmux; fi'
+
 TOOL_fastfetch_check_cmd="fastfetch"
 TOOL_fastfetch_method="github_release"
 TOOL_fastfetch_github_repo="fastfetch-cli/fastfetch"
@@ -358,7 +366,7 @@ LINUX_TOOL_ORDER=(
   # Infrastructure (no deps)
   bun starship mise sheldon zoxide atuin dotenvx uv rust lazydocker direnv
   # GitHub releases (no deps)
-  fzf fastfetch delta lazygit ghq dops yazi rainfrog typst
+  fzf fzftmux fastfetch delta lazygit ghq dops yazi rainfrog typst
   just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex sesh
   # APT-only (skipped on Alpine)
   gh neovim eza bat postgresql


### PR DESCRIPTION
## Summary

`prefix C-f` が Linux 上で動かない根本原因を修正。fzf の GitHub release tarball には `fzf-tmux` wrapper スクリプトが含まれておらず、sesh popup の内部コマンドが silent fail していた。

## Root cause

```tmux
bind C-f run-shell "sesh connect \"$(... | fzf-tmux -p 80%,70% ...)\""
```
`fzf-tmux` は fzf の `bin/fzf-tmux` にある単体 bash スクリプトで、release tarball には含まれていない。Mac 側は `brew install fzf` で両方入るが、Linux 側は github_release 経由で fzf バイナリのみが入る状態だった。

## Fix

`TOOL_fzftmux_*` を新規ツールとして登録:

- `method=curl_pipe`: `bin/fzf-tmux` を master から直接 curl で取得
- `depends_on=fzf`: fzf より後にインストール
- 配置先: NO_SUDO モードで `$HOME/.local/bin`、それ以外で `/usr/local/bin`
- `LINUX_TOOL_ORDER` の `fzf` 直後に `fzftmux` を追加

独立した tool として扱うことで、既に fzf が入っていても fzf-tmux だけ欠けている環境でも自動補完される。

## Test plan

- [ ] Linux x86_64 host で `bash scripts/linux.sh` 実行後 `command -v fzf-tmux` が真
- [ ] `prefix C-f` で sesh popup が正常に開く (`Ctrl-a/t/g/x/d/f` が効く)
- [ ] fzf が既にインストール済みの環境でも fzf-tmux だけダウンロードされる

Closes #112