### PR TITLE
feat(nix): phase 2b - shell migration (tmux/zsh/starship/abbr, sheldon removed)

### DIFF
--- a/mac/zsh/.zshrc.local
+++ b/mac/zsh/.zshrc.local
@@ -15,7 +15,7 @@ if [[ -n $GHOSTTY_RESOURCES_DIR ]]; then
 fi
 
 # --- Mac Tools Init ---
-command -v sheldon &>/dev/null && eval "$(sheldon source)"
+# sheldon removed in Phase 2b: zsh plugins now managed by programs.zsh.plugins (zsh-completions, zsh-autosuggestions, zsh-abbr, forgit, zsh-syntax-highlighting).
 command -v atuin &>/dev/null && eval "$(atuin init zsh)"
 
 # Ctrl+P で atuin の履歴検索を有効化（Up Arrow と同じ動作）

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -11,6 +11,11 @@
     ./programs/mise.nix
     ./programs/sesh.nix
     ./programs/aerc.nix
+    # Phase 2b additions
+    ./programs/zsh.nix
+    ./programs/zsh-abbr.nix
+    ./programs/starship.nix
+    ./programs/tmux.nix
   ];
 
   home.username = "matsushimakouta";

--- a/nix/home/programs/starship.nix
+++ b/nix/home/programs/starship.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  programs.starship = {
+    enable = true;
+    enableZshIntegration = false; # zsh.nix sources starship manually
+
+    # The original starship.toml relies on Powerline / Nerd Font codepoints
+    # (U+E0B0 …) that are easy to lose when retyping into a Nix string.
+    # Parse the TOML file directly so the bytes flow through unchanged.
+    settings = builtins.fromTOML (
+      builtins.readFile ../../../common/starship/.config/starship.toml
+    );
+  };
+}

--- a/nix/home/programs/tmux.nix
+++ b/nix/home/programs/tmux.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+let
+  # Local plugin (lives in this repo). mkTmuxPlugin copies the tree to
+  # $out/share/tmux-plugins/tmux-popup-manager and tmux's run-shell sees
+  # `popup-manager.tmux` as the rtp file.
+  tmuxPopupManager = pkgs.tmuxPlugins.mkTmuxPlugin {
+    pluginName = "tmux-popup-manager";
+    version = "local";
+    src = ./tmux/plugins/tmux-popup-manager;
+    rtpFilePath = "popup-manager.tmux";
+  };
+
+  # tmux-which-key needs its custom config.yaml inside its own install dir
+  # (the plugin reads from "$(dirname "$0")/config.yaml" at load time).
+  # Override the nixpkgs derivation to bundle the user's config.yaml.
+  tmuxWhichKeyWithConfig = pkgs.tmuxPlugins.tmux-which-key.overrideAttrs (oldAttrs: {
+    postInstall = (oldAttrs.postInstall or "") + ''
+      cp ${../../../common/tmux/.config/tmux/plugins/tmux-which-key/config.yaml} \
+         $out/share/tmux-plugins/tmux-which-key/config.yaml
+    '';
+  });
+in
+{
+  programs.tmux = {
+    enable = true;
+
+    # tmux's default behaviour for the package-managed conf is to point at
+    # $XDG_CONFIG_HOME/tmux/tmux.conf — keep that. Pass our config via
+    # extraConfig (also goes through the same path).
+    extraConfig = builtins.readFile ./tmux/tmux.conf;
+
+    plugins = [
+      # Plugin extraConfig runs BEFORE the plugin source (HM design),
+      # so @resurrect-* / @continuum-* vars are set at the right time.
+      {
+        plugin = pkgs.tmuxPlugins.resurrect;
+        extraConfig = ''
+          set -g @resurrect-capture-pane-contents 'on'
+          # Resurrect long-lived supervisors across reboot. Leading "~" matches
+          # the process via extended regex against the full command line.
+          # ralph-crew daemon: on resurrect, its own startup hook re-runs
+          # _run_init which rebuilds the crew-NN windows/panes against the new
+          # pane_ids.
+          set -g @resurrect-processes '"~ralph-crew daemon"'
+        '';
+      }
+      {
+        plugin = pkgs.tmuxPlugins.continuum;
+        extraConfig = ''
+          set -g @continuum-restore 'on'
+        '';
+      }
+      pkgs.tmuxPlugins.vim-tmux-navigator
+      {
+        plugin = pkgs.tmuxPlugins.tmux-thumbs;
+        extraConfig = ''
+          set -g @thumbs-key e
+        '';
+      }
+      tmuxWhichKeyWithConfig
+      tmuxPopupManager
+      # ataraxy-labs/opensessions: NOT in nixpkgs and writes to its own
+      # checkout at runtime — installed via TPM line in tmux.conf instead.
+    ];
+  };
+
+  # Theme files (referenced by tmux.conf via `source-file ~/.config/tmux/${theme}.tmux`)
+  # tmux config dir is also where the scripts live; ship them all here.
+  xdg.configFile = {
+    "tmux/tokyonight.tmux".source =
+      ../../../common/tmux/.config/tmux/tokyonight.tmux;
+    "tmux/catppuccin.tmux".source =
+      ../../../common/tmux/.config/tmux/catppuccin.tmux;
+    "tmux/gruvbox.tmux".source =
+      ../../../common/tmux/.config/tmux/gruvbox.tmux;
+    "tmux/rosepine.tmux".source =
+      ../../../common/tmux/.config/tmux/rosepine.tmux;
+    "tmux/syntopic.tmux".source =
+      ../../../common/tmux/.config/tmux/syntopic.tmux;
+    "tmux/claude-hooks.tmux".source =
+      ../../../common/tmux/.config/tmux/claude-hooks.tmux;
+  };
+
+  # tmux-layout dev preset (used by tmux-layout script)
+  xdg.dataFile."tmux-layout/dev.layout".source =
+    ../../../common/tmux/.local/share/tmux-layout/dev.layout;
+}

--- a/nix/home/programs/tmux/plugins/tmux-popup-manager/popup-manager.tmux
+++ b/nix/home/programs/tmux/plugins/tmux-popup-manager/popup-manager.tmux
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# tmux-popup-manager: entry point
+# Reads @popup-* options, registers command-aliases, bind-keys, and which-key menu.
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Register global popups
+"$CURRENT_DIR/scripts/loader.sh" global
+
+# Register hook for project-local popups
+tmux set-hook -ga session-created \
+    "run-shell '\"$CURRENT_DIR/scripts/loader.sh\" project \"#{hook_session_name}\"'"

--- a/nix/home/programs/tmux/plugins/tmux-popup-manager/scripts/helpers.sh
+++ b/nix/home/programs/tmux/plugins/tmux-popup-manager/scripts/helpers.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# tmux-popup-manager: helper functions
+
+get_tmux_option() {
+    local option="$1"
+    local default="$2"
+    local value
+    value="$(tmux show-option -gqv "$option")"
+    if [ -z "$value" ]; then
+        echo "$default"
+    else
+        echo "$value"
+    fi
+}
+
+# Capitalize first letter of a string
+capitalize() {
+    local str="$1"
+    echo "$(echo "${str:0:1}" | tr '[:lower:]' '[:upper:]')${str:1}"
+}
+
+# Escape spaces for tmux command parsing
+tmux_escape() {
+    printf '%s' "$1" | sed 's/ /\\ /g'
+}

