### PR TITLE
Sync tmux popup clipboard via OS-direct copy + lemonade relay

### DIFF
--- a/common/lazygit/.config/lazygit/config.yml
+++ b/common/lazygit/.config/lazygit/config.yml
@@ -20,3 +20,6 @@ refresher:
   refreshInterval: 3
 os:
   editCommand: "nvim"
+  # tmux popup 内で起動されるため OSC52 では host clipboard に届かない。
+  # OS 判定 wrapper 経由で pbcopy/lemonade/wl-copy/xclip を直接呼ぶ。
+  copyToClipboardCmd: '~/dotfiles/scripts/clipboard-copy'

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -39,7 +39,8 @@ bind v copy-mode
 
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'C-v' send -X rectangle-toggle
-bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
+# y: pipe to OS-aware clipboard wrapper (popup OSC52 を回避するため pbcopy/lemonade/wl-copy/xclip 直接呼出)
+bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel "~/dotfiles/scripts/clipboard-copy"
 bind-key -T copy-mode-vi Enter send-keys -X cancel
 bind-key -T copy-mode-vi Escape send-keys -X cancel
 # スクロール量を4行に変更（デフォルトは半ページ）
@@ -49,7 +50,7 @@ bind-key -T copy-mode-vi C-d send-keys -X scroll-down \; send-keys -X scroll-dow
 bind-key -T copy-mode-vi u send-keys -X halfpage-up
 bind-key -T copy-mode-vi d send-keys -X halfpage-down
 # Mouse drag: auto-copy to clipboard, exit copy-mode and scroll to bottom
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/dotfiles/scripts/clipboard-copy"
 set -g base-index 1
 setw -g pane-base-index 1
 set -s escape-time 0

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -44,6 +44,7 @@ brew "just"
 brew "watchexec"
 brew "hyperfine"
 brew "autossh"   # persistent ssh tunnel (dev-tunnel)
+# lemonade は brew formula 未提供。github release から install (scripts/mac.sh の install_lemonade)
 
 # --- Database ---
 brew "pgcli"         # PostgreSQL用インタラクティブクライアント（オートコンプリート・シンタックスハイライト）

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -335,6 +335,19 @@ TOOL_rainfrog_archive_pattern='rainfrog-${VERSION}-${ARCH}-unknown-linux-musl.ta
 TOOL_rainfrog_binary_path='rainfrog'
 TOOL_rainfrog_arch_map='x86_64:x86_64 aarch64:aarch64'
 
+# remote → host clipboard relay (tmux popup OSC52 不能対策)
+# 用途: SSH 接続元 (mac) で lemonade-server 起動 + 接続時 RemoteForward 2489
+# → remote 側で `lemonade copy` 実行で host clipboard に届く。
+# clipboard-copy wrapper が SSH session を検出してこれを呼び出す。
+# 注: upstream に arm64 binary なし (v1.1.1 は amd64/386 のみ)。
+# arm64 環境では go install での self-build が必要 (本 tool は skip される)。
+TOOL_lemonade_check_cmd="lemonade"
+TOOL_lemonade_method="github_release"
+TOOL_lemonade_github_repo="lemonade-command/lemonade"
+TOOL_lemonade_archive_pattern='lemonade_linux_${ARCH}.tar.gz'
+TOOL_lemonade_binary_path='lemonade'
+TOOL_lemonade_arch_map='x86_64:amd64'
+
 # ════════════════════════════════════════
 # APT repo installs (Debian/Ubuntu only)
 # ════════════════════════════════════════
