### PR TITLE
Fix wt-traefik-up: pass -p and --no-deps to compose overlay

### DIFF
--- a/scripts/wt-traefik-up
+++ b/scripts/wt-traefik-up
@@ -140,9 +140,12 @@ YAML
 echo "[wt-traefik-up] Wrote ${overlay}"
 
 # --- Recreate nginx with overlay (only nginx is affected; web/bff stay) ---
+# Project name must match wt-up.sh (`wt-<name>`); without -p the parent directory
+# name is used and compose treats existing containers as foreign, then trips on
+# container_name conflicts. --no-deps keeps web/bff untouched.
 cd "$compose_dir"
 echo "[wt-traefik-up] Recreating nginx with Traefik overlay..."
-docker compose -f compose.yml -f compose.traefik.yml up -d nginx
+docker compose -p "wt-${wt_name}" -f compose.yml -f compose.traefik.yml up -d --no-deps nginx
 
 cat <<INFO
 


### PR DESCRIPTION
## Summary

Fixes a runtime bug discovered during end-to-end verification of `wt-traefik-up`. The overlay step (`docker compose -f compose.yml -f compose.traefik.yml up -d nginx`) failed with `container_name is already in use` because:

1. Without `-p`, compose derived the project name from the parent directory (e.g. `bff-startup-stability`), which differs from `wt-up.sh`'s `wt-bff-startup-stability`. Compose then treated the already-running containers as foreign and tried to create new ones with the same `container_name:`, crashing on the conflict.
2. Even with `-p`, recreating `nginx` would also touch `web` (and any other deps) without `--no-deps`, causing transient downtime / config-hash recomputes for unrelated services.

## Changes

- `scripts/wt-traefik-up`: add `-p "wt-${wt_name}"` and `--no-deps` to the overlay `docker compose up`.

## Verification

End-to-end test against `bff-startup-stability` worktree:

- Traefik registered route: `wt-bff-startup-stability@docker [enabled]`
- nginx attached to `dev-edge` network with merged Traefik labels (existing `syntopic.wt.*` labels preserved)
- Mac `curl https://app-bff-startup-stability.localhost:48080/` returns `HTTP 200` in 320ms (SynTopic SSR HTML, 7350 bytes)
- Path: ssh forward 48080 -> Traefik -> SNI passthrough -> wt-nginx -> Vite SSR

## Test plan

- [x] `bash -n` and `shellcheck` pass
- [x] End-to-end verified against an active wt
- [x] Subsequent runs of `wt-traefik-up <wt>` no longer trip on container_name conflict