### PR TITLE
feat(nix): phase 2c - editor + UI migration (nvim/vim/aerospace/ghostty/sketchybar)

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -16,6 +16,12 @@
     ./programs/zsh-abbr.nix
     ./programs/starship.nix
     ./programs/tmux.nix
+    # Phase 2c additions
+    ./programs/nvim.nix
+    ./programs/vim.nix
+    ./programs/aerospace.nix
+    ./programs/ghostty.nix
+    ./programs/sketchybar.nix
   ];
 
   home.username = "matsushimakouta";

--- a/nix/home/programs/aerospace.nix
+++ b/nix/home/programs/aerospace.nix
@@ -1,0 +1,10 @@
+{ ... }:
+
+{
+  # home-manager has no programs.aerospace module (verified against
+  # master as of 2026-05-24). aerospace.toml is a single declarative
+  # file — ship it via xdg.configFile so changes go through switch.
+
+  xdg.configFile."aerospace/aerospace.toml".source =
+    ../../../common/aerospace/.config/aerospace/aerospace.toml;
+}

--- a/nix/home/programs/ghostty.nix
+++ b/nix/home/programs/ghostty.nix
@@ -1,0 +1,21 @@
+{ ... }:
+
+{
+  # Ghostty is the active terminal — its config controls font, theme,
+  # background image, keybindings, and shell integration features. The
+  # backgrounds/ directory holds a JPEG referenced by background-image.
+  # themes/ holds custom theme definitions referenced by `theme = ...`.
+
+  xdg.configFile."ghostty/config".source =
+    ../../../common/ghostty/.config/ghostty/config;
+
+  xdg.configFile."ghostty/backgrounds" = {
+    source = ../../../common/ghostty/.config/ghostty/backgrounds;
+    recursive = true;
+  };
+
+  xdg.configFile."ghostty/themes" = {
+    source = ../../../common/ghostty/.config/ghostty/themes;
+    recursive = true;
+  };
+}

--- a/nix/home/programs/nvim.nix
+++ b/nix/home/programs/nvim.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+{
+  # LazyVim setup: lazy.nvim writes to lazy-lock.json at runtime when
+  # plugins are added/updated/removed. If the tree lives in /nix/store
+  # (read-only) lazy.nvim fails with E5113: Read-only file system.
+  #
+  # The community convergent pattern (NixOS Discourse #35109, LazyVim
+  # discussion #1972) is to mkOutOfStoreSymlink the whole .config/nvim,
+  # keeping lazy.nvim's existing workflow (`:Lazy update`, git-add the
+  # lockfile yourself).
+  #
+  # IMPORTANT: must use an absolute path via config.home.homeDirectory.
+  # Relative paths (`./nvim`) resolve inside the store copy of the flake
+  # and silently link into /nix/store — folke filed this as HM#2085.
+  home.file.".config/nvim".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/nvim/.config/nvim";
+}

--- a/nix/home/programs/sketchybar.nix
+++ b/nix/home/programs/sketchybar.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+  # sketchybar status bar config (sketchybarrc + plugins/*.sh).
+  # Recursive xdg.configFile preserves the directory tree; executable
+  # permission is inferred from source file perms (the plugin scripts
+  # are chmod +x in the repo).
+
+  xdg.configFile."sketchybar" = {
+    source = ../../../common/sketchybar/.config/sketchybar;
+    recursive = true;
+  };
+}

--- a/nix/home/programs/vim.nix
+++ b/nix/home/programs/vim.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  # Plain text dotfiles at $HOME root, declarative via home.file.
+  # (~/.vimrc is just 5 lines; .nanorc 2 lines; .latexmkrc 32 lines —
+  # attrset translation buys nothing.)
+
+  home.file.".vimrc".source = ../../../common/vim/.vimrc;
+  home.file.".nanorc".source = ../../../common/vim/.nanorc;
+  home.file.".latexmkrc".source = ../../../common/vim/.latexmkrc;
+}


### PR DESCRIPTION
## Summary

Phase 2 PR 3 of 4 — editor + macOS UI migration. nvim uses Pattern 1 (mkOutOfStoreSymlink) per community convergence ([LazyVim #1972](https://github.com/LazyVim/LazyVim/discussions/1972), [NixOS Discourse #35109](https://discourse.nixos.org/t/neovim-config-read-only/35109), [HM #2085](https://github.com/nix-community/home-manager/issues/2085)); other four are fully declarative.

(Replaces #159 which was auto-closed when the branch was deleted to drop stale base commits.)

## Modules

- \`nix/home/programs/nvim.nix\`: \`home.file mkOutOfStoreSymlink\` with absolute path via \`config.home.homeDirectory\` (HM#2085: relative paths resolve inside the store copy of the flake and silently lock the tree).
- \`nix/home/programs/vim.nix\`: \`home.file\` for \`.vimrc\` / \`.nanorc\` / \`.latexmkrc\`.
- \`nix/home/programs/aerospace.nix\`: \`xdg.configFile.source\` for the single TOML.
- \`nix/home/programs/ghostty.nix\`: \`xdg.configFile\` for config + recursive trees for \`backgrounds/\` and \`themes/\`.
- \`nix/home/programs/sketchybar.nix\`: \`xdg.configFile\` recursive for \`sketchybarrc\` + \`plugins/*.sh\`.

## Why Pattern 1 for nvim

lazy.nvim writes lazy-lock.json at runtime when plugins are added/updated. A pure declarative \`xdg.configFile."nvim".source = ./nvim\` lands the tree in \`/nix/store\` (read-only) and lazy.nvim dies with \`E5113: Read-only file system\`. mkOutOfStoreSymlink preserves \`:Lazy update\` workflow and the git-add-the-lockfile pattern. Same approach already used in Phase 2a for gh hosts.yml.

Declarative alternative (\`programs.neovim.plugins\` + \`dev.path\`) requires re-wiring LazyVim into Nix and giving up runtime plugin management — far heavier than the value for a single-user setup.

## Validation (shonenm)

- [x] \`nix flake check\` + \`nix build .#darwinConfigurations.shonenm.system\` pass
- [x] \`sudo darwin-rebuild switch --flake .#shonenm\` succeeds
- [x] \`~/.config/nvim\` chain resolves to \`dotfiles/common/nvim/.config/nvim\`; lazy-lock.json writable
- [x] \`aerospace --version\` returns \`0.20.3-Beta\`
- [x] Ghostty config + backgrounds + themes resolve through home-manager-files
- [x] sketchybar plugins symlinked + executable
- [x] vim opens with .vimrc settings

## Out of scope (Phase 6)

- Removal of \`common/{vim,aerospace,ghostty,sketchybar}/\` legacy stow trees
- \`common/nvim/\` must stay — mkOutOfStoreSymlink target

## Refs

- Phase 0: #138/#139, Phase 1a: #142/#149, Phase 2a: #151/#153, Phase 2b: #154/#155
- Pattern 1 research: NixOS Discourse #35109, LazyVim #1972

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)