### PR TITLE
fix(pi): bind alt+enter to newLine for tmux Shift+Enter

### DIFF
--- a/common/pi/.pi/agent/keybindings.json
+++ b/common/pi/.pi/agent/keybindings.json
@@ -1,4 +1,5 @@
 {
-  "tui.input.newLine": ["shift+enter"],
-  "tui.input.submit": ["enter"]
+  "tui.input.newLine": ["shift+enter", "alt+enter"],
+  "tui.input.submit": ["enter"],
+  "app.message.followUp": []
 }


### PR DESCRIPTION
## Summary

Ghostty が Shift+Enter を `text:\x1b\r` で送る環境では、tmux 内で pi の Kitty keyboard protocol が無効化され `\x1b\r` が `alt+enter` として届く(pi-tui `keys.js` L714)。`shift+enter` の binding だけでは tmux 内 pi で改行できなかったため、`newLine` に `alt+enter` を追加し、競合する `app.message.followUp` を無効化する。

Ghostty 側の設定は据え置きなので codex / Claude Code の挙動に影響無し。

## Changes

- `common/pi/.pi/agent/keybindings.json`
  - `tui.input.newLine` に `alt+enter` を追加
  - `app.message.followUp` を空配列にして `alt+enter` 競合を排除

## Test plan

- [x] tmux 内の pi で Shift+Enter → 改行
- [x] tmux 外の pi で Shift+Enter → 改行(既存の `shift+enter` binding で動作)
- [x] codex / Claude Code で Shift+Enter → 改行維持(Ghostty 設定不変)

## Notes

副作用: pi の `Alt+Enter` フォローアップ機能はデフォルトでは発火しなくなる。利用したい場合は `app.message.followUp` を別キーに割当て可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)