--- a/nix/home/programs/tmux/plugins/tmux-popup-manager/scripts/loader.sh
+++ b/nix/home/programs/tmux/plugins/tmux-popup-manager/scripts/loader.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# tmux-popup-manager: core loader
+# Usage: loader.sh global | loader.sh project <session_name>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/helpers.sh"
+
+# Parse a popup definition: key|width|height|command[|display_name]
+# Sets: _key, _width, _height, _cmd, _display_name
+parse_popup_def() {
+    local value="$1"
+    local name="$2"
+    IFS='|' read -r _key _width _height _cmd _display_name <<< "$value"
+    if [ -z "$_display_name" ]; then
+        _display_name="$(capitalize "$name")"
+    fi
+}
+
+# Register a popup command-alias (without bind-key)
+register_alias() {
+    local name="$1"
+    local width="$2"
+    local height="$3"
+    local cmd="$4"
+    local idx="$5"
+    local alias_name="popup-${name}"
+
+    local alias_value
+    if [ "$cmd" = "SCRATCH" ]; then
+        # Special: toggle scratch session
+        alias_value="${alias_name}=if-shell -F '#{==:#{session_name},scratch}' { detach-client } { display-popup -E -w ${width}% -h ${height}% -d '#{pane_current_path}' 'tmux new-session -A -s scratch' }"
+    else
+        local escaped_cmd
+        escaped_cmd="$(tmux_escape "$cmd")"
+        alias_value="${alias_name}=display-popup -E -w ${width}% -h ${height}% -d '#{pane_current_path}' ${escaped_cmd}"
+    fi
+
+    tmux set -g "command-alias[$idx]" "$alias_value"
+}
+
+# Enumerate @popup-* options and collect popup definitions
+# Populates the _popups array: "name|key|width|height|cmd|display_name"
+collect_popups() {
+    _popups=()
+    while IFS= read -r line; do
+        # Extract option name (everything before first space)
+        local opt_name="${line%% *}"
+        local name="${opt_name#@popup-}"
+        local value
+        value="$(tmux show-option -gqv "$opt_name")"
+        [ -z "$value" ] && continue
+
+        parse_popup_def "$value" "$name"
+        _popups+=("${name}|${_key}|${_width}|${_height}|${_cmd}|${_display_name}")
+    done < <(tmux show-options -g 2>/dev/null | grep '^@popup-' | grep -v '^@popup-manager-')
+}
+
+# Build which-key menu string from popup entries
+# Args: popup entries (same format as _popups array)
+build_menu_string() {
+    local menu=""
+    for entry in "$@"; do
+        IFS='|' read -r name key width height cmd display_name <<< "$entry"
+        local alias_name="popup-${name}"
+
+        # Quote display names containing spaces or hyphens
+        local quoted_name
+        if [[ "$display_name" == *" "* ]] || [[ "$display_name" == *"-"* ]]; then
+            quoted_name="\"${display_name}\""
+        else
+            quoted_name="$display_name"
+        fi
+
+        if [ -n "$menu" ]; then
+            menu+=" "
+        fi
+        menu+="${quoted_name} \"${key}\" ${alias_name}"
+    done
+    echo "$menu"
+}
+
+cmd_global() {
+    local alias_start
+    alias_start="$(get_tmux_option "@popup-manager-alias-start" "220")"
+
+    collect_popups
+
+    local idx="$alias_start"
+    for entry in "${_popups[@]}"; do
+        IFS='|' read -r name key width height cmd display_name <<< "$entry"
+        register_alias "$name" "$width" "$height" "$cmd" "$idx"
+        tmux bind-key "$key" "popup-${name}"
+        idx=$((idx + 1))
+    done
+
+    # which-key integration
+    local wk_var
+    wk_var="$(get_tmux_option "@popup-manager-which-key-var" "")"
+    if [ -n "$wk_var" ]; then
+        local menu
+        menu="$(build_menu_string "${_popups[@]}")"
+        if [ -n "$menu" ]; then
+            tmux set -g "$wk_var" "$menu"
+        fi
+    fi
+}
+
+cmd_project() {
+    local session="$1"
+    [ -z "$session" ] && return 1
+
+    local project_file_name
+    project_file_name="$(get_tmux_option "@popup-manager-project-file" ".tmux-popups")"
+
+    # Get session start directory
+    local session_path
+    session_path="$(tmux display-message -t "$session" -p '#{pane_current_path}' 2>/dev/null)"
+    [ -z "$session_path" ] && return 1
+
+    # Find git root (fall back to session path)
+    local project_root
+    project_root="$(git -C "$session_path" rev-parse --show-toplevel 2>/dev/null)"
+    [ -z "$project_root" ] && project_root="$session_path"
+
+    local project_file="${project_root}/${project_file_name}"
+    [ ! -f "$project_file" ] && return 0
+
+    # Read project-local popup definitions
+    local project_popups=()
+    local alias_start
+    alias_start="$(get_tmux_option "@popup-manager-alias-start" "220")"
+    # Offset project aliases by 100 to avoid collision with global aliases
+    local project_alias_start=$((alias_start + 100))
+
+    while IFS= read -r line; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
+        # Parse: name|key|width|height|command[|display_name]
+        local name key width height cmd display_name
+        IFS='|' read -r name key width height cmd display_name <<< "$line"
+        [ -z "$name" ] && continue
+        if [ -z "$display_name" ]; then
+            display_name="$(capitalize "$name")"
+        fi
+        project_popups+=("${name}|${key}|${width}|${height}|${cmd}|${display_name}")
+    done < "$project_file"
+
+    [ ${#project_popups[@]} -eq 0 ] && return 0
+
+    # Register project-local command-aliases only (no bind-key to avoid global key collision)
+    # Project popups are accessible via which-key +Popup menu
+    local idx="$project_alias_start"
+    for entry in "${project_popups[@]}"; do
+        IFS='|' read -r name key width height cmd display_name <<< "$entry"
+        register_alias "$name" "$width" "$height" "$cmd" "$idx"
+        idx=$((idx + 1))
+    done
+
+    # which-key integration: session-scoped menu (global + project)
+    local wk_var
+    wk_var="$(get_tmux_option "@popup-manager-which-key-var" "")"
+    if [ -n "$wk_var" ]; then
+        collect_popups
+        local all_popups=("${_popups[@]}")
+        # Add separator between global and project popups
+        all_popups+=("_sep_||||||")
+        all_popups+=("${project_popups[@]}")
+
+        local menu=""
+        for entry in "${all_popups[@]}"; do
+            if [[ "$entry" == "_sep_"* ]]; then
+                [ -n "$menu" ] && menu+=' ""'
+                continue
+            fi
+            IFS='|' read -r name key width height cmd display_name <<< "$entry"
+            local alias_name="popup-${name}"
+            local quoted_name
+            if [[ "$display_name" == *" "* ]] || [[ "$display_name" == *"-"* ]]; then
+                quoted_name="\"${display_name}\""
+            else
+                quoted_name="$display_name"
+            fi
+            [ -n "$menu" ] && menu+=" "
+            menu+="${quoted_name} \"${key}\" ${alias_name}"
+        done
+
+        if [ -n "$menu" ]; then
+            tmux set -t "$session" "$wk_var" "$menu"
+        fi
+    fi
+}
+
+# Main dispatch
+case "${1:-}" in
+    global)
+        cmd_global
+        ;;
+    project)
+        cmd_project "$2"
+        ;;
+    *)
+        echo "Usage: loader.sh global | loader.sh project <session_name>" >&2
+        exit 1
+        ;;
+esac

