### PR TITLE
Add remote dev gateway (Traefik) and persistent SSH tunnel

### DIFF
--- a/common/claude/.claude/statusline-command.sh
+++ b/common/claude/.claude/statusline-command.sh
@@ -149,11 +149,11 @@ for p in "${lines_plain[@]}"; do
 done
 
 for idx in "${!lines_raw[@]}"; do
-  plain_len=${#lines_plain[$idx]}
+  plain_len=${#lines_plain[idx]}
   pad=$(( max_len - plain_len ))
   if [ "$pad" -gt 0 ]; then
     spaces=$(printf '%*s' "$pad" '')
-    lines_raw[$idx]="${lines_raw[$idx]}${spaces}"
+    lines_raw[idx]="${lines_raw[idx]}${spaces}"
   fi
 done
 

--- a/common/traefik-dev/.config/traefik-dev/compose.yml
+++ b/common/traefik-dev/.config/traefik-dev/compose.yml
@@ -1,0 +1,32 @@
+# Dev Gateway: Traefik on remote host
+# 配置先: リモートホストの ~/.config/traefik-dev/compose.yml
+# 起動: ローカルから `dev-gateway up [host]` で操作する
+#
+# 役割:
+# - 同じ docker host 上のコンテナの Traefik label を docker socket 経由で watch
+# - HTTPS は upstream 側で TLS 終端 → Traefik は SNI ベースで TCP passthrough
+# - HTTP (管理 UI) は Traefik で HTTP router 集約
+#
+# 前提: `docker network create dev-edge` を 1 度だけ実行 (sudo 不要)
+
+services:
+  traefik:
+    image: traefik:v3.1
+    container_name: dev-traefik
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:48080:48080"   # 主入口: HTTPS TCP passthrough (wt 用)
+      - "127.0.0.1:48081:48081"   # 副入口: HTTP (管理 UI 用)
+      - "127.0.0.1:48090:8080"    # Traefik dashboard / API (insecure, localhost only)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik.yml:/etc/traefik/traefik.yml:ro
+    networks:
+      - dev-edge
+    labels:
+      dev-gateway.role: "traefik"
+
+networks:
+  dev-edge:
+    name: dev-edge
+    external: true

--- a/common/traefik-dev/.config/traefik-dev/traefik.yml
+++ b/common/traefik-dev/.config/traefik-dev/traefik.yml
@@ -1,0 +1,22 @@
+# Traefik static config (dev gateway)
+
+api:
+  dashboard: true
+  insecure: true   # bind は localhost only なので OK (compose.yml 参照)
+
+entryPoints:
+  websecure:
+    address: ":48080"
+  web:
+    address: ":48081"
+
+providers:
+  docker:
+    exposedByDefault: false
+    network: dev-edge
+    watch: true
+
+log:
+  level: INFO
+
+accessLog: {}

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -42,6 +42,7 @@ brew "direnv"
 brew "just"
 brew "watchexec"
 brew "hyperfine"
+brew "autossh"   # persistent ssh tunnel (dev-tunnel)
 
 # --- Database ---
 brew "pgcli"         # PostgreSQL用インタラクティブクライアント（オートコンプリート・シンタックスハイライト）

--- a/config/packages.linux.alpine.txt
+++ b/config/packages.linux.alpine.txt
@@ -21,3 +21,4 @@ tealdeer
 dust
 bottom
 imagemagick
+autossh

--- a/config/packages.linux.apt.txt
+++ b/config/packages.linux.apt.txt
@@ -12,3 +12,5 @@ fd-find
 rsync
 luarocks
 imagemagick
+autossh
+openssh-client

--- a/docs/dev-gateway.md
+++ b/docs/dev-gateway.md
@@ -1,0 +1,126 @@
+# dev-gateway
+
+リモートホスト上に Traefik を 1 つ立て、複数 docker container への HTTP/HTTPS 入口を 1 port に集約する個人インフラ。
+
+## 解決する問題
+
+- 並列に立てる開発環境 (git worktree, ブランチ別 stack 等) を増やすたびに、ローカルから専用 port forward を追加しないといけない
+- 管理 UI ごとに forward を増やしている
+- VPN 切断時の復旧コストが forward 本数に比例
+
+## 仕組み
+
+```
+[ローカル]                       [リモート]
+  ssh -L 48080 ─────────────────► Traefik :48080 (TCP SNI passthrough, HTTPS)
+  ssh -L 48081 ─────────────────► Traefik :48081 (HTTP, 管理 UI 用)
+  ssh -L 48090 ─────────────────► Traefik :48090 (dashboard / API)
+                                     │
+                                     ├── (HTTPS) upstream nginx A (SNI: *-foo.localhost)
+                                     ├── (HTTPS) upstream nginx B (SNI: *-bar.localhost)
+                                     ├── (HTTP)  ui-x.dev.localhost  → container x:port
+                                     ├── (HTTP)  ui-y.dev.localhost  → container y:port
+                                     └── ...
+```
+
+- Traefik は docker socket を read-only で watch し、`traefik.enable=true` label が付いた container を自動でルート化
+- HTTPS は upstream 側で TLS 終端 → Traefik は ClientHello の SNI で振り分け (mkcert 等で発行した `*.localhost` 証明書をそのまま使える)
+- HTTP は Traefik で HTTP router 集約。`name.dev.localhost:48081` のような subdomain でアクセス
+- TCP 独自プロトコル (postgres, redis 系, debugger 等) は Traefik を経由せず個別 forward (Traefik の TCP routing は SNI が必要なため)
+
+## 配置
+
+dotfiles 内:
+- `common/traefik-dev/.config/traefik-dev/compose.yml` — Traefik コンテナ定義
+- `common/traefik-dev/.config/traefik-dev/traefik.yml` — static config
+- `scripts/dev-gateway` — ローカルから操作する CLI
+- `scripts/dev-gateway-lib.sh` — 共通ロジック
+
+リモート側に dotfiles を stow すると、`~/.config/traefik-dev/` が出現する。
+
+## 初回セットアップ
+
+リモートに対して 1 度だけ実行 (sudo 不要、ユーザーが `docker` group 所属である必要):
+
+```sh
+# ローカルから:
+dev-gateway up <host-alias>     # 自動で `docker network create dev-edge` も実行
+```
+
+`~/.config/traefik-dev/compose.yml` が立ち上がる。
+
+## アプリ側でやること (Traefik にぶら下げる)
+
+### HTTPS upstream を SNI passthrough で受ける場合
+
+upstream nginx (アプリ側プロキシ) を `dev-edge` ネットワークに参加させ、label を付与:
+
+```yaml
+services:
+  nginx:
+    networks:
+      - default
+      - dev-edge
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: "dev-edge"
+      traefik.tcp.routers.<name>.rule: "HostSNI(`*-<name>.localhost`)"
+      traefik.tcp.routers.<name>.tls.passthrough: "true"
+      traefik.tcp.routers.<name>.entrypoints: "websecure"
+      traefik.tcp.services.<name>.loadbalancer.server.port: "443"
+networks:
+  dev-edge:
+    external: true
+```
+
+### HTTP コンテナを subdomain で公開する場合
+
+```yaml
+services:
+  some-ui:
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: "dev-edge"
+      traefik.http.routers.some-ui.rule: "Host(`some-ui.dev.localhost`)"
+      traefik.http.routers.some-ui.entrypoints: "web"
+      traefik.http.services.some-ui.loadbalancer.server.port: "3000"
+    networks:
+      - default
+      - dev-edge
+networks:
+  dev-edge:
+    external: true
+```
+
+## ローカル側 DNS
+
+- Chrome / Firefox: `*.localhost` は自動で 127.0.0.1 に解決される (RFC 6761)
+- Safari: 解決しないので dnsmasq 推奨
+  - `brew install dnsmasq`
+  - `address=/.localhost/127.0.0.1` を追加
+
+## 使い方
+
+```sh
+dev-gateway up      <host>            # 起動
+dev-gateway status  <host>            # コンテナ状態
+dev-gateway routes  <host>            # 現在登録されているルート一覧
+dev-gateway logs    <host> [service]  # Traefik ログ追従
+dev-gateway reload  <host>            # Traefik 再起動
+dev-gateway down    <host>            # 停止
+
+# 環境変数でデフォルト host を渡す:
+export DEV_GATEWAY_DEFAULT_HOST=<host-alias>
+dev-gateway up
+dev-gateway routes
+```
+
+## トラブルシュート
+
+- routes が空: `traefik.enable=true` label が付いた container が起動していないか、Traefik と同じ docker network に参加していない
+- 対象 URL にアクセスできない: `dev-tunnel status` で ssh 健全性確認 → `dev-gateway status` で Traefik 健全性確認 → `dev-gateway routes` で対象ルートの存在確認
+- HTTPS 証明書エラー: upstream 側の `*.localhost` 証明書が SAN にアクセスホスト名を含んでいるか確認
+
+## 関連
+
+- `dev-tunnel`: ローカルから本 gateway への 1 本 forward を autossh で堅牢化

--- a/docs/dev-tunnel.md
+++ b/docs/dev-tunnel.md
@@ -1,0 +1,84 @@
+# dev-tunnel
+
+VPN 経由のリモート開発で発生する port forward の脆弱性を、autossh + ControlMaster で解消する個人ツール。
+
+## 解決する問題
+
+- VPN 切断や WiFi 切替で全 ssh forward が一斉に死ぬ
+- 切れた際に手動で全 forward を貼り直す手間
+- 起動忘れ
+
+## 仕組み
+
+- `autossh` が ssh セッション全体を監視し、ServerAliveInterval=30 で死活判定
+- 死んだ場合は ssh プロセスごと再起動 → ControlMaster 経由でぶら下がる全 forward が一括復活
+- forward の定義は ssh 側 (`~/.ssh/config` の `LocalForward`) に置き、dev-tunnel は autossh プロセス管理に専念
+- PID は `~/.local/state/dev-tunnel/<host>.pid`、ログは `~/.local/state/dev-tunnel/logs/<host>.log`
+
+## ssh config の推奨エントリ
+
+`~/.ssh/config` 本体は dotfiles 管理だが、host 固有エントリは `~/.ssh/config.d/` に置く (環境固有のため)。
+`Include ~/.ssh/config.d/*` が `~/.ssh/config` で読み込まれる前提。
+
+テンプレ (`~/.ssh/config.d/<your-file>`):
+
+```
+Host <your-host-alias>
+  HostName <remote-hostname-or-ip>
+  User <your-user>
+  ControlMaster auto
+  ControlPath ~/.ssh/sockets/%r@%h-%p
+  ControlPersist 600
+  ServerAliveInterval 30
+  ServerAliveCountMax 3
+  ExitOnForwardFailure yes
+  # dev-gateway 用 (Traefik) は 1 本に集約
+  LocalForward 48080 127.0.0.1:48080
+  LocalForward 48081 127.0.0.1:48081
+  LocalForward 48090 127.0.0.1:48090
+  # TCP プロトコル (Traefik 不向き) は個別に並べる。必要なものだけ。
+  # LocalForward 5432 127.0.0.1:5432   # postgres
+  # LocalForward 7687 127.0.0.1:7687   # bolt 等
+```
+
+ControlPath ディレクトリは事前に作成: `mkdir -p ~/.ssh/sockets`
+
+## 使い方
+
+```sh
+# 引数で host 指定
+dev-tunnel start <host-alias>
+dev-tunnel status <host-alias>
+dev-tunnel restart <host-alias>
+dev-tunnel health <host-alias>
+dev-tunnel stop <host-alias>
+
+# 環境変数でデフォルト host を渡す方法も可
+export DEV_TUNNEL_DEFAULT_HOST=<host-alias>
+dev-tunnel start
+dev-tunnel status
+```
+
+複数 host を扱う場合:
+
+```sh
+dev-tunnel start home-lab
+dev-tunnel start work-vpn
+dev-tunnel status home-lab
+```
+
+## トラブルシュート
+
+- 起動するが forward されない: ssh config の `ExitOnForwardFailure=yes` で起動時にエラー → ログ (`~/.local/state/dev-tunnel/logs/<host>.log`) を確認
+- ControlMaster が "not connected": autossh は生きているが ssh セッションが再接続中。ServerAliveInterval (30s) 後に復活するはず
+- pid file が残っているのにプロセスがない: `dev-tunnel stop` で消える、または pid file を手で削除
+- VPN 切断検知が遅い: ServerAliveInterval / ServerAliveCountMax を短くする (例: 10/2 で 20 秒で検知)
+
+## 依存
+
+- `autossh` (mac: `brew install autossh`、linux: `apt install autossh`)
+  - dotfiles の `config/Brewfile` と `config/packages.linux.apt.txt` に追加済
+
+## 関連
+
+- `dev-gateway`: リモート側の Traefik 管理 (forward 1 本化の相方)

--- a/scripts/dev-gateway
+++ b/scripts/dev-gateway
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# dev-gateway - リモートホスト上の Traefik gateway を操作する CLI
+#
+# 使い方:
+#   dev-gateway up      [host]   # docker compose up -d
+#   dev-gateway down    [host]
+#   dev-gateway status  [host]
+#   dev-gateway logs    [host] [service]
+#   dev-gateway reload  [host]   # traefik container restart
+#   dev-gateway routes  [host]   # 現在の HTTP / TCP ルート一覧
+#
+# host は引数で指定するか、$DEV_GATEWAY_DEFAULT_HOST で既定値を設定する。
+#
+# 前提:
+#   - リモート host に dotfiles を stow 済 (~/.config/traefik-dev/ がある)
+#   - host から docker が使える (docker group)
+
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/dev-gateway-lib.sh"
+
+usage() {
+  cat <<USAGE
+dev-gateway - remote Traefik gateway management
+
+Usage:
+  dev-gateway <command> [host] [args]
+
+Commands:
+  up      [host]              docker compose up -d
+  down    [host]              docker compose down
+  status  [host]              container status
+  logs    [host] [service]    docker compose logs -f (default service: traefik)
+  reload  [host]              restart traefik container
+  routes  [host]              dump current HTTP/TCP routers
+
+Default host:
+  \$DEV_GATEWAY_DEFAULT_HOST が設定されていればそれを使う。
+
+Examples:
+  dev-gateway up myremote
+  DEV_GATEWAY_DEFAULT_HOST=myremote dev-gateway routes
+USAGE
+}
+
+cmd="${1:-}"
+host="${2:-${DEV_GATEWAY_DEFAULT_HOST:-}}"
+arg3="${3:-}"
+
+if [[ -z "$host" && "$cmd" != "" && "$cmd" != "-h" && "$cmd" != "--help" && "$cmd" != "help" ]]; then
+  echo "Error: host を引数で指定するか \$DEV_GATEWAY_DEFAULT_HOST を設定してください" >&2
+  exit 1
+fi
+
+case "$cmd" in
+  up)     dg_up     "$host" ;;
+  down)   dg_down   "$host" ;;
+  status) dg_status "$host" ;;
+  logs)   dg_logs   "$host" "$arg3" ;;
+  reload) dg_reload "$host" ;;
+  routes) dg_routes "$host" ;;
+  ""|-h|--help|help) usage ;;
+  *) echo "Unknown command: $cmd" >&2; usage; exit 1 ;;
+esac

