### PR TITLE
Migrate Docker runtime from OrbStack to Colima on macOS

### DIFF
--- a/common/sketchybar/.config/sketchybar/plugins/icon_map.sh
+++ b/common/sketchybar/.config/sketchybar/plugins/icon_map.sh
@@ -804,9 +804,6 @@ function __icon_map() {
    "Opera")
         icon_result=":opera:"
         ;;
-   "OrbStack")
-        icon_result=":orbstack:"
-        ;;
    "OrcaSlicer")
         icon_result=":orcaslicer:"
         ;;

--- a/common/zsh/.zprofile
+++ b/common/zsh/.zprofile
@@ -7,6 +7,4 @@ if [[ "$OSTYPE" == darwin* ]]; then
   # Homebrew
   [[ -f /opt/homebrew/bin/brew ]] && eval "$(/opt/homebrew/bin/brew shellenv)"
 
-  # OrbStack: command-line tools and integration
-  source ~/.orbstack/shell/init.zsh 2>/dev/null || :
 fi

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -21,13 +21,19 @@ brew "aerc"
 brew "imagemagick"
 brew "qrencode"
 
+# --- Container Runtime (macOS) ---
+brew "colima"       # OSS container runtime on Lima VM
+brew "docker"       # Docker CLI (colima provides the daemon)
+brew "docker-compose"  # Docker Compose plugin
+brew "docker-credential-helper"  # osxkeychain credential store
+
 # --- Development ---
 brew "neovim"
 brew "typst"
 brew "fancy-cat"    # ターミナル内PDFビューア（Kitty graphics protocol）
 brew "lazygit"
 brew "trasta298/tap/keifu"
-brew "lazydocker"
+brew "lazydocker"  # TUI for Docker management
 brew "git-delta"
 brew "gh"
 brew "ghq"


### PR DESCRIPTION
## Summary
Replace OrbStack with Colima as the macOS Docker runtime. Colima is an
open-source container runtime built on Lima VM, using macOS
Virtualization.Framework. Removes OrbStack shell init, icon mapping, and
adds required Homebrew formulae to Brewfile. Linux setups unaffected.

## Changes
- `common/zsh/.zprofile`: Remove OrbStack shell init (`source ~/.orbstack/shell/init.zsh`)
- `config/Brewfile`: Add colima, docker, docker-compose, docker-credential-helper
- `common/sketchybar/.../icon_map.sh`: Remove OrbStack icon mapping

## Test plan
- [x] `brew install colima docker docker-compose` succeeds
- [x] `colima start --cpu 4 --memory 8` boots successfully
- [x] `docker run hello-world` works
- [x] `docker compose version` works
- [x] `brew services start colima` auto-starts on login

Closes #143