### PR TITLE
imprv(pi): enhanced statusline with color segments, MCP stats, and context bar

### DIFF
--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -178,47 +178,31 @@ export default function (pi: ExtensionAPI) {
             ? theme.fg(ctxColor, gauge(pct, 10))
             : "";
 
-          // ---- Line 1: tokens + gauge + cost + branch + model ----
-          const line1Parts: string[] = [];
-          line1Parts.push(`${tokIn} ${tokOut}`);       // always
-          if (gaugeStr) line1Parts.push(gaugeStr);      // always if context available
-          line1Parts.push(tokCost);                      // always
-          if (branchStr) line1Parts.push(branchStr);     // if in git repo
-          line1Parts.push(modelStr);                     // always
-
-          const line1 = line1Parts.join(" │ ");
-
-          // ---- Line 2: web stats + mcp stats ----
-          const line2Parts: string[] = [];
-          if (stats.webSearch > 0 || stats.webFetch > 0) {
-            line2Parts.push(
-              theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`)
-            );
-          }
-          if (stats.mcpCalls > 0) {
-            line2Parts.push(
-              theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`)
-            );
-          }
+          // ---- Layout: 3-line, all left-aligned ----
+          // Line 1: tokens + gauge + cost
+          // Line 2: branch + model
+          // Line 3: web stats + mcp stats (only if data exists)
 
           if (mode === "compact") {
-            // Single line: tokens + model only
-            const left = `${tokIn} ${tokOut} ${tokCost}`;
-            const right = modelStr;
-            const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
-            return [truncateToWidth(left + " ".repeat(pad) + right, width)];
+            return [truncateToWidth(`${tokIn} ${tokOut} ${tokCost}  ${modelStr}`, width)];
           }
 
-          // Detailed: 1-2 lines
-          if (line2Parts.length === 0) {
-            return [truncateToWidth(line1, width)];
-          }
+          const l1 = [tokIn, tokOut, gaugeStr, tokCost].filter(Boolean).join(" │ ");
+          const lines = [truncateToWidth(l1, width)];
 