--- a/nix/home/programs/tmux/tmux.conf
+++ b/nix/home/programs/tmux/tmux.conf
@@ -1,0 +1,340 @@
+# --- Prefix Key ---
+set -g prefix C-Space
+unbind C-b
+bind C-Space send-prefix
+
+# --- General ---
+# default-command: do NOT bake $SHELL at config-load time. rcon's ssh-t
+# evaluates the inline script in bash (login shell from /etc/passwd is
+# bash on no-sudo hosts), so ${SHELL}=bash gets frozen for the server's
+# lifetime and new panes open bash. Use a runtime resolver: at pane spawn,
+# default-shell -c will run this string, command -v zsh finds whatever
+# zsh is in PATH at that moment (PATH was set via .zshenv / rcon).
+set -g default-command 'exec "$(command -v zsh 2>/dev/null || echo /bin/bash)"'
+set -g mouse on
+set -g set-clipboard on  # OSC52 clipboard (SSH経由でもコピー可能)
+set -g focus-events on   # Neovim autoread等に必要
+set -g window-size latest  # 最後にアクティブなクライアントのサイズに合わせる
+set -g aggressive-resize off  # Claude Code等のTUI再描画チラつき軽減 (default offを明示)
+set -g history-limit 10000
+set -g allow-passthrough on  # Kitty graphics protocol (image.nvim等で必要)
+set -g extended-keys on      # CSI u: C-S-u等の修飾キーをNeovimに正しく送信
+set -ga update-environment TERM
+set -ga update-environment TERM_PROGRAM
+
+# Terminal title (for aerospace window detection)
+set -g set-titles on
+set -g set-titles-string "#{b:pane_current_path}"
+
+# --- Copy Mode (vi-style) ---
+setw -g mode-keys vi
+
+# prefix+u / prefix+C-u でcopy-modeに入りスクロールアップ
+unbind -n C-u
+bind u copy-mode \; send-keys -X halfpage-up
+bind C-u copy-mode \; send-keys -X halfpage-up
+
+# prefix+v でcopy-modeに入る
+bind v copy-mode
+
+bind-key -T copy-mode-vi 'v' send -X begin-selection
+bind-key -T copy-mode-vi 'C-v' send -X rectangle-toggle
+# y: pipe to OS-aware clipboard wrapper (popup OSC52 を回避するため pbcopy/lemonade/wl-copy/xclip 直接呼出)
+bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel "~/dotfiles/scripts/clipboard-copy"
+bind-key -T copy-mode-vi Enter send-keys -X cancel
+bind-key -T copy-mode-vi Escape send-keys -X cancel
+# スクロール量を4行に変更（デフォルトは半ページ）
+bind-key -T copy-mode-vi C-u send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up
+bind-key -T copy-mode-vi C-d send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down
+# u/d で半ページスクロール（倍速移動）
+bind-key -T copy-mode-vi u send-keys -X halfpage-up
+bind-key -T copy-mode-vi d send-keys -X halfpage-down
+# Mouse drag: auto-copy to clipboard, exit copy-mode and scroll to bottom
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/dotfiles/scripts/clipboard-copy"
+set -g base-index 1
+setw -g pane-base-index 1
+set -s escape-time 0
+
+# Activity monitoring
+setw -g monitor-activity on
+set -g renumber-windows on
+
+# Session lifecycle
+# detach-on-destroy off: セッション閉鎖時に tmux クライアントを放り出さず、
+# 別のセッションに自動切替する。sesh last / choose-tree ワークフロー成立に必須。
+set -g detach-on-destroy off
+
+# Status bar update interval (reduce for remote sessions)
+set -g status-interval 5
+
+# --- Terminal / Color (Ghostty + Neovim) ---
+# default-terminal must NOT depend on $TERM at server-start time (rcon may
+# launch tmux from a non-interactive ssh where TERM is empty, freezing "")
+set -g default-terminal "tmux-256color"
+set -ag terminal-features ",xterm-256color:RGB"
+# Undercurl support
+set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
+set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
+
+# --- Keybindings (Vim-like) ---
+# Pane split
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# New window inherits current pane's cwd (consistency with split-window)
+bind c new-window -c "#{pane_current_path}"
+
+# Pane navigation: vim-tmux-navigator (C-h/j/k/l) を使用
+
+# Pane resize
+bind -r H resize-pane -L 2
+bind -r J resize-pane -D 2
+bind -r K resize-pane -U 2
+bind -r L resize-pane -R 2
+
+# Zoom toggle
+#   z: normal zoom — tmux auto-unzooms on pane switch and does not restore on return
+#   Z: pane-sticky zoom — after-select-pane hook re-zooms when returning to the pane
+#   Pressing either again while sticky unzooms and clears the sticky flag
+bind z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh normal"
+bind Z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh sticky"
+
+# Reload config (shows RELOAD mode during reload)
+bind r set -g @reload_mode 1 \; \
+       refresh-client -S \; \
+       source-file ~/.config/tmux/tmux.conf \; \
+       set -gu @reload_mode \; \
+       refresh-client -S
+
+# Window kill (X = bigger than x for pane)
+unbind &
+bind X confirm-before -p "kill-window #W? (y/n)" kill-window
+
+# Pane swap (by display number shown with prefix+q)
+bind W command-prompt -p "Swap pane:","with pane:" "swap-pane -s '%%.%1' -t '%%.%2'"
+
+# Visual pane swap: pick two panes via fzf popup; slot sizes preserved,
+# only contents swap. Uses fzf rather than display-panes so small panes
+# (below tmux's big-digit render threshold) remain selectable.
+# Overrides default prefix+m (select-pane -m).
+bind m display-popup -E -w 80% -h 40% "~/dotfiles/scripts/tmux-swap-picker"
+# Mark / unmark current pane (toggle). Replaces default mark role freed by
+# prefix+m above; keeps `{marked}` referenceable for cross-window swap-pane etc.
+bind M select-pane -m
+
+# Pane title
+bind t command-prompt -p "Pane title:" "select-pane -T '%%'"
+
+# Window title
+bind T command-prompt -p "Window name:" "rename-window '%%'"
+
+# Window navigation
+set -g repeat-time 1000  # リピート可能時間を1秒に
+bind -r p select-window -t :-
+bind -r n select-window -t :+
+
+# Session navigation
+# choose-tree を名前順 (アルファベット) 固定にして命名規約 (rcon-*, proj-*, pers-*, ops-*)
+# による擬似グルーピングを成立させる。switch-client -p/-n も内部的に名前順で走査するため、
+# choose-tree の表示順と ( / ) の巡回順が一致する。
+bind s choose-tree -Zs -O name
+bind Tab switch-client -l
+bind -r ( switch-client -p
+bind -r ) switch-client -n
+
+# sesh last: 直前のセッションに戻る。switch-client -l と比べて sesh 側の履歴を
+# 参照するので fzf picker 経由で切り替えた履歴も拾える。セッション 1 つだけの
+# ときは黙らずメッセージを出す (コミュニティ標準のフォールバック)。
+bind L run-shell "sesh last || tmux display-message -d 1000 'Only one session'"
+
+# sesh root: 現在の session の "root" に相当する session にジャンプ。
+# worktree (`<main>--wt--<slug>`) 等のネストから親プロジェクトへ一撃で戻るとき便利。
+# #{pane_current_path} は tmux 側で invocation time に展開されるため、shell expansion ではなく
+# tmux format substitution を使う必要がある (shell expansion だと config load 時点で固定される)。
+bind 9 run-shell "sesh connect --root '#{pane_current_path}'"
+
+# sesh: fuzzy session picker (config + tmux + zoxide 横断) の多段フィルタ版。
+# 公式 README の配布レシピを採用。popup 内で Ctrl キーで ソース切替:
+#   ^a all / ^t tmux / ^g configs / ^x zoxide / ^f find (fd) / ^d kill session
+# prefix+f はローカル tmux session のみの色付き picker (軽量)、
+# prefix+C-f はプロジェクトディレクトリ横断で新規セッション作成含むスーパーセット。
+# 注: prefix+C-s / prefix+C-t は opensessions 用 (focus / toggle) のため避ける。
+# 重要: display-popup でラップしない。内側の fzf-tmux -p が自前で popup を開くため、
+# 二重 popup になって入力が届かなくなる (旧実装のバグ)。run-shell に任せる。
+bind C-f run-shell "sesh connect \"\$(
+  sesh list --icons | fzf-tmux -p 80%,70% --no-sort --ansi \
+    --border-label ' sesh ' --prompt '⚡  ' \
+    --header '  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find' \
+    --bind 'tab:down,btab:up' \
+    --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)' \
+    --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)' \
+    --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)' \
+    --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)' \
+    --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)' \
+    --preview-window 'right:55%' \
+    --preview 'sesh preview {}'
+)\""
+
+# Sync mode toggle (with style change, reads @theme-* at runtime)
+bind S run-shell '\
+  off=$(tmux show-option -gqv @theme-border-inactive); \
+  on=$(tmux show-option -gqv @theme-border-success); \
+  off=${off:-"#3b4261"}; on=${on:-"#73daca"}; \
+  if [ "$(tmux show-window-options -v synchronize-panes)" = "on" ]; then \
+    tmux setw synchronize-panes off; \
+    tmux set -g window-style "fg=colour244,bg=default"; \
+    tmux set -g pane-border-style "fg=${off},bg=default"; \
+  else \
+    tmux setw synchronize-panes on; \
+    tmux set -g window-style "fg=colour255,bg=default"; \
+    tmux set -g pane-border-style "fg=${on},bg=default"; \
+  fi'
+
+# --- Popup Manager ---
+# Project / git / DB tools: route through tmux-popup-in-container so they run
+# inside the backing docker container for rcon-managed sessions (falls through
+# to host execution for non-docker sessions, preserving in-docker tmux compat).
+set -g @popup-lazygit   "g|80|80|~/dotfiles/scripts/tmux-popup-in-container lazygit"
+set -g @popup-keifu     "k|80|80|~/dotfiles/scripts/tmux-popup-in-container zsh -lc keifu"
+set -g @popup-pgcli     "P|80|80|~/dotfiles/scripts/tmux-popup-in-container pgcli \${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres}"
+set -g @popup-quay      "Q|80|80|~/dotfiles/scripts/tmux-popup-in-container quay"
+set -g @popup-gh-dash   "G|85|85|~/dotfiles/scripts/tmux-popup-in-container gh dash|gh-dash"
+set -g @popup-scratch   "j|80|80|SCRATCH|Scratchpad"
+set -g @popup-sessions  "f|60|60|~/dotfiles/scripts/tmux-session-color.sh fzf-sessions"
+set -g @popup-projects  "F|60|60|~/dotfiles/scripts/tmux-popup-ghq.sh"
+set -g @popup-layout    "A|60|40|~/dotfiles/scripts/tmux-layout menu"
+set -g @popup-manager-which-key-var "@wk_menu_popup"
+
+# --- Nested Session Toggle (F12) ---
+# F12で外側tmuxのキーバインドをOFFにし、内側tmuxにパススルー
+# OFFの間: prefix無効、ステータスバーがグレーアウト、[OFF]表示
+bind -T root F12 run-shell '\
+    fg=$(tmux show-option -gqv @theme-fg-subtle); \
+    bg=$(tmux show-option -gqv @theme-bg-dark); \
+    fg=${fg:-"#545c7e"}; bg=${bg:-"#1a1b26"}; \
+    tmux set prefix None \; \
+         set key-table off \; \
+         set status-style "fg=${fg},bg=${bg}" \; \
+         set window-status-current-format "#[fg=${fg},bg=${bg}] #I #W " \; \
+         set window-status-current-style "fg=${fg},bg=${bg}"; \
+    if [ "$(tmux display -p "#{pane_in_mode}")" = "1" ]; then \
+         tmux send-keys -X cancel; fi; \
+    tmux refresh-client -S'
+
+bind -T off F12 \
+    set -u prefix \;\
+    set -u key-table \;\
+    set -u status-style \;\
+    set -u window-status-current-format \;\
+    set -u window-status-current-style \;\
+    refresh-client -S
+
+# --- Status Bar ---
+set -g status-position top
+
+# Theme: tokyonight | syntopic
+# Last selection is persisted in $XDG_STATE_HOME/tmux/current-theme by
+# scripts/tmux-theme-toggle.sh. Fall back to tokyonight on first run.
+run-shell 'state="${XDG_STATE_HOME:-$HOME/.local/state}/tmux/current-theme"; \
+  theme=$( [ -f "$state" ] && cat "$state" || echo tokyonight ); \
+  tmux source-file "$HOME/.config/tmux/${theme}.tmux"'
+
+# Theme picker: prefix + y opens a menu to select the tmux theme.
+bind y display-menu -T "Theme" -x C -y C \
+    "tokyonight"  t "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh tokyonight'" \
+    "catppuccin"  c "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh catppuccin'" \
+    "gruvbox"     g "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh gruvbox'" \
+    "rosepine"    r "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh rosepine'" \
+    "syntopic"    s "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh syntopic'"
+
+# Claude Code 通知統合
+source-file ~/.config/tmux/claude-hooks.tmux
+
+# Per-session accent color hooks (claude-hooks.tmux の後に追加、-ga で append)
+set-hook -ga session-created 'run-shell "~/dotfiles/scripts/tmux-session-color.sh apply #{session_name} 2>/dev/null || true"'
+set-hook -ga client-session-changed 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -ga client-attached 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -ga after-new-window 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+
+# Pane-sticky zoom: register after-select-pane hook once (reload-safe via @zoom-hooks-loaded)
+run-shell "~/dotfiles/scripts/tmux-zoom-hooks.sh"
+
+# 現セッションに即時適用 (config reload & 既存セッション対応)
+run-shell "~/dotfiles/scripts/tmux-session-color.sh apply '#{session_name}' 2>/dev/null || true"
+
+# --- Plugins (TPM) ---
+set -g @plugin 'tmux-plugins/tpm'
+# vim-tmux-navigator: extend pattern so C-h/j/k/l also pass through to:
+#   - ssh sessions  (so rcon → remote tmux receives the keypress)
+#   - nested tmux   (same purpose, when remote runs another tmux server)
+# Without this, the outer tmux thinks "ssh process is not vim" and grabs
+# the key for its own select-pane, never reaching the inner tmux.
+set -g @vim_navigator_pattern '(\S+/)?g?\.?(view|l?n?vim?x?|fzf|ssh|tmux)(diff)?(-wrapped)?'
+# Override the default detection: match against tmux's own #{pane_current_command}
+# instead of `ps -t $pane_tty`. Reason: `ps -t` enumerates EVERY process whose
+# controlling tty equals the pane's pty — including backgrounded nvim, :term
+# children, and zombies — and `+` (foreground-group flag) is unreliable when
+# multiple process groups linger on the same tty (we've seen `Ss+ zsh` AND
+# `S+ nvim` coexist, producing a false-positive regex match that stole C-h/j/k/l
+# from pane navigation). tmux's `pane_current_command` is computed from the
+# kernel's foreground-pgrp lookup on the pty and reflects what's actually on
+# screen, so it gives the authoritative answer with no false positives.
+set -g @vim_navigator_check "echo '#{pane_current_command}' | grep -iqE '^@vim_navigator_pattern$'"
+set -g @plugin 'ataraxy-labs/opensessions'         # Session sidebar + AI agent status
+
+# Resurrect long-lived supervisors across reboot. Leading "~" matches the process
+# via extended regex against the full command line (with its original args), so
+# the resurrected process restarts with the same --interval / --config flags.
+# ralph-crew daemon: on resurrect, its own startup hook re-runs _run_init which
+# rebuilds the crew-NN windows/panes against the new pane_ids.
+
+# tmux-thumbs: Vimium-style hint selection (TPM binding disabled, using custom wrapper)
+
+# Initialize TPM (keep at the bottom)
+setenv -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.tmux/plugins/"
+if "test ! -d ~/.tmux/plugins/tpm" \
+   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
+run '~/.tmux/plugins/tpm/tpm'
+
+
+# Override plugins for prefix+C-h/C-l (window navigation)
+unbind C-l
+bind -r C-h select-window -t :-
+bind -r C-l select-window -t :+
+
+# Note: a previous version pinned C-h/j/k/l to plain select-pane to work
+# around vim-tmux-navigator's TTY detection failing inside docker exec
+# panes. That broke nvim's own split navigation in host-direct sessions.
+# Removed so vim-tmux-navigator's smart binding handles it:
+#   - inside nvim split with neighbour → move within nvim
+#   - at split edge → fall through to tmux select-pane
+
+# prefix + V : paste tmux buffer as literal keystrokes (bypasses bracketed
+# paste markers). For TUIs like `claude auth login` / `claude setup-token`
+# that read input in raw mode and reject pasted bracketed sequences.
+# Usage: copy the auth code (Cmd+C on Mac is mirrored into tmux buffer via
+# set-clipboard=on OSC52), then press prefix+V instead of Cmd+V.
+bind V run-shell 'tmux send-keys -l -- "$(tmux show-buffer)"'
+
+# tmux-thumbs: custom wrapper (overrides TPM binding)
+bind e run-shell "~/dotfiles/scripts/tmux-thumbs-wrapper.sh"
+
+
+# Force transparent background (Tmux 3.2+ requires both)
+set -g status-bg default
+set -g status-style bg=default
+
+# Visual settings (pane borders, window styles) are set by the theme file
+
+# --- Counteract opensessions resize-window side-effect ---
+# opensessions calls `resize-window` when creating/managing sidebars, which
+# flips window-size to "manual" and locks the window at a fixed size.
+# On every client-resized event, reset all windows in the session back to
+# "latest" so they track the client's terminal size.
+# Must come AFTER the opensessions plugin (loaded via TPM above).
+set-hook -gu client-resized
+set-hook -ga client-resized  'run-shell "for w in $(tmux list-windows -F \"##W\"); do tmux setw -t \"\$w\" window-size latest 2>/dev/null; done"'
+set-hook -ga after-new-window 'run-shell "tmux setw window-size latest 2>/dev/null"'