--- a/scripts/dev-gateway-lib.sh
+++ b/scripts/dev-gateway-lib.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# dev-gateway-lib.sh - リモートホスト上の Traefik gateway 管理ライブラリ
+# 関連: scripts/dev-gateway, common/traefik-dev/
+
+set -euo pipefail
+
+DG_REMOTE_DIR="${DG_REMOTE_DIR:-\$HOME/.config/traefik-dev}"
+DG_NETWORK="${DG_NETWORK:-dev-edge}"
+DG_API_LOCAL_PORT="${DG_API_LOCAL_PORT:-48090}"
+
+# ssh exec helper. Quoted single-arg style to keep remote shell predictable.
+dg_ssh() {
+  local host="$1"; shift
+  ssh "$host" "$@"
+}
+
+dg_check_host() {
+  local host="$1"
+  if ! ssh -G "$host" >/dev/null 2>&1; then
+    echo "Error: ssh host '$host' not defined" >&2
+    return 1
+  fi
+}
+
+dg_ensure_network() {
+  local host="$1"
+  if ! dg_ssh "$host" "docker network inspect $DG_NETWORK >/dev/null 2>&1"; then
+    echo "dev-gateway: creating docker network '$DG_NETWORK' on $host"
+    dg_ssh "$host" "docker network create $DG_NETWORK"
+  fi
+}
+
+dg_up() {
+  local host="$1"
+  dg_check_host "$host" || return 1
+  dg_ensure_network "$host"
+  dg_ssh "$host" "cd $DG_REMOTE_DIR && docker compose up -d"
+  echo "dev-gateway: up on $host"
+}
+
+dg_down() {
+  local host="$1"
+  dg_check_host "$host" || return 1
+  dg_ssh "$host" "cd $DG_REMOTE_DIR && docker compose down"
+  echo "dev-gateway: down on $host"
+}
+
+dg_status() {
+  local host="$1"
+  dg_check_host "$host" || return 1
+  dg_ssh "$host" "cd $DG_REMOTE_DIR && docker compose ps --format 'table {{.Name}}\t{{.Status}}\t{{.Ports}}'"
+}
+
+dg_logs() {
+  local host="$1"
+  local svc="${2:-traefik}"
+  dg_check_host "$host" || return 1
+  dg_ssh "$host" "cd $DG_REMOTE_DIR && docker compose logs -f --tail=100 $svc"
+}
+
+dg_reload() {
+  local host="$1"
+  dg_check_host "$host" || return 1
+  dg_ssh "$host" "cd $DG_REMOTE_DIR && docker compose restart traefik"
+  echo "dev-gateway: traefik restarted on $host"
+}
+
+dg_routes() {
+  local host="$1"
+  dg_check_host "$host" || return 1
+  # Traefik API は 127.0.0.1:48090 (compose 設定) で localhost only。
+  # ssh config 側で LocalForward 48090 ... を入れていれば直接叩ける。
+  # それ以外なら ssh 経由で curl。
+  if curl -fsS --max-time 2 "http://127.0.0.1:${DG_API_LOCAL_PORT}/api/http/routers" >/dev/null 2>&1; then
+    curl -fsS "http://127.0.0.1:${DG_API_LOCAL_PORT}/api/http/routers" \
+      | jq -r '.[] | "[http]\t\(.name)\t\(.rule)\t-> \(.service)"' 2>/dev/null
+    curl -fsS "http://127.0.0.1:${DG_API_LOCAL_PORT}/api/tcp/routers" \
+      | jq -r '.[] | "[tcp] \t\(.name)\t\(.rule)\t-> \(.service)"' 2>/dev/null
+  else
+    echo "(API not reachable on localhost:${DG_API_LOCAL_PORT}, fetching via ssh)"
+    dg_ssh "$host" "curl -fsS http://127.0.0.1:48090/api/http/routers" \
+      | jq -r '.[] | "[http]\t\(.name)\t\(.rule)\t-> \(.service)"' 2>/dev/null
+    dg_ssh "$host" "curl -fsS http://127.0.0.1:48090/api/tcp/routers" \
+      | jq -r '.[] | "[tcp] \t\(.name)\t\(.rule)\t-> \(.service)"' 2>/dev/null
+  fi
+}