-          const line2 = line2Parts.join(" · ");
-          return [
-            truncateToWidth(line1, width),
-            truncateToWidth(line2, width),
-          ];
+          const l2 = [branchStr, modelStr].filter(Boolean).join(" · ");
+          if (l2) lines.push(truncateToWidth(l2, width));
+
+          const l3: string[] = [];
+          if (stats.webSearch > 0 || stats.webFetch > 0) {
+            l3.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
+          }
+          if (stats.mcpCalls > 0) {
+            l3.push(theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`));
+          }
+          if (l3.length > 0) lines.push(truncateToWidth(l3.join(" · "), width));
+
+          return lines;
         },
       };
     });

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -1,12 +1,12 @@
 // Statusline Extension for pi
 //
-// Enhanced footer with:
-//   - 3 display modes: detailed / compact / off (toggle via /statusline)
-//   - Color-coded token stats (green/yellow/red by context usage)
-//   - Visual context progress bar: [======>  ] 45%
-//   - MCP activity stats alongside web stats
-//   - Multi-line layout when width is insufficient
-//   - Unified stats reading from ~/.pi/research/
+// Multi-line footer with:
+//   Line 1: token stats + context gauge + cost + branch + model
+//   Line 2: web stats + MCP stats
+//   3 modes: detailed / compact / off (toggle via /statusline)
+//
+// The gauge is a plain-character progress bar: ████░░░░░░  29%
+// No ANSI codes inside compound strings to avoid truncation issues.
 
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -33,14 +33,11 @@ const DIRTY_CHECK_INTERVAL_MS = 5000;
 function checkGitDirty(): boolean {
   try {
     const output = execSync("git status --porcelain", {
-      encoding: "utf-8",
-      timeout: 1000,
+      encoding: "utf-8", timeout: 1000,
       stdio: ["pipe", "pipe", "ignore"],
     });
     return output.trim().length > 0;
-  } catch {
-    return false;
-  }
+  } catch { return false; }
 }
 
 function formatTokens(n: number): string {
@@ -50,13 +47,8 @@ function formatTokens(n: number): string {
 }
 
 interface StatsSnapshot {
-  webSearch: number;
-  webFetch: number;
-  webCache: number;
-  webCite: number;
-  mcpCalls: number;
-  mcpErrors: number;
-  mcpServers: number;
+  webSearch: number; webFetch: number; webCache: number;
+  mcpCalls: number; mcpErrors: number;
 }
 
 let cachedStats: StatsSnapshot | null = null;
@@ -66,36 +58,29 @@ const STATS_CACHE_TTL = 10_000;
 function readStats(): StatsSnapshot {
   const now = Date.now();
   if (cachedStats && now - statsCacheMs < STATS_CACHE_TTL) return cachedStats;
-
-  const stats: StatsSnapshot = {
-    webSearch: 0, webFetch: 0, webCache: 0, webCite: 0,
-    mcpCalls: 0, mcpErrors: 0, mcpServers: 0,
-  };
-
+  const s: StatsSnapshot = { webSearch: 0, webFetch: 0, webCache: 0, mcpCalls: 0, mcpErrors: 0 };
   const dir = join(homedir(), ".pi", "research");
-
-  // Web stats
   try {
     const ws = JSON.parse(readFileSync(join(dir, "stats.json"), "utf-8"));
-    stats.webSearch = ws.searchCount ?? 0;
-    stats.webFetch = ws.fetchCount ?? 0;
-    stats.webCache = ws.cacheHits ?? 0;
-    stats.webCite = ws.citationCount ?? 0;
+    s.webSearch = ws.searchCount ?? 0; s.webFetch = ws.fetchCount ?? 0; s.webCache = ws.cacheHits ?? 0;
   } catch { /* ignore */ }
-
-  // MCP stats
   try {
     const ms = JSON.parse(readFileSync(join(dir, "mcp-stats.json"), "utf-8"));
-    for (const [, v] of Object.entries(ms) as [string, { calls?: number; errors?: number; totalMs?: number }][]) {
-      stats.mcpCalls += v.calls ?? 0;
-      stats.mcpErrors += v.errors ?? 0;
+    for (const [, v] of Object.entries(ms) as [string, { calls?: number; errors?: number }][]) {
+      s.mcpCalls += v.calls ?? 0; s.mcpErrors += v.errors ?? 0;
     }
-    stats.mcpServers = Object.keys(ms).length;
   } catch { /* ignore */ }
+  cachedStats = s; statsCacheMs = now;
+  return s;
+}
 
-  cachedStats = stats;
-  statsCacheMs = now;
-  return stats;
+/**
+ * Plain-character progress gauge. Safe to use inside theme.fg() because the
+ * characters have no ANSI codes. Returns something like "████░░░░  29%".
+ */
+function gauge(pct: number, barChars: number): string {
+  const filled = Math.round((pct / 100) * barChars);
+  return "█".repeat(filled) + "░".repeat(barChars - filled) + ` ${pct.toFixed(0)}%`;
 }
 
 // ---------------------------------------------------------------------------
@@ -109,27 +94,22 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand("statusline", {
     description: "Toggle statusline mode: detailed, compact, or off",
     getArgumentCompletions: () => [
-      { value: "detailed", label: "Full info with progress bar" },
-      { value: "compact", label: "Minimal (model + branch + token count)" },
+      { value: "detailed", label: "Two-line layout with gauge and all stats" },
+      { value: "compact", label: "Single line, minimal" },
       { value: "off", label: "Disable custom statusline" },
     ],
     handler: async (args, ctx) => {
       if (args === "detailed" || args === "compact" || args === "off") {
         mode = args;
       } else {
-        // Cycle: detailed → compact → off → detailed
         const cycle: DisplayMode[] = ["detailed", "compact", "off"];
-        const idx = cycle.indexOf(mode);
-        mode = cycle[(idx + 1) % cycle.length];
+        mode = cycle[(cycle.indexOf(mode) + 1) % cycle.length];
       }
-
       if (mode === "off") {
         ctx.ui.setFooter(undefined);
-        ctx.ui.notify("Statusline: off (default footer)", "info");
-      } else if (mode === "compact") {
-        ctx.ui.notify("Statusline: compact mode", "info");
+        ctx.ui.notify("Statusline: off", "info");
       } else {
-        ctx.ui.notify("Statusline: detailed mode", "info");
+        ctx.ui.notify(`Statusline: ${mode}`, "info");
       }
     },
   });
@@ -141,15 +121,12 @@ export default function (pi: ExtensionAPI) {
     if (mode === "off") return;
     const now = Date.now();
     if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
-      dirtyState = checkGitDirty();
-      lastDirtyCheck = now;
+      dirtyState = checkGitDirty(); lastDirtyCheck = now;
     }
   });
-
   pi.on("session_start", async () => {
     if (mode === "off") return;
-    dirtyState = checkGitDirty();
-    lastDirtyCheck = Date.now();
+    dirtyState = checkGitDirty(); lastDirtyCheck = Date.now();
   });
 
   // -----------------------------------------------------------------------
@@ -158,21 +135,18 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     ctx.ui.setFooter((tui, theme, footerData) => {
       const unsub = footerData.onBranchChange(() => tui.requestRender());
-
       return {
         dispose: unsub,
         invalidate() {},
         render(width: number): string[] {
           if (mode === "off") return [];
 
-          // ---- Token stats ----
+          // ---- Accumulate token stats ----
           let input = 0, output = 0, cost = 0;
           for (const e of ctx.sessionManager.getBranch()) {
             if (e.type === "message" && e.message.role === "assistant") {
               const m = e.message as AssistantMessage;
-              input += m.usage.input;
-              output += m.usage.output;
-              cost += m.usage.cost.total;
+              input += m.usage.input; output += m.usage.output; cost += m.usage.cost.total;
             }
           }
 
@@ -185,90 +159,66 @@ export default function (pi: ExtensionAPI) {
           // ---- Stats ----
           const stats = readStats();
 
-          // ---- Git ----
+          // ---- Git / Model ----
           const branch = footerData.getGitBranch();
-          const branchColor = dirtyState ? "warning" : "accent";
           const branchStr = branch
-            ? `${theme.fg(branchColor, branch)}${dirtyState ? theme.fg("warning", "*") : ""}`
+            ? `${theme.fg(dirtyState ? "warning" : "accent", branch)}${dirtyState ? theme.fg("warning", "*") : ""}`
             : "";
-
-          // ---- Model ----
           const modelStr = theme.fg("muted", ctx.model?.id || "no-model");
 
-          // ---- Color-coded segments ----
+          // ---- Tokens (left side) ----
+          const tokIn = theme.fg("text", `↑${formatTokens(input)}`);
+          const tokOut = theme.fg("accent", `↓${formatTokens(output)}`);
           const costColor = cost > 1 ? "warning" : cost > 0.1 ? "text" : "dim";
+          const tokCost = theme.fg(costColor, `$${cost.toFixed(3)}`);
+
+          // ---- Gauge ----
           const ctxColor = pct > 80 ? "error" : pct > 60 ? "warning" : "success";
+          const gaugeStr = capacity > 0
+            ? theme.fg(ctxColor, gauge(pct, 10))
+            : "";
 
-          // ---- Left side ----
-          const segIn = theme.fg("text", `↑${formatTokens(input)}`);
-          const segOut = theme.fg("accent", `↓${formatTokens(output)}`);
-          const segCost = theme.fg(costColor, `$${cost.toFixed(3)}`);
+          // ---- Line 1: tokens + gauge + cost + branch + model ----
+          const line1Parts: string[] = [];
+          line1Parts.push(`${tokIn} ${tokOut}`);       // always
+          if (gaugeStr) line1Parts.push(gaugeStr);      // always if context available
+          line1Parts.push(tokCost);                      // always
+          if (branchStr) line1Parts.push(branchStr);     // if in git repo
+          line1Parts.push(modelStr);                     // always
 
-          // ---- Layout: progressive hiding from right to left as width decreases ----
-          // Elements from right to left (first to hide → last to hide):
-          //   model → branch → mcp stats → web stats → context gauge → cost → output → input
+          const line1 = line1Parts.join(" │ ");
+
+          // ---- Line 2: web stats + mcp stats ----
+          const line2Parts: string[] = [];
+          if (stats.webSearch > 0 || stats.webFetch > 0) {
+            line2Parts.push(
+              theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`)
+            );
+          }
+          if (stats.mcpCalls > 0) {
+            line2Parts.push(
+              theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`)
+            );
+          }
 
           if (mode === "compact") {
-            // Compact: minimal, always single line
-            const left = `${segIn} ${segOut} ${segCost}`;
-            const right = [modelStr].join(" ");
+            // Single line: tokens + model only
+            const left = `${tokIn} ${tokOut} ${tokCost}`;
+            const right = modelStr;
             const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
             return [truncateToWidth(left + " ".repeat(pad) + right, width)];
           }
 
-          // Detailed: progressive layout
-          // Build a single line, dropping elements from right as space shrinks.
-          // Use color ONLY on simple tokens (no ANSI inside compound strings that get truncated).
-          const lines: string[] = [];
-
-          // Left base: always show tokens
-          const leftBase = `${segIn} ${segOut} ${segCost}`;
-
-          // Context gauge (simple text, pre-colored via ctxColor)
-          const ctxGauge = capacity > 0
-            ? ` ${theme.fg(ctxColor, `[${pct.toFixed(0)}%]`)}`
-            : "";
-
-          // Right elements in priority order (first to drop = rightmost)
-          const rightElems: string[] = [];
-          if (branchStr) rightElems.push(branchStr);
-          if (stats.webSearch > 0 || stats.webFetch > 0) {
-            rightElems.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
-          }
-          if (stats.mcpCalls > 0) {
-            rightElems.push(theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`));
-          }
-          rightElems.push(modelStr);
-
-          // Try fitting everything on one line. If not, drop elements or fall back to two lines.
-          const fullLeft = leftBase + ctxGauge;
-          const fullRight = rightElems.join(" ");
-          const fullWidth = visibleWidth(fullLeft) + visibleWidth(fullRight) + 1;
-
-          if (fullWidth <= width) {
-            // Everything fits on one line
-            const pad = " ".repeat(width - visibleWidth(fullLeft) - visibleWidth(fullRight));
-            lines.push(fullLeft + pad + fullRight);
-          } else {
-            // Doesn't fit. Try dropping right elements one by one.
-            let dropped = false;
-            for (let i = rightElems.length; i >= 0; i--) {
-              const r = rightElems.slice(0, i).join(" ");
-              const w = visibleWidth(fullLeft) + (r ? visibleWidth(r) + 1 : 0);
-              if (w <= width) {
-                const pad = r ? " ".repeat(width - visibleWidth(fullLeft) - visibleWidth(r)) : "";
-                lines.push(fullLeft + (r ? pad + r : ""));
-                dropped = true;
-                break;
-              }
-            }
-            if (!dropped) {
-              // Even tokens alone don't fit — minimal fallback
-              lines.push(truncateToWidth(leftBase, width));
-            }
+          // Detailed: 1-2 lines
+          if (line2Parts.length === 0) {
+            return [truncateToWidth(line1, width)];
           }
 
-          return lines;
+          const line2 = line2Parts.join(" · ");
+          return [
+            truncateToWidth(line1, width),
+            truncateToWidth(line2, width),
+          ];
         },
       };
     });

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -25,8 +25,6 @@ let mode: DisplayMode = "detailed";
 let dirtyState = false;
 let lastDirtyCheck = 0;
 const DIRTY_CHECK_INTERVAL_MS = 5000;
