### PR TITLE
feat(claude): add d-grill-me skill and --grill mode to d-ralph-plan

### DIFF
--- a/common/claude/.claude/skills/d-grill-me/SKILL.md
+++ b/common/claude/.claude/skills/d-grill-me/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: d-grill-me
+description: 実装前に plan / design を1問ずつ容赦なく詰問し、決定木の各分岐を解消して共通理解に到達する。既存ドキュメント・コードと照合し、用語整合 (docs/CONTEXT.md) と不可逆判断 (docs/adr/) をインライン記録する。
+user-invocable: true
+disable-model-invocation: true
+arguments: "<plan-or-design-description>"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch, WebSearch
+---
+
+# Grill Me - 詰問による plan/design 詰め
+
+実装前に、ユーザーの plan / design / feature 方向性を1問ずつ詰問し、決定木の各分岐を解消して共通理解に到達する。
+意図・制約・隠れた前提・未検討の代替案を炙り出すフェーズ用。バグ探索ではない。
+
+このスキルは grill-with-docs (Matt Pocock) をベースにする。プロジェクトに canonical なアーキテクチャドキュメント・型定義/契約モジュールがあれば、それを正解の基準として参照する。
+
+## 詰問の進め方
+
+- 1問ずつ質問する。各質問に対するフィードバックを待ってから次の質問へ進む。一度に複数問を出さない。
+- 各質問には AI の推奨回答を理由とともに併記する。
+- 決定木を分岐ごとに下る。決定間の依存を1つずつ解消する。
+- コードベースやドキュメントを調べれば答えられる質問は、ユーザーに聞かず自分で調査する。
+- 質問は AskUserQuestion ツールではなく通常のテキストで行い、ユーザーのターン返信を待つ (自由記述の議論を妨げないため)。
+
+## セッション中の挙動
+
+詰問しながら以下を常に行う:
+
+- 既存モデルとの照合: プロジェクトのアーキテクチャドキュメント・型定義/契約モジュール・docs/CONTEXT.md の既存定義と矛盾する前提・用語使用を即座に指摘する。
+- 曖昧な言葉を鋭くする: 多義的・曖昧な用語に canonical term を提案する (例: "account は Customer か User か")。
+- 具体シナリオで境界を詰める: エッジケースのシナリオを提示し、境界・例外の扱いを確定する。
+- コードとの相互参照: ユーザーの主張とコードが矛盾したら表面化する (例: "コードは Order 全体を cancel するが、partial cancellation を可能と言った。どちらが正しいか")。
+
+## 永続化
+
+決定が固まった時点で、バッチせず即座に書き戻す。
+
+### 用語集 docs/CONTEXT.md
+
+用語が解決するたびに docs/CONTEXT.md を更新する (遅延作成: ファイルが無ければ最初の用語解決時に作成)。
+docs/CONTEXT.md は glossary 専用。実装詳細・spec・scratch pad にしない。
+
+書式:
+
+```markdown
+# Context
+
+## Language
+
+### {用語}
+1-2文の定義。関係・cardinality を示す。
+_Avoid_: {非推奨のエイリアス}
+```
+
+ルール:
+- opinionated に正規語を1つ選ぶ。矛盾は明示する。
+- 定義は短く保つ。汎用プログラミング概念は含めない。
+- 自然なクラスタで subheading 分割する。
+
+### ADR docs/adr/
+
+不可逆な設計判断は docs/adr/NNNN-slug.md として連番で記録する (遅延作成: ディレクトリが無ければ最初の ADR 必要時に作成)。
+
+ADR を提案するのは以下3条件がすべて真のときのみ:
+1. 元に戻すのが難しい (hard to reverse)
+2. 文脈なしでは驚く判断 (surprising without context)
+3. 実際のトレードオフの結果である (real trade-off)
+
+書式 (最小):
+
+```markdown
+# {短いタイトル}
+
+{文脈・決定・理由を1-3文}
+```
+
+任意で Status / Considered Options / Consequences を追記してよい。
+
+qualify する判断種別: アーキテクチャ形状、統合パターン、lock-in を伴う技術選択、境界/スコープ、意図的な規約逸脱、コードに現れない制約、非自明な却下案。
+
+## 終了
+
+決定木が解消したら、カバーした内容のサマリを提示する:
+
+- Decisions: 確定した設計判断
+- Constraints: 確定した制約
+- Open questions: 残った未解決事項 (あれば)
+- 用語整合 / ADR: docs/CONTEXT.md・docs/adr/ への記録内容
+
+サマリ提示後、スキルを終了する。実装は行わない。