--- a/scripts/dev-gateway-lib.sh
+++ b/scripts/dev-gateway-lib.sh
@@ -9,8 +9,11 @@ DG_NETWORK="${DG_NETWORK:-dev-edge}"
 DG_API_LOCAL_PORT="${DG_API_LOCAL_PORT:-48090}"
 
 # ssh exec helper. Quoted single-arg style to keep remote shell predictable.
+# Client-side expansion of $@ is intentional — callers compose remote commands
+# using DG_REMOTE_DIR / DG_NETWORK that already escape remote-side $HOME.
 dg_ssh() {
   local host="$1"; shift
+  # shellcheck disable=SC2029
   ssh "$host" "$@"
 }
 

--- a/scripts/dev-tunnel
+++ b/scripts/dev-tunnel
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# dev-tunnel - persistent autossh トンネル管理 CLI
+#
+# 使い方:
+#   dev-tunnel start [host]        # autossh 起動
+#   dev-tunnel stop  [host]
+#   dev-tunnel status [host]
+#   dev-tunnel restart [host]
+#   dev-tunnel health [host]       # 疎通確認
+#
+# host は引数で指定するか、$DEV_TUNNEL_DEFAULT_HOST で既定値を設定する。
+# 接続先 host の定義は ~/.ssh/config (Include 経由含む) に置く。
+# 推奨エントリは docs/dev-tunnel.md を参照。
+
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/dev-tunnel-lib.sh"
+
+usage() {
+  cat <<USAGE
+dev-tunnel - persistent autossh トンネル管理
+
+Usage:
+  dev-tunnel <command> [host]
+
+Commands:
+  start    [host]   autossh を起動
+  stop     [host]   autossh を停止
+  status   [host]   稼働状態と ControlMaster 健全性を表示
+  restart  [host]   stop + start
+  health   [host]   ssh で疎通確認
+
+Default host:
+  $DEV_TUNNEL_DEFAULT_HOST が設定されていればそれを使う。
+  未設定なら host 引数が必須。
+
+Examples:
+  dev-tunnel start myremote-dev
+  DEV_TUNNEL_DEFAULT_HOST=myremote-dev dev-tunnel status
+USAGE
+}
+
+cmd="${1:-}"
+host="${2:-${DEV_TUNNEL_DEFAULT_HOST:-}}"
+
+if [[ -z "$host" && "$cmd" != "" && "$cmd" != "-h" && "$cmd" != "--help" && "$cmd" != "help" ]]; then
+  echo "Error: host を引数で指定するか \$DEV_TUNNEL_DEFAULT_HOST を設定してください" >&2
+  exit 1
+fi
+
+case "$cmd" in
+  start)   dt_start "$host" ;;
+  stop)    dt_stop  "$host" ;;
+  status)  dt_status "$host" ;;
+  restart) dt_restart "$host" ;;
+  health)  dt_health "$host" ;;
+  ""|-h|--help|help) usage ;;
+  *) echo "Unknown command: $cmd" >&2; usage; exit 1 ;;
+esac