-const MIN_WIDTH_COMPACT = 60;
-const MIN_WIDTH_SINGLE = 100;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -98,15 +96,6 @@ function readStats(): StatsSnapshot {
   cachedStats = stats;
   statsCacheMs = now;
   return stats;
-}
-
-function contextBar(pct: number, width: number, theme: any): string {
-  const barWidth = Math.max(4, width);
-  const filled = Math.round((pct / 100) * barWidth);
-  const arrow = filled > 0 && filled < barWidth ? ">" : "";
-  const bar = "=".repeat(Math.max(0, filled - (arrow ? 1 : 0))) + arrow + " ".repeat(Math.max(0, barWidth - filled));
-  const color = pct > 80 ? "error" : pct > 60 ? "warning" : "success";
-  return theme.fg(color, `[${bar}]`) + ` ${pct.toFixed(0)}%`;
 }
 
 // ---------------------------------------------------------------------------
@@ -215,50 +204,71 @@ export default function (pi: ExtensionAPI) {
           const segOut = theme.fg("accent", `↓${formatTokens(output)}`);
           const segCost = theme.fg(costColor, `$${cost.toFixed(3)}`);
 
-          // ---- Right segments ----
-          const parts: string[] = [];
+          // ---- Layout: progressive hiding from right to left as width decreases ----
+          // Elements from right to left (first to hide → last to hide):
+          //   model → branch → mcp stats → web stats → context gauge → cost → output → input
 
-          // Web stats
-          if (stats.webSearch > 0 || stats.webFetch > 0) {
-            parts.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
-          }
-
-          // MCP stats
-          if (stats.mcpCalls > 0) {
-            parts.push(theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? `×${stats.mcpErrors}` : ""}`));
-          }
-
-          if (branchStr) parts.push(branchStr);
-          parts.push(modelStr);
-
-          // ---- Layout ----
-          if (mode === "compact" || width < MIN_WIDTH_COMPACT) {
-            // Compact: single line, minimal
+          if (mode === "compact") {
+            // Compact: minimal, always single line
             const left = `${segIn} ${segOut} ${segCost}`;
-            const right = [...parts, modelStr].filter(Boolean).join(" ");
+            const right = [modelStr].join(" ");
             const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
             return [truncateToWidth(left + " ".repeat(pad) + right, width)];
           }
 
-          // Detailed: full layout
-          const ctxBar = capacity > 0
-            ? contextBar(pct, Math.min(20, Math.floor(width * 0.15)), theme)
+          // Detailed: progressive layout
+          // Build a single line, dropping elements from right as space shrinks.
+          // Use color ONLY on simple tokens (no ANSI inside compound strings that get truncated).
+          const lines: string[] = [];
+
+          // Left base: always show tokens
+          const leftBase = `${segIn} ${segOut} ${segCost}`;
+
+          // Context gauge (simple text, pre-colored via ctxColor)
+          const ctxGauge = capacity > 0
+            ? ` ${theme.fg(ctxColor, `[${pct.toFixed(0)}%]`)}`
             : "";
 
-          const left = [segIn, segOut, segCost, ctxBar].filter(Boolean).join(" ");
-          const right = parts.join(" ");
+          // Right elements in priority order (first to drop = rightmost)
+          const rightElems: string[] = [];
+          if (branchStr) rightElems.push(branchStr);
+          if (stats.webSearch > 0 || stats.webFetch > 0) {
+            rightElems.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
+          }
+          if (stats.mcpCalls > 0) {
+            rightElems.push(theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`));
+          }
+          rightElems.push(modelStr);
 
