### PR TITLE
chore: Disable claude-mem stop hook

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -456,11 +456,42 @@ install_claude_mem() {
 
   if [[ -f "$HOME/.claude-mem/settings.json" ]]; then
     log_success "claude-mem already installed"
+  else
+    log_info "Installing claude-mem..."
+    npx -y claude-mem install
+  fi
+
+  disable_claude_mem_stop_hook
+}
+
+disable_claude_mem_stop_hook() {
+  if ! command_exists jq; then
+    log_warn "jq not found, skipping claude-mem Stop hook patch"
     return
   fi
 
-  log_info "Installing claude-mem..."
-  npx -y claude-mem install
+  local patched=false
+  local hooks_json
+  for hooks_json in "$HOME"/.claude/plugins/cache/thedotmack/claude-mem/*/hooks/hooks.json; do
+    [[ -f "$hooks_json" ]] || continue
+
+    if [[ "$(jq -r 'has("hooks") and (.hooks | has("Stop"))' "$hooks_json" 2>/dev/null)" != "true" ]]; then
+      continue
+    fi
+
+    local tmp="${hooks_json}.tmp.$$"
+    if jq 'del(.hooks.Stop)' "$hooks_json" > "$tmp" && mv "$tmp" "$hooks_json"; then
+      log_success "Disabled claude-mem Stop hook: $hooks_json"
+      patched=true
+    else
+      rm -f "$tmp"
+      log_warn "Failed to patch claude-mem Stop hook: $hooks_json"
+    fi
+  done
+
+  if [[ "$patched" == "false" ]]; then
+    log_success "claude-mem Stop hook already disabled"
+  fi
 }
 
 install_genshijin() {

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -50,11 +50,42 @@ install_claude_mem() {
 
   if [[ -f "$HOME/.claude-mem/settings.json" ]]; then
     log_success "claude-mem already installed"
+  else
+    log_info "Installing claude-mem..."
+    npx -y claude-mem install
+  fi
+
+  disable_claude_mem_stop_hook
+}
+
+disable_claude_mem_stop_hook() {
+  if ! command_exists jq; then
+    log_warn "jq not found, skipping claude-mem Stop hook patch"
     return
   fi
 
-  log_info "Installing claude-mem..."
-  npx -y claude-mem install
+  local patched=false
+  local hooks_json
+  for hooks_json in "$HOME"/.claude/plugins/cache/thedotmack/claude-mem/*/hooks/hooks.json; do
+    [[ -f "$hooks_json" ]] || continue
+
+    if [[ "$(jq -r 'has("hooks") and (.hooks | has("Stop"))' "$hooks_json" 2>/dev/null)" != "true" ]]; then
+      continue
+    fi
+
+    local tmp="${hooks_json}.tmp.$$"
+    if jq 'del(.hooks.Stop)' "$hooks_json" > "$tmp" && mv "$tmp" "$hooks_json"; then
+      log_success "Disabled claude-mem Stop hook: $hooks_json"
+      patched=true
+    else
+      rm -f "$tmp"
+      log_warn "Failed to patch claude-mem Stop hook: $hooks_json"
+    fi
+  done
+
+  if [[ "$patched" == "false" ]]; then
+    log_success "claude-mem Stop hook already disabled"
+  fi
 }
 
 install_genshijin() {


### PR DESCRIPTION
## 実装内容
- Linux/macOS の dotfiles install で、claude-mem インストール後に Stop hook だけを削除する post-install patch を追加
- claude-mem が既にインストール済みの場合も、install script 再実行で patch が再適用されるように変更

## 技術詳細
- `~/.claude/plugins/cache/thedotmack/claude-mem/*/hooks/hooks.json` を探索し、`jq 'del(.hooks.Stop)'` で Stop/summarize hook のみ削除
- `SessionStart` / `UserPromptSubmit` / `PostToolUse` / `PreToolUse` / `SessionEnd` は維持
- `jq` がない環境では warning を出して skip

## 検証
- `bash -n scripts/linux.sh`
- `bash -n scripts/mac.sh`
- `git diff --check -- scripts/linux.sh scripts/mac.sh`
- 現環境の claude-mem hook manifest で `.hooks.Stop = false` を確認