--- a/nix/home/programs/zsh-abbr.nix
+++ b/nix/home/programs/zsh-abbr.nix
@@ -1,0 +1,10 @@
+{ ... }:
+
+{
+  # zsh-abbr is loaded as a zsh plugin (see nix/home/programs/zsh.nix).
+  # This module just publishes the user-abbreviations file at
+  # ABBR_USER_ABBREVIATIONS_FILE = ~/.config/zsh-abbr/user-abbreviations.
+
+  xdg.configFile."zsh-abbr/user-abbreviations".text =
+    builtins.readFile ../../../common/zsh-abbr/.config/zsh-abbr/user-abbreviations;
+}

--- a/nix/home/programs/zsh.nix
+++ b/nix/home/programs/zsh.nix
@@ -1,0 +1,527 @@
+{ config, lib, pkgs, ... }:
+
+let
+  # .p10k.zsh is large (1738 lines); ship as-is via readFile so the p10k
+  # configure wizard's output is preserved verbatim.
+  p10kConfig = builtins.readFile ../../../common/zsh/.p10k.zsh;
+in
+{
+  programs.zsh = {
+    enable = true;
+
+    # HM disables its built-in compinit when oh-my-zsh/prezto isn't enabled;
+    # we call compinit explicitly in initContent for the 24h-cached pattern.
+    enableCompletion = false;
+    autosuggestion.enable = false;     # provided manually via zsh-defer
+    syntaxHighlighting.enable = false; # provided manually with mkOrder 5000 (HM #7592)
+
+    history = {
+      size = 50000;
+      save = 50000;
+      share = true;
+      path = "${config.home.homeDirectory}/.zsh_history";
+    };
+
+    sessionVariables = {
+      XDG_CONFIG_HOME = "${config.home.homeDirectory}/.config";
+
+      FZF_DEFAULT_COMMAND = "fd --type f --hidden --exclude .git";
+      FZF_CTRL_T_COMMAND = "fd --type f --hidden --exclude .git";
+      FZF_ALT_C_COMMAND = "fd --type d --hidden --exclude .git";
+
+      # forgit: rename conflicting alias (gsp is zsh-abbr 'git stash pop')
+      forgit_stash_push = "gspu";
+
+      # zsh-abbr
+      ABBR_USER_ABBREVIATIONS_FILE = "${config.home.homeDirectory}/.config/zsh-abbr/user-abbreviations";
+
+      DENO_INSTALL = "${config.home.homeDirectory}/.deno";
+    };
+
+    # envExtra goes into ~/.zshenv — runs for ALL shells (login + non-login).
+    # Re-prepend nix-managed paths so Nix-installed binaries win over
+    # /opt/homebrew/bin regardless of how the shell is launched.
+    envExtra = ''
+      for p in \
+        "$HOME/.nix-profile/bin" \
+        "/etc/profiles/per-user/$USER/bin" \
+        "/run/current-system/sw/bin" \
+        "/nix/var/nix/profiles/default/bin"
+      do
+        [[ -d "$p" ]] && export PATH="$p:$PATH"
+      done
+
+      # Env vars whose value embeds double quotes — declaring via
+      # sessionVariables would produce `export VAR="..."` with broken inner
+      # quoting. Use single-quoted heredocs here instead.
+      export FZF_DEFAULT_OPTS='
+        --height=80%
+        --layout=reverse
+        --border=rounded
+        --info=inline
+        --color=fg:#c0caf5,bg:-1,hl:#bb9af7
+        --color=fg+:#c0caf5,bg+:#283457,hl+:#7dcfff
+        --color=info:#7aa2f7,prompt:#7dcfff,pointer:#7dcfff
+        --color=marker:#9ece6a,spinner:#9ece6a,header:#9ece6a
+        --bind="ctrl-d:half-page-down,ctrl-u:half-page-up"
+      '
+
+      export FORGIT_STASH_FZF_OPTS='
+        --bind="alt-p:reload(git stash pop $(cut -d: -f1 <<<{}) 1>/dev/null && git stash list)"
+        --bind="alt-a:reload(git stash apply $(cut -d: -f1 <<<{}) 1>/dev/null && git stash list)"
+        --bind="alt-d:reload(git stash drop $(cut -d: -f1 <<<{}) 1>/dev/null && git stash list)"
+        --header="enter:show | alt-p:pop | alt-a:apply | alt-d:drop | ctrl-y:copy ref"
+      '
+    '';
+
+    # PATH fix moved from profileExtra (login-shells only) to envExtra below
+    # so non-login interactive shells (Ghostty default) also get it.
+
+    # zsh-completions is consumed via fpath (its completion files land in
+    # share/zsh/site-functions of the user profile, which is already in
+    # FPATH). Install it as a regular home package instead of a plugin.
+
+    plugins = [
+      # zsh-defer first so subsequent plugins can be deferred from initContent
+      {
+        name = "zsh-defer";
+        src = pkgs.zsh-defer;
+        file = "share/zsh-defer/zsh-defer.plugin.zsh";
+      }
+      {
+        name = "zsh-autosuggestions";
+        src = pkgs.zsh-autosuggestions;
+        file = "share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh";
+      }
+      {
+        name = "zsh-abbr";
+        src = pkgs.zsh-abbr;
+        file = "share/zsh/zsh-abbr/zsh-abbr.plugin.zsh";
+      }
+      {
+        name = "forgit";
+        src = pkgs.zsh-forgit;
+        file = "share/zsh/zsh-forgit/forgit.plugin.zsh";
+      }
+    ];
+
+    shellAliases = {
+      l = "ls -CF";
+    };
+
+    initContent = lib.mkMerge [
+      # === Pre-init: p10k instant prompt MUST be at very top ===
+      (lib.mkOrder 550 ''
+        if [[ -r "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh" ]]; then
+          source "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh"
+        fi
+      '')
+
+      # === p10k config (sourced after plugins, but functions are immediate) ===
+      (lib.mkOrder 1000 ''
+        # Powerlevel10k config (1738-line file inlined via readFile)
+        ${p10kConfig}
+      '')
+
+      # === Default-priority content (1000): main .zshrc.common body ===
+      ''
+        # --- Shell ---
+        [[ "$SHELL" != */zsh ]] && export SHELL=$(which zsh)
+
+        # --- Terminal Detection (SSH) ---
+        if [[ -n "$SSH_CONNECTION" && -z "$TERM_PROGRAM" && "$TERM" == *ghostty* ]]; then
+          export TERM_PROGRAM=ghostty
+        fi
+
+        # --- Path (user-managed, non-Nix) ---
+        [[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
+        [[ -d "$HOME/.pixi/bin" ]] && export PATH="$HOME/.pixi/bin:$PATH"
+        [[ -d "$HOME/.bun/bin" ]] && export PATH="$HOME/.bun/bin:$PATH"
+        [[ -d "$HOME/.atuin/bin" ]] && export PATH="$HOME/.atuin/bin:$PATH"
+        [[ -d "$HOME/.cargo/bin" ]] && export PATH="$HOME/.cargo/bin:$PATH"
+        export PATH="$HOME/dotfiles/scripts:$PATH"
+        [[ -d "$DENO_INSTALL/bin" ]] && export PATH="$DENO_INSTALL/bin:$PATH"
+        [[ -x "$HOME/syntopic/tools/packages/syntopic/bin/syntopic" ]] && \
+          export PATH="$HOME/syntopic/tools/packages/syntopic/bin:$PATH"
+        [[ -d "$HOME/bin" ]] && export PATH="$PATH:$HOME/bin"
+
+        # --- 1Password Secrets (non-interactive, graceful) ---
+        if command -v op &>/dev/null && op whoami &>/dev/null 2>&1; then
+          export JINA_API_KEY="$(op read "op://Personal/Jina AI/credential" 2>/dev/null)"
+        fi
+
+        # --- Interactive-only ---
+        [[ -o interactive ]] || return
+
+        # --- Tool integrations ---
+        command -v mise &>/dev/null && eval "$(mise activate zsh)"
+        command -v direnv &>/dev/null && eval "$(direnv hook zsh)"
+
+        # --- Completion ---
+        autoload -Uz compinit
+        if [[ -n ''${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
+          compinit
+        else
+          compinit -C
+        fi
+
+        # --- Conditional command aliases ---
+        if command -v lsd &>/dev/null; then
+          alias ls="lsd"
+          alias ll="lsd -l"
+          alias la="lsd -la"
+        elif command -v eza &>/dev/null; then
+          alias ls="eza --icons --git"
+          alias ll="eza --icons --git -l"
+          alias la="eza --icons --git -la"
+        fi
+
+        command -v rg &>/dev/null && alias grep="rg"
+        command -v fd &>/dev/null && alias find="fd"
+        command -v tldr &>/dev/null && alias man="tldr"
+        command -v sd &>/dev/null && alias sed="sd"
+        command -v dust &>/dev/null && alias du="dust"
+        command -v btm &>/dev/null && alias top="btm"
+        command -v rip &>/dev/null && alias rm="rip"
+        command -v viddy &>/dev/null && alias watch="viddy"
+        command -v doggo &>/dev/null && alias dig="doggo"
+        command -v xh &>/dev/null && alias http="xh"
+
+        # --- Global aliases (pipe modifiers) ---
+        alias -g L='| bat'
+        alias -g G='| rg'
+        alias -g C='| pbcopy'
+        alias -g H='| head'
+        alias -g T='| tail'
+
+        # --- Suffix aliases (open by extension) ---
+        alias -s {md,txt,yaml,yml,toml,json}=nvim
+        alias -s py=python
+        alias -s {png,jpg,jpeg,gif,webp}=open
+
+        # --- Modern tools (custom completions, starship, zoxide) ---
+        [[ -d "$HOME/.zsh/completions" ]] && fpath=("$HOME/.zsh/completions" $fpath)
+        command -v starship &>/dev/null && eval "$(starship init zsh)"
+        command -v zoxide &>/dev/null && eval "$(zoxide init zsh --cmd cd)"
+
+        # --- Auto ls on cd ---
+        chpwd() {
+          ls
+        }
+
+        # --- 1Password CLI helpers ---
+        if command -v op &>/dev/null; then
+          op_secret() {
+            op read "$1" 2>/dev/null
+          }
+
+          export_op_secret() {
+            local var_name="$1"
+            local op_ref="$2"
+            export "$var_name"="$(op read "$op_ref" 2>/dev/null)"
+          }
+
+          setup_git_from_op() {
+            local name email
+            name=$(op read "op://Personal/Git Config/name") || { echo "Failed to read name"; return 1; }
+            email=$(op read "op://Personal/Git Config/email") || { echo "Failed to read email"; return 1; }
+            cat > ~/.gitconfig.local << GITCFG
+        [user]
+            name = $name
+            email = $email
+        GITCFG
+            echo "Git config updated: $name <$email>"
+          }
+        fi
+
+        # --- Zsh options ---
+        setopt CORRECT
+        setopt AUTO_CD
+        setopt NO_FLOW_CONTROL
+
+        # --- Yazi (file manager) ---
+        y() {
+          local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd
+          yazi "$@" --cwd-file="$tmp"
+          if cwd="$(command cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+            builtin cd -- "$cwd"
+          fi
+          rm -f -- "$tmp"
+        }
+
+        # --- ghq + fzf repo picker ---
+        if command -v ghq &>/dev/null && command -v fzf &>/dev/null; then
+          repo() {
+            local selected
+            selected=$(ghq list | fzf --query="''${1:-}" \
+              --preview "bat --style=plain --color=always $(ghq root)/{}/README.md 2>/dev/null || eza --icons -la $(ghq root)/{} 2>/dev/null || ls -la $(ghq root)/{}" \
+              --preview-window=right:50%:wrap \
+              --prompt="repo> " \
+              --height=80%)
+            if [[ -n "$selected" ]]; then
+              cd "$(ghq root)/$selected"
+            fi
+          }
+        fi
+
+        # --- sesh widget (Alt-s) ---
+        if command -v sesh &>/dev/null && command -v fzf &>/dev/null; then
+          sesh-sessions() {
+            local session
+            session=$(sesh list -i | fzf --height 40% --reverse \
+              --border-label ' sesh ' --border --prompt '⚡  ' --ansi < /dev/tty)
+            if [[ -n "$session" ]]; then
+              BUFFER="sesh connect \"$session\""
+              zle accept-line
+            else
+              zle reset-prompt 2>/dev/null
+            fi
+          }
+          zle -N sesh-sessions
+          bindkey '\es' sesh-sessions
+        fi
+
+        # --- Claude wrapper ---
+        _claude_should_auto_name() {
+          case "''${1:-}" in
+            agents|auth|auto-mode|doctor|install|mcp|plugin|plugins|setup-token|update|upgrade)
+              return 1
+              ;;
+          esac
+          local arg
+          for arg in "$@"; do
+            case "$arg" in
+              -n|--name|--name=*|-r|--resume|--resume=*|--continue) return 1 ;;
+            esac
+          done
+          return 0
+        }
+
+        claude() {
+          printf '\033[?2004l'
+          local rc
+          local -a name_args=()
+          if _claude_should_auto_name "$@"; then
+            local auto_name
+            auto_name="$(git -C "$PWD" branch --show-current 2>/dev/null)"
+            [[ -z "$auto_name" ]] && auto_name="$(basename "$PWD")"
+            [[ -n "$auto_name" ]] && name_args=(--name "$auto_name")
+          fi
+          if [[ -f "$HOME/.local/share/claude-fallback/active" ]]; then
+            local fallback_env="$HOME/.local/share/claude-fallback/env"
+            source "$fallback_env"
+            ANTHROPIC_BASE_URL="https://openrouter.ai/api" \
+            ANTHROPIC_API_KEY="$OPENROUTER_API_KEY" \
+            command claude "''${name_args[@]}" "$@"
+          else
+            command claude "''${name_args[@]}" "$@"
+          fi
+          rc=$?
+          printf '\033[?2004h'
+          return $rc
+        }
+
+        # --- Local bin env (cargo etc.) ---
+        [[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"
+
+        # --- Claude context helpers (dexec/rssh/rcon/dotsync) ---
+        _claude_context() {
+          local project="''${CLAUDE_PROJECT:-$(basename "$PWD")}"
+          local device="$(hostname -s)"
+          local workspace="" tmux_session="" tmux_window=""
+          if [[ -n "$TMUX" ]]; then
+            tmux_session=$(tmux display-message -p '#S' 2>/dev/null)
+            tmux_window=$(tmux display-message -p '#I' 2>/dev/null)
+          fi
+          local map_file="''${HOME}/.local/share/claude/workspace_map.json"
+          if [[ -f "$map_file" ]]; then
+            local env_key
+            env_key=$(git rev-parse --show-toplevel 2>/dev/null)
+            [[ -z "$env_key" ]] && env_key="$PWD"
+            workspace=$(jq -r --arg key "$env_key" '.[$key].workspace // ""' "$map_file" 2>/dev/null)
+          fi
+          echo "{\"project\":\"$project\",\"device\":\"$device\",\"workspace\":\"$workspace\",\"tmux_session\":\"$tmux_session\",\"tmux_window\":\"$tmux_window\"}"
+        }
+
+        dexec() {
+          local container="$1"
+          [[ -z "$container" ]] && { echo "Usage: dexec <container> [command...]" >&2; return 1; }
+          shift
+          local context="''${CLAUDE_CONTEXT:-$(_claude_context)}"
+          docker exec -it -e TERM="$TERM" -e COLORTERM="$COLORTERM" -e CLAUDE_CONTEXT="$context" "$container" "''${@:-bash}"
+        }
+
+        rssh() {
+          local context="$(_claude_context)"
+          local args=()
+          local host=""
+          local cmd_start=-1
+          local i=1
+          for arg in "$@"; do
+            if [[ -z "$host" ]]; then
+              if [[ "$arg" == -* ]]; then
+                args+=("$arg")
+                if [[ "$arg" =~ ^-[pioJLRDWFl]$ ]]; then
+                  :
+                fi
+              elif [[ "''${args[-1]:-}" =~ ^-[pioJLRDWFl]$ ]]; then
+                args+=("$arg")
+              else
+                host="$arg"
+                args+=("$arg")
+                cmd_start=$((i + 1))
+              fi
+            fi
+            ((i++))
+          done
+          if [[ -z "$host" ]]; then
+            echo "Usage: rssh [ssh-options] <host> [command]" >&2
+            return 1
+          fi
+          local cmd=""
+          if [[ $cmd_start -le $# ]]; then
+            cmd="''${@:$cmd_start}"
+          fi
+          if [[ -n "$cmd" ]]; then
+            ssh "''${args[@]}" "export CLAUDE_CONTEXT='$context' && $cmd"
+          else
+            ssh -t "''${args[@]}" "export CLAUDE_CONTEXT='$context' && exec \$SHELL -l"
+          fi
+        }
+
+        rcon() {
+          local target="$1" session="$2"
+          if [[ -z "$target" ]]; then
+            local config_file="''${XDG_CONFIG_HOME:-$HOME/.config}/rcon/targets"
+            [[ ! -f "$config_file" ]] && { echo "rcon: config not found: $config_file" >&2; return 1; }
+            target=$(command grep -v '^\s*#' "$config_file" | command grep -v '^\s*$' | fzf --prompt="rcon> ")
+            [[ -z "$target" ]] && return 1
+          fi
+          local host container
+          if [[ "$target" == *:* ]]; then
+            host="''${target%%:*}"
+            container="''${target#*:}"
+          else
+            host="$target"
+          fi
+          local context="''${CLAUDE_CONTEXT:-$(_claude_context)}"
+          if [[ -n "$container" ]]; then
+            local sess="''${session:-$container}"
+            sess="''${sess//:/-}"
+            sess="''${sess//./-}"
+            ssh -t "$host" "
+              set -e
+              export PATH=\"\$HOME/.local/bin:\$PATH\"
+              export TERMINFO_DIRS=\"\$HOME/.terminfo:/usr/share/terminfo:/lib/terminfo\"
+              export CLAUDE_CONTEXT='$context'
+              export RCON_HOST_MACHINE='$host'
+              export RCON_CONTAINER='$container'
+              export RCON_HOST_HOME=\"\$HOME\"
+              cmd=\"\$HOME/dotfiles/scripts/tmux-docker-enter '$container'\"
+              container_wd=\$(docker inspect '$container' --format '{{.Config.WorkingDir}}' 2>/dev/null)
+              [ -z \"\$container_wd\" ] && container_wd=\"/\"
+              existing_path=\$(tmux list-sessions -F '#{session_path}' -f \"#{==:#{session_name},$sess}\" 2>/dev/null | head -1 || true)
+              if [ -n \"\$existing_path\" ] && [ \"\$existing_path\" != \"\$container_wd\" ]; then
+                echo \"rcon: recreating session '$sess' (session_path was '\$existing_path', should be '\$container_wd')\" >&2
+                tmux kill-session -t '$sess' 2>/dev/null || true
+              fi
+              tmux new-session -A -d -s '$sess' -c \"\$container_wd\" \"\$cmd\" 2>/dev/null || true
+              tmux set-option -t '$sess' default-command \"\$cmd\"
+              tmux set-option -t '$sess' '@rcon-host' '$host'
+              tmux set-option -t '$sess' '@rcon-container' '$container'
+              tmux set-option -t '$sess' '@rcon-container-home' \"\$container_wd\"
+              exec tmux attach-session -t '$sess'
+            "
+          else
+            local sess="''${session:-main}"
+            ssh -t "$host" "
+              export PATH=\"\$HOME/.local/bin:\$HOME/.pixi/bin:\$PATH\"
+              export TERMINFO_DIRS=\"\$HOME/.terminfo:/usr/share/terminfo:/lib/terminfo\"
+              export CLAUDE_CONTEXT='$context'
+              export RCON_HOST_MACHINE='$host'
+              zsh_bin=\$(command -v zsh 2>/dev/null) && export SHELL=\"\$zsh_bin\"
+              cwd=\"\$HOME\"
+              [ -d \"\$HOME/$sess\" ] && cwd=\"\$HOME/$sess\"
+              tmux new-session -A -d -s '$sess' -c \"\$cwd\" 2>/dev/null || true
+              tmux set-option -t '$sess' '@rcon-host' '$host'
+              exec tmux attach-session -t '$sess'
+            "
+          fi
+        }
+
+        dotsync() {
+          local skip_pull=false
+          [[ "$1" == "--no-pull" ]] && skip_pull=true
+          local repo_dir="''${DOTFILES_DIR:-$HOME/dotfiles}"
+          ( cd "$repo_dir" && git push ) || { echo "dotsync: push failed" >&2; return 1; }
+          if [[ "$skip_pull" == "false" ]]; then
+            ssh -o ConnectTimeout=5 ailab 'cd ~/dotfiles && git pull --ff-only' \
+              || { echo "dotsync: ailab pull failed (push succeeded)" >&2; return 1; }
+          fi
+        }
+
+        # --- Container pane cwd tracking ---
+        if [[ -f /.dockerenv ]] && [[ -n "''${TMUX_PANE:-}" ]] && [[ -d /tmp/tmux-pane-state ]]; then
+          _tmux_track_container_cwd() {
+            local num="''${TMUX_PANE#%}"
+            print -r -- "$PWD" > "/tmp/tmux-pane-state/cwd-''${num}" 2>/dev/null
+          }
+          typeset -ga chpwd_functions
+          chpwd_functions+=(_tmux_track_container_cwd)
+          _tmux_track_container_cwd
+        fi
+
+        # --- fzf zsh integration ---
+        command -v fzf &>/dev/null && source <(fzf --zsh)
+
+        # --- zsh-syntax-highlighting: initialize highlighters list ---
+        # .zshrc.local appends 'regexp' (for zsh-abbr coloring) without
+        # initializing the array, which would otherwise leave only regexp
+        # active and disable the default 'main' highlighter.
+        typeset -ga ZSH_HIGHLIGHT_HIGHLIGHTERS
+        ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets)
+
+        # --- OS-specific zshrc.local (mac/linux divergence stays in stow tree) ---
+        [[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
+
+        # --- zsh-abbr reload after .zshrc.local (which calls 'abbr import') ---
+        # Handled by .zshrc.local itself for now.
+      ''
+
+      # === Late: zsh-syntax-highlighting MUST load after everything else ===
+      # HM #7592 workaround: don't use programs.zsh.syntaxHighlighting.enable
+      # (no order guarantee). Source manually with mkOrder 5000.
+      (lib.mkOrder 5000 ''
+        source ${pkgs.zsh-syntax-highlighting}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+
+        # Force nix-managed paths to win. envExtra prepends them in .zshenv,
+        # but somewhere in the launchd → Ghostty → /etc/zprofile chain
+        # path_helper or similar reshuffles PATH and pushes them to the end.
+        # Re-prepend here at the very end of .zshrc so Nix binaries shadow
+        # /opt/homebrew/bin regardless of what happened earlier.
+        for p in \
+          "$HOME/.nix-profile/bin" \
+          "/etc/profiles/per-user/$USER/bin" \
+          "/run/current-system/sw/bin" \
+          "/nix/var/nix/profiles/default/bin"
+        do
+          [[ -d "$p" ]] && export PATH="$p:''${PATH/$p:/}"
+        done
+      '')
+    ];
+  };
+
+  # zsh-completions installs completion functions under
+  # share/zsh/site-functions which is already in FPATH for the user profile.
+  home.packages = [ pkgs.zsh-completions ];
+
+  programs.zoxide = {
+    enable = true;
+    enableZshIntegration = false; # we source zoxide manually for `--cmd cd`
+  };
+
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = false; # we source fzf manually
+  };
+}

--- a/nix/modules/packages/core.nix
+++ b/nix/modules/packages/core.nix
@@ -6,9 +6,9 @@
   # Casks (ghostty, raycast, karabiner-elements, aerospace) → Phase 1c.
   environment.systemPackages = with pkgs; [
     # Shell & Terminal
-    tmux
-    starship
-    sheldon
+    # tmux → home-manager (programs.tmux, Phase 2b)
+    # starship → home-manager (programs.starship, Phase 2b)
+    # sheldon REMOVED — replaced by programs.zsh.plugins (Phase 2b)
     atuin
     zoxide
     sesh


### PR DESCRIPTION
## Summary

Phase 2 PR 2 of 4 — shell stack migration. Replaces sheldon with `programs.zsh.plugins` and most TPM plugins with `programs.tmux.plugins`. Keeps `ataraxy-labs/opensessions` on TPM as a deliberate hybrid (it writes to its own checkout and runs local `bun` at activation, neither of which survives nixification cleanly).

## Plugin manager research

Before committing to Nix-native plugin management, surveyed the community (NixOS Discourse 2024-2026, multiple dotfiles repos, [Haseeb Majid's tmux+HM guide](https://haseebmajid.dev/posts/2023-07-10-setting-up-tmux-with-nix-home-manager/), [librephoenix dotfiles](https://librephoenix.com/2023-11-02-how-to-manage-your-dotfiles-the-nix-way-with-home-manager)). Findings:

- HM `programs.zsh.plugins` has 3 known footguns (syntax-highlighting load order [#7592](https://github.com/nix-community/home-manager/issues/7592), no deferred-load parity with sheldon, completion fpath edge cases). Workarounds are well-documented and applied below.
- HM `programs.tmux.plugins` covers all five upstream plugins we use; only opensessions resists nixification (runtime checkout + bun assumption).
- Community generally moves to Nix-native; hybrid setups (Evan Travers, librephoenix) coexist openly.

## Scaffold + configs

- `nix/home/programs/zsh.nix`: `programs.zsh.enable` + plugins (zsh-defer, zsh-autosuggestions, zsh-abbr, zsh-forgit). `envExtra` for FZF/forgit vars whose values embed double quotes. `initContent` via `lib.mkMerge` for ordered loading:
  - `mkOrder 550` — p10k instant prompt block
  - `mkOrder 1000` — p10k config (1738 lines inlined via `readFile`)
  - default — main `.zshrc.common` body (PATH, env, integrations, functions, `.zshrc.local` source)
  - `mkOrder 5000` — zsh-syntax-highlighting source + PATH refix
- `nix/home/programs/tmux.nix`: `programs.tmux.enable` + plugins (resurrect, continuum, vim-tmux-navigator, tmux-thumbs, tmux-which-key with custom config bundled via `overrideAttrs`, tmux-popup-manager local plugin via `mkTmuxPlugin`). Theme files and tmux-layout preset shipped through `xdg.configFile` / `xdg.dataFile`.
- `nix/home/programs/starship.nix`: `programs.starship.enable` with `settings = builtins.fromTOML (readFile starship.toml)` so the Powerline / Nerd Font codepoints (U+E0B0…) in the original survive verbatim.
- `nix/home/programs/zsh-abbr.nix`: `xdg.configFile` for the `user-abbreviations` file.
- `nix/home/programs/tmux/tmux.conf`: copy of the original with Nix-managed `@plugin` lines stripped; TPM line kept solely for opensessions.

## Package layer + .zshrc.local adjustments

- `nix/modules/packages/core.nix`: drop tmux, starship, sheldon. sheldon binary still in Brewfile (`brew "sheldon"`); cleanup deferred to Phase 6.
- `mac/zsh/.zshrc.local`: remove `eval "$(sheldon source)"`. The in-stow `ZSH_HIGHLIGHT_HIGHLIGHTERS+=(regexp)` line is now safe because `zsh.nix` initialises the array to `(main brackets)` before sourcing `.zshrc.local`.

## PATH precedence fix (Phase 2a carryover)

`brew shellenv` / `path_helper` was pushing `/etc/profiles/per-user/$USER/bin` to the end of PATH on a fresh Ghostty shell, causing Homebrew binaries to shadow Nix-installed ones. Two-stage fix:

- `envExtra` prepends nix paths in `.zshenv` (runs in all shells).
- A second prepend inside `mkOrder 5000` re-asserts them at the very end of `.zshrc`, surviving any path_helper-style reshuffling.

Result: `which fd` / `which tmux` / `which starship` all resolve to `/etc/profiles/per-user/$USER/bin/...`.

## Validation (shonenm)

- [x] `nix flake check` passes
- [x] `nix build .#darwinConfigurations.shonenm.system --no-link` passes
- [x] `sudo darwin-rebuild switch --flake .#shonenm` succeeds
- [x] PATH ordering: positions 1-3 = nix paths, all binaries resolve to nix profile
- [x] `abbr` is from `/nix/store/.../zsh-abbr-6.5.2`, 66 abbreviations imported
- [x] `_zsh_highlight` is from `/nix/store/.../zsh-syntax-highlighting-0.8.0`
- [x] `_zsh_autosuggest_start` from home-manager plugin dir
- [x] `forgit::log` resolved
- [x] `ZSH_HIGHLIGHT_HIGHLIGHTERS = (main brackets regexp)` — basic + zsh-abbr highlighting active
- [x] All tmux plugins `run-shell` from `/nix/store/...` derivations
- [x] tmux-which-key picks up the bundled `config.yaml`
- [x] starship prompt renders with full rounded segment caps (fromTOML preserved codepoints)
- [x] opensessions still loads via TPM (sidebar visible)

## Out of scope (deferred to Phase 6)

- Removal of `common/{tmux,zsh,zsh-abbr,sheldon,starship}/` legacy stow trees
- `brew "sheldon"` removal from `config/Brewfile`
- opensessions full nixification

## Pre-switch manual steps (executed)

```bash
for pkg in tmux zsh zsh-abbr sheldon starship; do
  stow -D -d common -t ~ "$pkg" || true
done
rm ~/.zshenv ~/.zshrc ~/.zprofile ~/.p10k.zsh
rm ~/.config/tmux ~/.config/sheldon
rm ~/.config/starship.toml ~/.config/zsh-abbr
```

## Refs

- Phase 0: #138, #139
- Phase 1a: #142, #149
- Phase 2a: #151, #153
- Plan: `docs/nix-migration-plan.md` § Phase 2
- Chunking decision: Option B (4 PRs) + Decision 2 (declarative)
- Plugin manager community research: NixOS Discourse 2024-2026, librephoenix, Haseeb Majid

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)