-          if (width >= MIN_WIDTH_SINGLE) {
-            // Single line
-            const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
-            return [truncateToWidth(left + " ".repeat(pad) + right, width)];
+          // Try fitting everything on one line. If not, drop elements or fall back to two lines.
+          const fullLeft = leftBase + ctxGauge;
+          const fullRight = rightElems.join(" ");
+          const fullWidth = visibleWidth(fullLeft) + visibleWidth(fullRight) + 1;
+
+          if (fullWidth <= width) {
+            // Everything fits on one line
+            const pad = " ".repeat(width - visibleWidth(fullLeft) - visibleWidth(fullRight));
+            lines.push(fullLeft + pad + fullRight);
+          } else {
+            // Doesn't fit. Try dropping right elements one by one.
+            let dropped = false;
+            for (let i = rightElems.length; i >= 0; i--) {
+              const r = rightElems.slice(0, i).join(" ");
+              const w = visibleWidth(fullLeft) + (r ? visibleWidth(r) + 1 : 0);
+              if (w <= width) {
+                const pad = r ? " ".repeat(width - visibleWidth(fullLeft) - visibleWidth(r)) : "";
+                lines.push(fullLeft + (r ? pad + r : ""));
+                dropped = true;
+                break;
+              }
+            }
+            if (!dropped) {
+              // Even tokens alone don't fit — minimal fallback
+              lines.push(truncateToWidth(leftBase, width));
+            }
           }
 
-          // Multi-line: stats on separate line when narrow
-          return [
-            truncateToWidth(left, width),
-            truncateToWidth(" ".repeat(Math.max(0, width - visibleWidth(right))) + right, width),
-          ];
+          return lines;
         },
       };
     });

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -1,12 +1,12 @@
 // Statusline Extension for pi
-// Replaces the footer with a richer status line showing:
-//   - Token stats (input/output/cost)
-//   - Git branch + dirty state
-//   - Context capacity
-//   - Web research activity (searches, fetches, cache hits)
-//   - Current model
 //
-// Toggle via /statusline command.
+// Enhanced footer with:
+//   - 3 display modes: detailed / compact / off (toggle via /statusline)
+//   - Color-coded token stats (green/yellow/red by context usage)
+//   - Visual context progress bar: [======>  ] 45%
+//   - MCP activity stats alongside web stats
+//   - Multi-line layout when width is insufficient
+//   - Unified stats reading from ~/.pi/research/
 
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -16,10 +16,21 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-let enabled = true;
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+type DisplayMode = "off" | "compact" | "detailed";
+let mode: DisplayMode = "detailed";
 let dirtyState = false;
 let lastDirtyCheck = 0;
 const DIRTY_CHECK_INTERVAL_MS = 5000;