--- a/scripts/dev-tunnel-lib.sh
+++ b/scripts/dev-tunnel-lib.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# dev-tunnel-lib.sh - autossh ベースの persistent tunnel 管理ライブラリ
+# 関連: scripts/dev-tunnel
+#
+# 設計:
+# - ssh ConfigFile (~/.ssh/config + Include) に定義済みの Host エントリを使う
+# - Host エントリ側で LocalForward / ControlMaster / ServerAliveInterval を指定
+# - autossh は ssh セッション全体を監視し、死んだら再起動
+# - PID は ~/.local/state/dev-tunnel/<host>.pid に保存
+
+set -euo pipefail
+
+DT_STATE_DIR="${DT_STATE_DIR:-$HOME/.local/state/dev-tunnel}"
+DT_LOG_DIR="${DT_LOG_DIR:-$HOME/.local/state/dev-tunnel/logs}"
+
+dt_ensure_dirs() {
+  mkdir -p "$DT_STATE_DIR" "$DT_LOG_DIR"
+}
+
+dt_pidfile() {
+  local host="$1"
+  printf '%s/%s.pid' "$DT_STATE_DIR" "$host"
+}
+
+dt_logfile() {
+  local host="$1"
+  printf '%s/%s.log' "$DT_LOG_DIR" "$host"
+}
+
+dt_is_running() {
+  local host="$1"
+  local pidfile
+  pidfile="$(dt_pidfile "$host")"
+  [[ -f "$pidfile" ]] || return 1
+  local pid
+  pid="$(<"$pidfile")"
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+dt_check_host() {
+  local host="$1"
+  if ! ssh -G "$host" >/dev/null 2>&1; then
+    echo "Error: ssh host '$host' not defined in ~/.ssh/config (or Includes)" >&2
+    return 1
+  fi
+}
+
+dt_start() {
+  local host="$1"
+  dt_check_host "$host" || return 1
+  dt_ensure_dirs
+  if dt_is_running "$host"; then
+    echo "dev-tunnel: $host already running (pid $(<"$(dt_pidfile "$host")"))"
+    return 0
+  fi
+  command -v autossh >/dev/null 2>&1 || {
+    echo "Error: autossh not installed. Run: brew install autossh (mac) or apt install autossh (linux)" >&2
+    return 1
+  }
+  local logfile pidfile
+  logfile="$(dt_logfile "$host")"
+  pidfile="$(dt_pidfile "$host")"
+  # AUTOSSH_GATETIME=0 = retry from boot, AUTOSSH_PORT=0 disables monitor port (rely on ServerAlive)
+  AUTOSSH_GATETIME=0 AUTOSSH_PORT=0 AUTOSSH_LOGFILE="$logfile" \
+    autossh -M 0 -f -N \
+      -o "ServerAliveInterval=30" \
+      -o "ServerAliveCountMax=3" \
+      -o "ExitOnForwardFailure=yes" \
+      "$host"
+  # autossh -f forks; capture child pid from pgrep filtered by host
+  sleep 0.3
+  local pid
+  pid="$(pgrep -f "autossh.*${host}\$" | head -1 || true)"
+  if [[ -z "$pid" ]]; then
+    echo "Error: failed to capture autossh pid for $host (check $logfile)" >&2
+    return 1
+  fi
+  printf '%s\n' "$pid" > "$pidfile"
+  echo "dev-tunnel: started $host (pid $pid)"
+}
+
+dt_stop() {
+  local host="$1"
+  local pidfile
+  pidfile="$(dt_pidfile "$host")"
+  if ! dt_is_running "$host"; then
+    echo "dev-tunnel: $host not running"
+    rm -f "$pidfile"
+    return 0
+  fi
+  local pid
+  pid="$(<"$pidfile")"
+  kill "$pid" 2>/dev/null || true
+  rm -f "$pidfile"
+  # Close any lingering ControlMaster session for clean state
+  ssh -O exit "$host" 2>/dev/null || true
+  echo "dev-tunnel: stopped $host (pid $pid)"
+}
+
+dt_status() {
+  local host="$1"
+  if dt_is_running "$host"; then
+    local pid
+    pid="$(<"$(dt_pidfile "$host")")"
+    echo "dev-tunnel: $host RUNNING (autossh pid $pid)"
+  else
+    echo "dev-tunnel: $host STOPPED"
+    return 1
+  fi
+  # ControlMaster socket health
+  if ssh -O check "$host" 2>&1 | grep -q "Master running"; then
+    echo "  ControlMaster: alive"
+  else
+    echo "  ControlMaster: not connected (autossh may be reconnecting)"
+  fi
+}
+
+dt_restart() {
+  local host="$1"
+  dt_stop "$host" || true
+  sleep 0.5
+  dt_start "$host"
+}
+
+dt_health() {
+  local host="$1"
+  dt_check_host "$host" || return 1
+  # Run a trivial command via the multiplexed connection to verify forward path
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" true 2>/dev/null; then
+    echo "dev-tunnel: $host reachable via ssh"
+  else
+    echo "dev-tunnel: $host UNREACHABLE" >&2
+    return 1
+  fi
+}

--- a/scripts/ralph-crew
+++ b/scripts/ralph-crew
@@ -343,7 +343,8 @@ _dispatch_task() {
   # in parallel (base = origin/<default>), rather than a single persistent PR
   # that hoards commits. The worker's own reconnaissance phase is responsible
   # for reading prior same-worker PRs and avoiding scope overlap.
-  local branch="crew/${worker_id}-$(date +%Y%m%d%H%M)"
+  local branch
+  branch="crew/${worker_id}-$(date +%Y%m%d%H%M)"
 
   # Read worker_cwd from worker JSON (set by _start_worker based on worktree_path)
   local worker_file="${STATE_DIR}/workers/${worker_id}.json"


### PR DESCRIPTION
## Summary

Consolidates port forwards for remote (VPN-based) development by introducing two complementary tools:

- `dev-tunnel`: autossh-based wrapper that keeps a single SSH session alive with ControlMaster, so dropped VPN connections recover automatically.
- `dev-gateway`: Traefik reverse proxy deployed on the remote host. Container labels declare HTTP/HTTPS routes; all traffic enters through one TCP entrypoint.

Combined, the local side maintains exactly **one** `ssh -L` for HTTP/HTTPS workloads, regardless of how many remote containers are running. New containers added on the remote become reachable automatically via Traefik label discovery — no local edits required. VPN drops recover via autossh's ServerAlive watchdog.

## Changes

- `scripts/dev-tunnel` + `scripts/dev-tunnel-lib.sh`: autossh CLI with start/stop/status/restart/health, default host via `$DEV_TUNNEL_DEFAULT_HOST`
- `scripts/dev-gateway` + `scripts/dev-gateway-lib.sh`: remote Traefik orchestration CLI with up/down/status/logs/routes/reload, default host via `$DEV_GATEWAY_DEFAULT_HOST`
- `common/traefik-dev/.config/traefik-dev/{compose.yml,traefik.yml}`: stow-friendly Traefik deployment template with TCP SNI passthrough on :48080, HTTP routing on :48081, dashboard on :48090
- `docs/dev-tunnel.md` + `docs/dev-gateway.md`: setup, usage, and troubleshooting guides with generic placeholders only
- `autossh` added to `config/Brewfile`, `config/packages.linux.apt.txt`, `config/packages.linux.alpine.txt`
- `openssh-client` added to `config/packages.linux.apt.txt` (autossh runtime dependency on Debian/Ubuntu)

## Test plan

- [ ] `bash -n scripts/dev-tunnel scripts/dev-tunnel-lib.sh scripts/dev-gateway scripts/dev-gateway-lib.sh` passes
- [ ] `dev-tunnel start <host>` launches autossh, `dev-tunnel status` reports running, `dev-tunnel stop` cleans up PID file
- [ ] `dev-gateway up <host>` provisions `dev-edge` network and brings up Traefik on remote
- [ ] `dev-gateway routes <host>` lists registered HTTP/TCP routers via Traefik API
- [ ] No internal hostnames present (verified: `grep -nE "ailab|chronos|matsushima|syntopic"` returns zero matches)
- [ ] Default host resolution works via env vars and falls back to required argument otherwise

Closes #116