--- a/common/claude/.claude/skills/d-ralph-plan/SKILL.md
+++ b/common/claude/.claude/skills/d-ralph-plan/SKILL.md
@@ -13,6 +13,17 @@ allowed-tools: Bash, Read, Write, Glob, Grep, Task, WebFetch, WebSearch, AskUser
 
 このスキルは通常の対話セッションとして動作します（自律ループ機構は使用しません）。
 
+## モード
+
+引数 `$ARGUMENTS` に `--grill` が含まれるかでモードを分岐する:
+
+- default（引数に `--grill` なし）: 旧来の挙動。Phase 0 -> 1 -> 2 -> 3 を各 GATE のユーザー承認のみで進める。grill フェーズは実行しない。
+- `--grill`: grill モード。`d-grill-me` スキルの詰問手法を組み込み、要件・制約・スコープ・隠れた前提・修了判定（受入条件と完了条件）を1問ずつ詰め切ってから状態ファイルを構築する。具体的には以下の追加フェーズ・追加ステップを有効化する:
+  - Phase 0.5: Requirement Grill
+  - Phase 1 / Phase 2 内の Completion Grill
+
+両モードとも grill の質問は AskUserQuestion ツールではなく通常テキストで行い、ユーザーのターン返信を待つ（自由記述の議論を妨げないため）。
+
 ## 絶対ルール
 
 1. 各フェーズの末尾でユーザーの明示的な承認を得るまで次のフェーズに進んではならない。「OK」「承認」「LGTM」「進めて」等の承認発言があるまで待機すること。承認なしにフェーズを跨ぐのは禁止。
@@ -26,6 +37,7 @@ allowed-tools: Bash, Read, Write, Glob, Grep, Task, WebFetch, WebSearch, AskUser
 | 引数 | 説明 |
 |------|------|
 | `<task-description>` | 実装するタスクの説明 |
+| `--grill` | grill モードを有効化（Phase 0.5 + Completion Grill） |
 
 ### 使用例
 
@@ -33,6 +45,7 @@ allowed-tools: Bash, Read, Write, Glob, Grep, Task, WebFetch, WebSearch, AskUser
 /d-ralph-plan "ユーザー認証機能を追加する"
 /d-ralph-plan "APIのレスポンスキャッシュ層を実装する"
 /d-ralph-plan docs/prd.md