+const MIN_WIDTH_COMPACT = 60;
+const MIN_WIDTH_SINGLE = 100;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function checkGitDirty(): boolean {
   try {
@@ -36,28 +47,109 @@ function checkGitDirty(): boolean {
 
 function formatTokens(n: number): string {
   if (n < 1000) return `${n}`;
-  if (n < 1000000) return `${(n / 1000).toFixed(1)}k`;
-  return `${(n / 1000000).toFixed(1)}M`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
+interface StatsSnapshot {
+  webSearch: number;
+  webFetch: number;
+  webCache: number;
+  webCite: number;
+  mcpCalls: number;
+  mcpErrors: number;
+  mcpServers: number;
+}
+
+let cachedStats: StatsSnapshot | null = null;
+let statsCacheMs = 0;
+const STATS_CACHE_TTL = 10_000;
+
+function readStats(): StatsSnapshot {
+  const now = Date.now();
+  if (cachedStats && now - statsCacheMs < STATS_CACHE_TTL) return cachedStats;
+
+  const stats: StatsSnapshot = {
+    webSearch: 0, webFetch: 0, webCache: 0, webCite: 0,
+    mcpCalls: 0, mcpErrors: 0, mcpServers: 0,
+  };
+
+  const dir = join(homedir(), ".pi", "research");
+
+  // Web stats
+  try {
+    const ws = JSON.parse(readFileSync(join(dir, "stats.json"), "utf-8"));
+    stats.webSearch = ws.searchCount ?? 0;
+    stats.webFetch = ws.fetchCount ?? 0;
+    stats.webCache = ws.cacheHits ?? 0;
+    stats.webCite = ws.citationCount ?? 0;
+  } catch { /* ignore */ }
+
+  // MCP stats
+  try {
+    const ms = JSON.parse(readFileSync(join(dir, "mcp-stats.json"), "utf-8"));
+    for (const [, v] of Object.entries(ms) as [string, { calls?: number; errors?: number; totalMs?: number }][]) {
+      stats.mcpCalls += v.calls ?? 0;
+      stats.mcpErrors += v.errors ?? 0;
+    }
+    stats.mcpServers = Object.keys(ms).length;
+  } catch { /* ignore */ }
+
+  cachedStats = stats;
+  statsCacheMs = now;
+  return stats;
+}
+
+function contextBar(pct: number, width: number, theme: any): string {
+  const barWidth = Math.max(4, width);
+  const filled = Math.round((pct / 100) * barWidth);
+  const arrow = filled > 0 && filled < barWidth ? ">" : "";
+  const bar = "=".repeat(Math.max(0, filled - (arrow ? 1 : 0))) + arrow + " ".repeat(Math.max(0, barWidth - filled));
+  const color = pct > 80 ? "error" : pct > 60 ? "warning" : "success";
+  return theme.fg(color, `[${bar}]`) + ` ${pct.toFixed(0)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
 export default function (pi: ExtensionAPI) {
-  // Toggle command
+  // -----------------------------------------------------------------------
+  // Command: /statusline [detailed|compact|off]
+  // -----------------------------------------------------------------------
   pi.registerCommand("statusline", {
-    description: "Toggle custom statusline footer",
-    handler: async (_args, ctx) => {
-      enabled = !enabled;
-      if (enabled) {
-        ctx.ui.notify("Statusline enabled", "info");
+    description: "Toggle statusline mode: detailed, compact, or off",
+    getArgumentCompletions: () => [
+      { value: "detailed", label: "Full info with progress bar" },
+      { value: "compact", label: "Minimal (model + branch + token count)" },
+      { value: "off", label: "Disable custom statusline" },
+    ],
+    handler: async (args, ctx) => {
+      if (args === "detailed" || args === "compact" || args === "off") {
+        mode = args;
       } else {
+        // Cycle: detailed → compact → off → detailed
+        const cycle: DisplayMode[] = ["detailed", "compact", "off"];
+        const idx = cycle.indexOf(mode);
+        mode = cycle[(idx + 1) % cycle.length];
+      }
+
+      if (mode === "off") {
         ctx.ui.setFooter(undefined);
-        ctx.ui.notify("Default footer restored", "info");
+        ctx.ui.notify("Statusline: off (default footer)", "info");
+      } else if (mode === "compact") {
+        ctx.ui.notify("Statusline: compact mode", "info");
+      } else {
+        ctx.ui.notify("Statusline: detailed mode", "info");
       }
     },
   });
 
-  // Update dirty state after each turn (user has likely made edits)
+  // -----------------------------------------------------------------------
+  // Git dirty check
+  // -----------------------------------------------------------------------
   pi.on("turn_end", async () => {
-    if (!enabled) return;
+    if (mode === "off") return;
     const now = Date.now();
     if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
       dirtyState = checkGitDirty();
@@ -65,17 +157,16 @@ export default function (pi: ExtensionAPI) {
     }
   });
 
-  // Also check on session start
   pi.on("session_start", async () => {
-    if (!enabled) return;
+    if (mode === "off") return;
     dirtyState = checkGitDirty();
     lastDirtyCheck = Date.now();
   });
 
-  // Install custom footer on session start
+  // -----------------------------------------------------------------------
+  // Footer renderer
+  // -----------------------------------------------------------------------
   pi.on("session_start", async (_event, ctx) => {
-    if (!enabled) return;
-
     ctx.ui.setFooter((tui, theme, footerData) => {
       const unsub = footerData.onBranchChange(() => tui.requestRender());
 
@@ -83,10 +174,10 @@ export default function (pi: ExtensionAPI) {
         dispose: unsub,
         invalidate() {},
         render(width: number): string[] {
-          // Token stats from session branch
-          let input = 0,
-            output = 0,
-            cost = 0;
+          if (mode === "off") return [];
+
+          // ---- Token stats ----
+          let input = 0, output = 0, cost = 0;
           for (const e of ctx.sessionManager.getBranch()) {
             if (e.type === "message" && e.message.role === "assistant") {
               const m = e.message as AssistantMessage;
@@ -96,64 +187,78 @@ export default function (pi: ExtensionAPI) {
             }
           }
 
-          // Git branch with color
-          const branch = footerData.getGitBranch();
-          const branchColor = dirtyState ? "warning" : "accent";
-          const branchStr = branch
-            ? ` ${theme.fg(branchColor, branch)}${dirtyState ? theme.fg("warning", "*") : ""} `
-            : "";
-
-          // Model
-          const modelStr = theme.fg("muted", ctx.model?.id || "no-model");
-
-          // Context capacity with color based on usage
+          // ---- Context ----
           const usage = ctx.getContextUsage();
           const capacity = ctx.model?.contextWindow ?? 0;
           const used = usage?.tokens ?? 0;
           const pct = capacity > 0 ? (used / capacity) * 100 : 0;
+
+          // ---- Stats ----
+          const stats = readStats();
+
+          // ---- Git ----
+          const branch = footerData.getGitBranch();
+          const branchColor = dirtyState ? "warning" : "accent";
+          const branchStr = branch
+            ? `${theme.fg(branchColor, branch)}${dirtyState ? theme.fg("warning", "*") : ""}`
+            : "";
+
+          // ---- Model ----
+          const modelStr = theme.fg("muted", ctx.model?.id || "no-model");
+
+          // ---- Color-coded segments ----
+          const costColor = cost > 1 ? "warning" : cost > 0.1 ? "text" : "dim";
           const ctxColor = pct > 80 ? "error" : pct > 60 ? "warning" : "success";
-          const ctxStr =
-            capacity > 0
-              ? theme.fg(ctxColor, `${formatTokens(used)}/${formatTokens(capacity)} (${pct.toFixed(0)}%)`)
-              : "";
 
-          // Research stats from audit log
-          const statsFile = join(homedir(), ".pi", "research", "stats.json");
-          let searchCount = 0;
-          let fetchCount = 0;
-          let cacheHits = 0;
-          if (existsSync(statsFile)) {
-            try {
-              const stats = JSON.parse(readFileSync(statsFile, "utf-8"));
-              searchCount = stats.searchCount ?? 0;
-              fetchCount = stats.fetchCount ?? 0;
-              cacheHits = stats.cacheHits ?? 0;
-            } catch { /* ignore */ }
+          // ---- Left side ----
+          const segIn = theme.fg("text", `↑${formatTokens(input)}`);
+          const segOut = theme.fg("accent", `↓${formatTokens(output)}`);
+          const segCost = theme.fg(costColor, `$${cost.toFixed(3)}`);
+
+          // ---- Right segments ----
+          const parts: string[] = [];
+
+          // Web stats
+          if (stats.webSearch > 0 || stats.webFetch > 0) {
+            parts.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
           }
-          const researchStr =
-            searchCount > 0 || fetchCount > 0
-              ? theme.fg("dim", `web q:${searchCount} f:${fetchCount} c:${cacheHits}`) + " "
-              : "";
 
-          // Left: colorful token stats + research
-          const inputStr = theme.fg("text", `↑${formatTokens(input)}`);
-          const outputStr = theme.fg("accent", `↓${formatTokens(output)}`);
-          const costStr = theme.fg("success", `$${cost.toFixed(3)}`);
+          // MCP stats
+          if (stats.mcpCalls > 0) {
+            parts.push(theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? `×${stats.mcpErrors}` : ""}`));
+          }
 
-          const leftParts = [inputStr, outputStr, costStr];
-          if (ctxStr) leftParts.push(ctxStr);
-          const left = leftParts.join(" ");
+          if (branchStr) parts.push(branchStr);
+          parts.push(modelStr);
 
-          // Right: research + branch + model
-          const right = `${researchStr}${branchStr}${modelStr}`.trimStart();
+          // ---- Layout ----
+          if (mode === "compact" || width < MIN_WIDTH_COMPACT) {
+            // Compact: single line, minimal
+            const left = `${segIn} ${segOut} ${segCost}`;
+            const right = [...parts, modelStr].filter(Boolean).join(" ");
+            const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
+            return [truncateToWidth(left + " ".repeat(pad) + right, width)];
+          }
 
-          const padWidth = Math.max(
-            1,
-            width - visibleWidth(left) - visibleWidth(right)
-          );
-          const pad = " ".repeat(padWidth);
+          // Detailed: full layout
+          const ctxBar = capacity > 0
+            ? contextBar(pct, Math.min(20, Math.floor(width * 0.15)), theme)
+            : "";
 
-          return [truncateToWidth(left + pad + right, width)];
+          const left = [segIn, segOut, segCost, ctxBar].filter(Boolean).join(" ");
+          const right = parts.join(" ");
+
+          if (width >= MIN_WIDTH_SINGLE) {
+            // Single line
+            const pad = Math.max(1, width - visibleWidth(left) - visibleWidth(right));
+            return [truncateToWidth(left + " ".repeat(pad) + right, width)];
+          }
+
+          // Multi-line: stats on separate line when narrow
+          return [
+            truncateToWidth(left, width),
+            truncateToWidth(" ".repeat(Math.max(0, width - visibleWidth(right))) + right, width),
+          ];
         },
       };
     });

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -10,7 +10,7 @@
 
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth } from "@earendil-works/pi-tui";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -179,28 +179,29 @@ export default function (pi: ExtensionAPI) {
             : "";
 
           // ---- Layout: 3-line, all left-aligned ----
-          // Line 1: tokens + gauge + cost
+          // Line 1: tokens + gauge
           // Line 2: branch + model
-          // Line 3: web stats + mcp stats (only if data exists)
+          // Line 3: cost + web stats + mcp stats
 
           if (mode === "compact") {
             return [truncateToWidth(`${tokIn} ${tokOut} ${tokCost}  ${modelStr}`, width)];
           }
 
-          const l1 = [tokIn, tokOut, gaugeStr, tokCost].filter(Boolean).join(" │ ");
+          const l1 = [tokIn, tokOut, gaugeStr].filter(Boolean).join(" │ ");
           const lines = [truncateToWidth(l1, width)];
 
           const l2 = [branchStr, modelStr].filter(Boolean).join(" · ");
           if (l2) lines.push(truncateToWidth(l2, width));
 
           const l3: string[] = [];
+          l3.push(tokCost);
           if (stats.webSearch > 0 || stats.webFetch > 0) {
             l3.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
           }
           if (stats.mcpCalls > 0) {
-            l3.push(theme.fg("cyan", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`));
+            l3.push(theme.fg("accent", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`));
           }
-          if (l3.length > 0) lines.push(truncateToWidth(l3.join(" · "), width));
+          lines.push(truncateToWidth(l3.join(" · "), width));
 
           return lines;
         },