@@ -375,7 +388,7 @@ LINUX_TOOL_ORDER=(
   bun starship mise sheldon zoxide atuin dotenvx uv rust lazydocker direnv
   # GitHub releases (no deps)
   fzf fzftmux fastfetch delta lazygit ghq dops yazi rainfrog typst
-  just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex sesh rtk
+  just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex sesh rtk lemonade
   # APT-only (skipped on Alpine)
   gh neovim eza bat postgresql
   # Cargo tools (depend on rust)

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -1,0 +1,91 @@
+# Clipboard 統合
+
+tmux popup (`display-popup -E`) 内の copy 操作を host (mac) clipboard に
+同期させる仕組み。tmux 3.6 の既知挙動として popup pty からの OSC52 escape
+sequence は outer terminal に転送されないため、OSC52 に依存しない経路を
+用意する。
+
+## 構成要素
+
+| 要素 | 役割 | 配置 |
+|------|------|------|
+| `scripts/clipboard-copy` | OS判定 wrapper。stdin → clipboard | host / remote 両方 |
+| `tmux.conf` | copy-mode-vi `y` / mouse drag を `copy-pipe-and-cancel` で wrapper に流す | host / remote 両方 |
+| `lazygit/config.yml` | `os.copyToClipboardCmd` で wrapper を呼ぶ | host / remote 両方 |
+| `lemonade` | remote 側 → host 側 clipboard へ TCP relay | mac (server) + linux remote (client) |
+| `mac/ssh/config` | `RemoteForward 2489` で remote → mac 接続を逆 forward | host のみ |
+| `templates/com.user.lemonade.plist` | mac 側で lemonade-server 常駐 | host のみ |
+
+## 解決順序 (clipboard-copy 内)
+
+1. macOS → `pbcopy`
+2. SSH session かつ `lemonade` あり → `lemonade copy`
+3. Wayland → `wl-copy`
+4. X11 → `xclip` / `xsel`
+5. fallback OSC52 (popup では効かないが pane では機能)
+
+## セットアップ
+
+### macOS (host)
+
+```bash
+cd ~/dotfiles && ./scripts/mac.sh
+# install_lemonade が以下を実行:
+#   - lemonade を ~/.local/bin に配置
+#   - launchd で com.user.lemonade を bootstrap (port 2489 listen)
+```
+
+確認:
+
+```bash
+lsof -i :2489          # lemonade-server がリッスン中か
+launchctl list | grep lemonade
+```
+
+### Linux remote
+
+```bash
+cd ~/dotfiles && ./install.sh
+# tools.linux.bash に lemonade 登録済み (LINUX_TOOL_ORDER) →
+# github_release tarball から ~/.local/bin/lemonade に install。
+# 注: x86_64 のみ自動 install (upstream に linux_arm64 binary なし)。
+#     arm64 環境では `go install github.com/lemonade-command/lemonade@latest`
+#     で self-build してください。
+```
+
+### SSH 接続
+
+`mac/ssh/.ssh/config` に `Host *` ブロックで `RemoteForward 2489 localhost:2489`
+を設定済み。任意のリモートに ssh するだけで自動的に逆フォワードされる。
+
+確認:
+
+```bash
+# mac → remote
+ssh user@remote
+# remote 側で:
+ss -tln | grep 2489    # 2489 が remote 上で listen 中
+echo hello | lemonade copy
+# mac 側で確認:
+pbpaste                # → "hello"
+```
+
+## tmux popup での挙動
+
+| 場面 | 経路 | 結果 |
+|------|------|------|
+| 通常 pane で `y` (mac) | wrapper → pbcopy | host clipboard |
+| 通常 pane で `y` (remote) | wrapper → lemonade copy → 2489 → mac pbcopy | host clipboard |
+| popup 内 lazygit の copy (mac) | lazygit → wrapper → pbcopy | host clipboard |
+| popup 内 lazygit の copy (remote) | lazygit → wrapper → lemonade copy → mac | host clipboard |
+| popup 内 nested tmux scratch の `y` (mac) | inner tmux → wrapper → pbcopy | host clipboard |
+| popup 内 nested tmux scratch の `y` (remote) | inner tmux → wrapper → lemonade copy → mac | host clipboard |
+
+## トラブルシューティング
+
+- mac で `pbpaste` が変わらない → `launchctl list com.user.lemonade` 確認、
+  `tail -f /tmp/lemonade.err`
+- remote で `lemonade copy` が `connection refused` → SSH の `-R 2489` が効いて
+  いない (sshd `AllowTcpForwarding yes` 必要)
+- lazygit でコピーされない → `~/.config/lazygit/config.yml` の
+  `os.copyToClipboardCmd` が wrapper になっているか確認

--- a/mac/ssh/.ssh/config
+++ b/mac/ssh/.ssh/config
@@ -3,6 +3,12 @@
 # Settings > Developer > SSH Agent
 Host *
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+  # Lemonade clipboard relay: remote の `lemonade copy` を host (mac) の
+  # lemonade-server (port 2489) に届ける逆フォワード。
+  # tmux popup OSC52 不能対策 (clipboard-copy wrapper が SSH session 検出時に呼出)。
+  # mac 側で lemonade-server 起動が前提 (`lemonade server &` または launchd)。
+  # remote に lemonade 未 install でも害なし (port listen されないだけ)。
+  RemoteForward 2489 localhost:2489
 
 # Include local host configs (not in dotfiles)
 Include ~/.ssh/config.d/*

--- a/scripts/clipboard-copy
+++ b/scripts/clipboard-copy
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# clipboard-copy — read stdin, send to host system clipboard.
+#
+# Bypasses the tmux display-popup OSC52 limitation: tmux 3.6 does not relay
+# OSC52 escape sequences from popup ptys to the outer terminal, so a popup
+# (lazygit / nested scratch tmux / etc.) cannot reach the host clipboard via
+# OSC52 alone. This wrapper picks an OS-direct copy command instead.
+#
+# Resolution order:
+#   1. macOS  -> pbcopy
+#   2. SSH session + lemonade present -> lemonade copy
+#      (lemonade-server on the SSH client side relays to host clipboard
+#      via reverse port-forward; required for remote linux popups -> mac)
+#   3. Wayland -> wl-copy
+#   4. X11    -> xclip / xsel
+#   5. fallback OSC52 (works in regular pane only — popup will silently no-op)
+
+set -euo pipefail
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  exec pbcopy
+fi
+
+if [[ -n "${SSH_CONNECTION:-}${SSH_CLIENT:-}${SSH_TTY:-}" ]] && command -v lemonade >/dev/null 2>&1; then
+  exec lemonade copy
+fi
+
+if [[ -n "${WAYLAND_DISPLAY:-}" ]] && command -v wl-copy >/dev/null 2>&1; then
+  exec wl-copy
+fi
+
+if [[ -n "${DISPLAY:-}" ]]; then
+  if command -v xclip >/dev/null 2>&1; then
+    exec xclip -selection clipboard
+  fi
+  if command -v xsel >/dev/null 2>&1; then
+    exec xsel --clipboard --input
+  fi
+fi
+
+data=$(base64 | tr -d '\n')
+printf '\033]52;c;%s\033\\' "$data"

--- a/scripts/clipboard-copy
+++ b/scripts/clipboard-copy
@@ -39,4 +39,4 @@ if [[ -n "${DISPLAY:-}" ]]; then
 fi
 
 data=$(base64 | tr -d '\n')
-printf '\033]52;c;%s\033\\' "$data"
+printf '\033]52;c;%s\033\134' "$data"

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -222,6 +222,45 @@ install_cargo_update() {
   log_success "cargo-update installed"
 }
 
+install_lemonade() {
+  if command_exists lemonade; then
+    log_success "lemonade already installed"
+    return
+  fi
+
+  log_info "Installing lemonade (clipboard relay server)..."
+  mkdir -p "$HOME/.local/bin"
+
+  local arch tarball
+  arch=$(uname -m)
+  if [[ "$arch" == "arm64" ]]; then
+    log_warn "lemonade upstream has no darwin_arm64 binary; skipping (build from source via go install if needed)"
+    return
+  fi
+  tarball="lemonade_darwin_amd64.tar.gz"
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  curl -fsSL "https://github.com/lemonade-command/lemonade/releases/latest/download/${tarball}" \
+    -o "$tmpdir/lemonade.tar.gz"
+  tar -xzf "$tmpdir/lemonade.tar.gz" -C "$tmpdir"
+  mv "$tmpdir/lemonade" "$HOME/.local/bin/lemonade"
+  chmod +x "$HOME/.local/bin/lemonade"
+  rm -rf "$tmpdir"
+  log_success "lemonade installed to ~/.local/bin"
+
+  # launchd: lemonade-server を常駐 (port 2489 で listen)
+  local plist_src="$DOTFILES_DIR/templates/com.user.lemonade.plist"
+  local plist_dst="$HOME/Library/LaunchAgents/com.user.lemonade.plist"
+  if [[ -f "$plist_src" ]]; then
+    mkdir -p "$HOME/Library/LaunchAgents"
+    sed "s|__HOME__|$HOME|g" "$plist_src" > "$plist_dst"
+    launchctl bootout "gui/$(id -u)/com.user.lemonade" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$plist_dst"
+    log_success "lemonade-server launched via launchd (com.user.lemonade)"
+  fi
+}
+
 install_gh_extensions() {
   if ! command_exists gh; then
     log_warn "gh CLI not found, skipping gh extensions"
@@ -291,6 +330,7 @@ configure_claude_remote_control_autostart
 install_dops
 install_quay
 install_cargo_update
+install_lemonade
 install_gh_extensions
 link_ai_scripts
 set_default_shell

--- a/templates/com.user.lemonade.plist
+++ b/templates/com.user.lemonade.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.lemonade</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/.local/bin/lemonade</string>
+        <string>server</string>
+        <string>--allow=127.0.0.1/32</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/tmp/lemonade.err</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/lemonade.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Fixes tmux 3.6 display-popup OSC52 limitation by routing copy operations through OS-specific clipboard commands instead of relying on escape sequences that don't propagate from popup ptys. Includes lemonade relay for remote systems to copy to the macOS host clipboard.

## Changes

- **clipboard-copy wrapper script** (`scripts/clipboard-copy`)
  - Detects OS and context (SSH, Wayland, X11)
  - Routes to: pbcopy (macOS) → lemonade (SSH+remote) → wl-copy (Wayland) → xclip/xsel (X11) → OSC52 fallback
  
- **tmux integration** (`common/tmux/.config/tmux/tmux.conf`)
  - copy-mode-vi `y` binding: routes through wrapper
  - mouse drag binding: routes through wrapper

- **lazygit integration** (`common/lazygit/.config/lazygit/config.yml`)
  - `copyToClipboardCmd` points to wrapper (critical for popup usage)

- **macOS lemonade setup** (`scripts/mac.sh`, `templates/com.user.lemonade.plist`)
  - install_lemonade() downloads binary from GitHub releases (x86_64 only)
  - LaunchAgent bootstrap keeps server running on port 2489
  - SSH config auto-applies `RemoteForward 2489 localhost:2489` to all hosts

- **Linux lemonade support** (`config/tools.linux.bash`)
  - Added to LINUX_TOOL_ORDER for automatic install.sh execution
  - x86_64 only (upstream has no arm64 binary)

- **Documentation** (`docs/clipboard.md`)
  - Problem statement, architecture, setup procedures, behavior matrix, troubleshooting

## Test plan

- [ ] macOS: copy in tmux pane → `pbpaste` shows copied text
- [ ] macOS: copy in tmux popup (lazygit) → `pbpaste` shows copied text
- [ ] macOS: verify `lsof -i :2489` shows lemonade-server listening
- [ ] Remote SSH: verify `ss -tln | grep 2489` shows port listening after ssh connection
- [ ] Remote SSH: `echo hello | lemonade copy` → `pbpaste` on macOS shows "hello"
- [ ] Remote: `install.sh` installs lemonade on x86_64, skips arm64 gracefully

Closes #127