+/d-ralph-plan --grill "ユーザー認証機能を追加する"
 ```
 
 ## 手順
@@ -65,6 +78,22 @@ allowed-tools: Bash, Read, Write, Glob, Grep, Task, WebFetch, WebSearch, AskUser
 
 --- GATE: Phase 0 完了 ---
 コンテキストレポートを提示したら停止し、ユーザーの承認を待つ。
+承認を得るまで Phase 0.5（grill モード時）または Phase 1（default モード時）に進んではならない。
+
+### Phase 0.5: Requirement Grill（grill モードのみ）
+
+default モードではこのフェーズをスキップして Phase 1 に進む。
+
+`d-grill-me` スキルの詰問手法を適用し、要件・制約・スコープ境界・隠れた前提を1問ずつ詰め切る:
+
+- 1問ずつ質問し、各質問に AI 推奨回答を理由とともに併記し、ユーザーのターン返信を待ってから次へ進む。
+- コードベース・docs（プロジェクトのアーキテクチャドキュメント・型定義・`docs/CONTEXT.md`）で答えられる質問は聞かず自分で調査する（Phase 0 の調査と統合）。
+- 既存アーキテクチャ・型定義と矛盾する前提を即指摘する（cross-reference）。
+- 曖昧な多義語に canonical term を提案する。エッジケースのシナリオで境界を確定する。
+- 用語が解決したら `docs/CONTEXT.md` に書き戻す。不可逆な設計判断は `docs/adr/NNNN-slug.md` に記録する（条件・書式は `d-grill-me` スキル参照）。
+
+--- GATE: Phase 0.5 完了 ---
+決定木が解消したらカバーサマリ（Decisions / Constraints / Open questions）を提示して停止し、ユーザーの承認を待つ。
 承認を得るまで Phase 1 に進んではならない。
 
 ### Phase 1: Requirements & Acceptance Criteria
@@ -93,6 +122,14 @@ allowed-tools: Bash, Read, Write, Glob, Grep, Task, WebFetch, WebSearch, AskUser
 - AC-T (全テストパス) と AC-L (tsc --noEmit エラー0) はデフォルトACとして必ず含める
 - 全てのACは検証可能な形式で記述する (コマンドまたは手順を明記)
 - ユーザーのフィードバックを受けて修正を繰り返す
+
+#### Completion Grill（grill モードのみ）
+
+default モードではスキップする。AC を提示する前に、各 AC を1問ずつ詰める:
+
+- 各 AC の検証方法（verification_command）が実際に機械的に検証可能か。曖昧な AC（"正しく動く" 等）は観測可能・検証可能な条件に書き直す。
+- 漏れている修了条件がないか（エラーパス・境界・後方互換）。必要なら AC を追加する。
+- 1問ずつ、推奨回答併記、ユーザー返信を待つ。
 
 --- GATE: Phase 1 完了 ---
 要件と受入条件を提示したら停止し、ユーザーの承認を待つ。
@@ -138,6 +175,15 @@ allowed-tools: Bash, Read, Write, Glob, Grep, Task, WebFetch, WebSearch, AskUser
 - 依存するタスク
 
 ユーザーのフィードバックを受けて修正を繰り返す。
+
+#### Completion Grill（grill モードのみ）
+
+default モードではスキップする。タスクグラフを承認に出す前に、修了判定を1問ずつ詰める:
+
+- 各タスクの完了条件（completion_condition）が曖昧でないか。「実装する」ではなく「何が成立したら done か」を観測可能な条件で表現する。
+- ralph 完了（RALPH_COMPLETE）の品質ゲート（typecheck / 全テスト / 全 AC verified）でこのタスクの正しさを十分に保証できるか。不足するなら AC を Phase 1 に追加で戻す。
+- タスク分割の粒度・依存（deps）の正しさ。
+- 1問ずつ、推奨回答併記、ユーザー返信を待つ。
 
 --- GATE: Phase 2 完了 ---
 設計とタスクグラフを提示したら停止し、ユーザーの承認を待つ。


### PR DESCRIPTION
## Summary
syntopic-platform PR #6849 で追加された grill-me を dotfiles へ汎用化して import。実装前に plan/design を詰問するワークフローをグローバルに利用可能にする。

## Changes
- `d-grill-me` (新規): 実装前に plan / design を1問ずつ詰問し決定木の各分岐を解消するスキル。用語整合を `docs/CONTEXT.md`、不可逆判断を `docs/adr/` にインライン記録。プロジェクト固有の `packages/contract` / `docs/*_ARCHITECTURE.md` 参照を「プロジェクトのアーキテクチャドキュメント・型定義/契約」に抽象化、`mcp__serena__*` 依存を除去、`d-` prefix + `disable-model-invocation` を付与。
- `d-ralph-plan` (更新): `--grill` 引数で grill モードを有効化。Phase 0.5 (Requirement Grill) と Phase 1 / Phase 2 内の Completion Grill を追加。dotfiles 既存構造に整合させ、block-questions フック依存を除去。

## Test plan
- [ ] `/d-grill-me` がスキル一覧に表示され起動できる
- [ ] `/d-ralph-plan --grill "..."` で Phase 0.5 / Completion Grill が有効化される
- [ ] `/d-ralph-plan "..."` (引数なし) では従来どおり grill フェーズがスキップされる