--- a/docs/specs/agent-implementation-plan.md
+++ b/docs/specs/agent-implementation-plan.md
@@ -1,0 +1,163 @@
+# pi Harness Implementation Plan
+
+全指摘事項を5PRで回収する実装計画。すべてのPRが独立してレビュー可能で、順序に依存しない。
+
+---
+
+## PR 1: Statusline Enhancement
+
+### Scope
+statusline.ts の視認性・情報量・カスタマイズ性の強化。
+
+### Tasks
+- [x] カラーセグメント表示 — トークン量は緑/黄/赤、costは青、gitブランチは紫
+- [x] MCP stats 表示 — statusline に `MCP q:3 c:5` を追加（web stats と同形式）
+- [x] コンテキスト使用率の視覚バー — `[====>    ] 45%` 形式のプログレスバー
+- [x] 複数行レイアウト対応 — 情報量が多い場合の折り返し or 2行表示
+- [x] /statusline コマンドで detailed/compact/off の3モード切替切替
+- [x] mcp-stats.json 読み取りを statusline に統合
+- [x] リファクタ: `~/.pi/research/stats.json` の統一フォーマット化（web + mcp 両方）
+
+### Files
+- `common/pi/.pi/agent/extensions/statusline.ts`
+- `common/pi/.pi/research/stats.json` (format update)
+
+---
+
+## PR 2: Memory / Persistence Layer
+
+### Scope
+セッション間知識継承のための SQLite ベース永続化層。毎回 fresh start 状態を解消する。
+
+### Tasks
+- [ ] `~/.pi/research/knowledge.db` — SQLite データベース新設
+  - テーブル: `sessions` (id, name, cwd, started_at, summary)
+  - テーブル: `knowledge` (id, key, value, source_session, created_at, ttl)
+  - テーブル: `decisions` (id, context, decision, rationale, session_id)
+- [ ] `extensions/memory.ts` — 新規拡張
+  - `session_start`: 前回セッションのサマリを inject
+  - `session_shutdown`: 現在セッションのサマリを保存（LLM に要約を依頼）
+  - `tool_execution_end`: 重要な決定を `decisions` テーブルに記録
+- [ ] LLM ツール: `memory_search` — knowledge.db を key/value 検索
+- [ ] LLM ツール: `memory_save` — 任意の知識を手動保存
+- [ ] AGENTS.md に Memory layer の使い方を追記
+
+### Files
+- `common/pi/.pi/agent/extensions/memory.ts` (new)
+- `common/pi/.pi/agent/AGENTS.md` (update)
+
+---
+
+## PR 3: Sub-agents & Delegation Automation
+
+### Scope
+pi-subagents パッケージ導入 + AGENTS.md の delegation 自動化。現在の手動 `pi -p` を拡張機能化。
+
+### Tasks
+- [ ] `pi install git:github.com/earendil-works/pi-subagents` — パッケージ導入
+- [ ] `extensions/agent-delegation.ts` — 新規拡張（pi-subagents 前提）
+  - AGENTS.md の difficulty 定義に基づき自動で適切なモデル・effort を選択
+  - pueue 連携: サブエージェントを `pueue add` で非同期実行
+  - 完了検知: pueue の完了をポーリングし、結果を親セッションに inject
+- [ ] LLM ツール: `delegate_agent` — 明示的な委譲用（task, model, effort 指定可）
+- [ ] `skills/github/delegate.md` — delegation ワークフロースキル
+- [ ] AGENTS.md の Agent Delegation セクション拡張（自動委譲ルール）
+
+### Files
+- `common/pi/.pi/agent/extensions/agent-delegation.ts` (new)
+- `common/pi/.pi/agent/settings.json` (packages 追加)
+- `common/pi/.pi/agent/AGENTS.md` (update)
+- `common/agent/.config/agent/skills/github/delegate.md` (new)
+
+---
+
+## PR 4: Remote Control & Session Management
+
+### Scope
+外出先・別端末からのセッション継続 + セッション管理の強化。
+
+### Tasks
+- [ ] **Remote Control**
+  - `extensions/remote-control.ts` — 新規拡張
+  - pi RPC モードを活用: `pi --rpc` で TCP/UNIX socket 待受
+  - `wt` + tmux 連携: リモート端末から tmux attach で既存セッションに接続
+  - `/remote` コマンド: 現在のセッションの RPC エンドポイントを表示
+  - `scripts/pi-remote` — リモート接続用ワンライナー
+- [ ] **Session Management**
+  - `extensions/session-manager.ts` — 新規拡張
+  - `/sessions` コマンド: セッション一覧（fzf 選択 → resume）
+  - `/session-name <name>` — セッション名の手動設定
+  - セッション自動命名: git branch + 最初のプロンプト要約
+  - `/session-export` / `/session-import` — JSONL の import/export
+- [ ] **Quick Questions**
+  - `extensions/quick-question.ts` — 新規拡張
+  - `/q <question>` — 会話履歴を汚さずに質問 → 回答を notification 表示
+  - 内部実装: 別 pi インスタンスを `-p` モードで起動し、結果のみ返す
+
+### Files
+- `common/pi/.pi/agent/extensions/remote-control.ts` (new)
+- `common/pi/.pi/agent/extensions/session-manager.ts` (new)
+- `common/pi/.pi/agent/extensions/quick-question.ts` (new)
+- `scripts/pi-remote` (new)
+
+---
+
+## PR 5: Plan Mode + Todo + Package Migration + Remaining Gaps
+
+### Scope
+QoL 機能の追加と技術的負債の解消。
+
+### Tasks
+- [ ] **Plan Mode**
+  - `extensions/plan-mode.ts` — 新規拡張
+  - `/plan` コマンド: read-only モードに切り替え（write/edit/bash をブロック）
+  - LLM に「実装せず計画だけ立案せよ」と指示
+  - `/approve` — 計画を承認し write/edit/bash のブロックを解除
+  - `/plan` プロンプトテンプレートと統合
+- [ ] **Todo Management**
+  - `extensions/todo-list.ts` — 新規拡張
+  - LLM ツール: `todo_create`, `todo_update`, `todo_list`
+  - TUI ウィジェット: セッション右上に TODO 進捗を常時表示（`ctx.ui.setWidget`）
+  - セッション間 TODO 継承（knowledge.db 連携）
+- [ ] **Package Migration**
+  - 自作 `mcp-gateway.ts` → `pi-mcp-adapter` への移行方針を決定（互換性確認後）
+  - 移行する場合: `pi install git:github.com/earendil-works/pi-mcp-adapter`
+  - 移行しない場合: 自作 gateway の HTTP MCP (syntopic) 対応を追加
+- [ ] **Auto Research Loop**
+  - `skills/research/deep-research.md` 強化
+  - search → fetch → summarize → refine → search の自動反復ロジック
+  - max iterations / timeout 付き
+- [ ] **Audit Log UI**
+  - `/audit` コマンド: `mcp-audit.jsonl` + `audit.log.jsonl` のサマリ表示
+  - 日次/週次の使用統計を notification 表示
+- [ ] **Add-dir support**
+  - `extensions/add-dir.ts` — 新規拡張
+  - `/add-dir <path>` — 追加ディレクトリを pi のコンテキストに読み込み
+  - マルチリポジトリ作業のサポート
+
+### Files
+- `common/pi/.pi/agent/extensions/plan-mode.ts` (new)
+- `common/pi/.pi/agent/extensions/todo-list.ts` (new)
+- `common/pi/.pi/agent/extensions/add-dir.ts` (new)
+- `common/pi/.pi/agent/extensions/mcp-gateway.ts` (update or deprecate)
+- `common/agent/.config/agent/skills/research/deep-research.md` (update)
+
+---
+
+## Gap Coverage Matrix
+
+| 指摘事項 | PR | 
+|----------|:--:|
+| Statusline 強化 | PR 1 |
+| Memory / Persistence | PR 2 |
+| Sub-agents | PR 3 |
+| Delegation 自動化 | PR 3 |
+| Remote Control | PR 4 |
+| Session 管理 | PR 4 |
+| Quick Questions | PR 4 |
+| Plan Mode | PR 5 |
+| Todo Management | PR 5 |
+| Package Migration | PR 5 |
+| Auto Research Loop | PR 5 |
+| Audit Log UI | PR 5 |
+| Add-dir | PR 5 |

--- a/docs/specs/agent-infrastructure.md
+++ b/docs/specs/agent-infrastructure.md
@@ -51,8 +51,8 @@
 | 項目 | 内容 |
 |------|------|
 | **Display** | トークン使用量 (in/out), コスト, コンテキスト容量 (%), git ブランチ, モデル名, web/MCP アクティビティ |
-| **Capacity color** | <60% 緑, 60-80% 黄, >80% 赤 |
-| **Pi impl** | `extensions/statusline.ts` — `ctx.ui.setFooter` |
+| **Gauge** | Unicodeブロックゲージ (████░░░░), 色は使用率連動 |
+| **Pi impl** | `extensions/statusline.ts` — 3行マルチラインフッター, 3モード切替 (detailed/compact/off) |
 | **Claude impl** | `hooks/statusline-command.sh` |
 
 ### 5. Web Research


### PR DESCRIPTION
## Summary
statusline.ts の大幅強化。表示モード、カラーセグメント、MCP stats、コンテキストバーを追加。

## Changes

| Feature | Detail |
|---------|--------|
| **3 display modes** | `/statusline` で detailed → compact → off を切り替え。引数で直接指定も可 |
| **Color segments** | トークン使用率に応じて cost セグメントを緑/黄/赤に色分け |
| **Context bar** | `[=====>  ] 45%` 形式の視覚プログレスバー。色も使用率連動 |
| **MCP stats** | `mcp-stats.json` を読み取り、web stats と並べて表示 |
| **Multi-line** | 端末幅が狭い場合、自動で2行レイアウトに切り替え |
| **Stats cache** | 10秒キャッシュでファイルI/Oを削減 |

## Before → After

```
Before: ↑12.3k ↓4.5k $0.023 45k/128k (35%)  main  deepseek-v4-pro

After:  ↑12.3k ↓4.5k $0.023 [=======>    ] 45%  web s:3 f:5 c:8  mcp q:12  main* deepseek-v4-pro
                                                                     (context bar)  (mcp stats)
```

Closes #157