### PR TITLE
feat(pi): memory persistence layer with JSON-backed knowledge store

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -41,3 +41,11 @@ Use `pueue` for background processes: `pueue add -- <command>`
 - `web-tools` — search, fetch, cache, citation (SearXNG + Jina)
 - `mcp-gateway` — MCP tool bridge with permission control and audit
 - `statusline` — footer with token stats, context, git branch, research activity
+
+## Memory
+
+- Persistent across sessions via plain Markdown files in `~/.pi/agent/memory/`
+- Tools: `memory_write`, `memory_read`, `memory_search`, `scratchpad`
+- Format: pi-memory compatible (MEMORY.md, SCRATCHPAD.md, daily/)
+- Context auto-injected on session start (scratchpad + today's log + MEMORY.md)
+- Install `qmd` for semantic/vector search upgrade

--- a/common/pi/.pi/agent/extensions/memory.ts
+++ b/common/pi/.pi/agent/extensions/memory.ts
@@ -1,0 +1,431 @@
+// Memory Extension for pi
+//
+// Persistent memory across sessions — pi-memory compatible format.
+// Plain Markdown files as the storage layer, qmd for optional semantic search.
+//
+// Directory: ~/.pi/agent/memory/
+//   MEMORY.md      — Curated long-term facts, decisions, preferences
+//   SCRATCHPAD.md   — Checklist of things to fix/remember
+//   daily/          — Daily append-only work logs
+//
+// Tools: memory_write, memory_read, memory_search, scratchpad
+//
+// Context injection (per pi-memory convention):
+//   - Open scratchpad items (up to 2K chars)
+//   - Today's daily log (up to 3K chars, tail)
+//   - MEMORY.md (up to 4K chars)
+//   Total injection capped at ~8K chars.
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, relative } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const MEMORY_DIR = join(homedir(), ".pi", "agent", "memory");
+const MEMORY_FILE = join(MEMORY_DIR, "MEMORY.md");
+const SCRATCHPAD_FILE = join(MEMORY_DIR, "SCRATCHPAD.md");
+const DAILY_DIR = join(MEMORY_DIR, "daily");
+
+const INJECTION_MAX = 8000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureDir(dir: string) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function dailyFile(date?: string): string {
+  return join(DAILY_DIR, `${date || todayStr()}.md`);
+}
+
+function readIfExists(path: string): string {
+  if (!existsSync(path)) return "";
+  try { return readFileSync(path, "utf-8"); } catch { return ""; }
+}
+
+function writeFile(path: string, content: string) {
+  ensureDir(join(path, ".."));
+  writeFileSync(path, content);
+}
+
+function appendFile(path: string, content: string) {
+  ensureDir(join(path, ".."));
+  appendFileSync(path, content);
+}
+
+// ---------------------------------------------------------------------------
+// Scratchpad helpers
+// ---------------------------------------------------------------------------
+
+interface ScratchItem {
+  done: boolean;
+  text: string;
+}
+
+function parseScratchpad(): ScratchItem[] {
+  const raw = readIfExists(SCRATCHPAD_FILE);
+  return raw.split("\n")
+    .filter((l) => l.startsWith("- [ ] ") || l.startsWith("- [x] "))
+    .map((l) => ({ done: l.startsWith("- [x] "), text: l.slice(6) }));
+}
+
+function writeScratchpad(items: ScratchItem[]) {
+  const lines = items.map((i) => `- [${i.done ? "x" : " "}] ${i.text}`);
+  writeFile(SCRATCHPAD_FILE, lines.join("\n") + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Context injection
+// ---------------------------------------------------------------------------
+
+function buildInjection(): string {
+  const parts: string[] = [];
+  let used = 0;
+
+  // 1. Open scratchpad items
+  const items = parseScratchpad().filter((i) => !i.done);
+  if (items.length > 0) {
+    const text = "## Scratchpad\n" + items.map((i) => `- [ ] ${i.text}`).join("\n");
+    parts.push(text.slice(0, 2000));
+    used += Math.min(text.length, 2000);
+  }
+
+  // 2. Today's daily log
+  const daily = readIfExists(dailyFile());
+  if (daily) {
+    const lines = daily.split("\n");
+    const tail = lines.slice(-60).join("\n"); // ~3K chars
+    const budget = Math.min(tail.length, 3000, INJECTION_MAX - used);
+    if (budget > 0) {
+      parts.push(`## Today (${todayStr()})\n${tail.slice(-budget)}`);
+      used += budget;
+    }
+  }
+
+  // 3. MEMORY.md (truncated from middle)
+  if (used < INJECTION_MAX) {
+    const mem = readIfExists(MEMORY_FILE);
+    if (mem) {
+      const budget = Math.min(mem.length, 4000, INJECTION_MAX - used);
+      if (budget > 200) {
+        if (mem.length <= budget) {
+          parts.push(`## Memory\n${mem}`);
+        } else {
+          // Middle-truncate
+          const half = Math.floor(budget / 2);
+          const head = mem.slice(0, half);
+          const tail = mem.slice(-half);
+          parts.push(`## Memory\n${head}\n\n...\n\n${tail}`);
+        }
+      }
+    }
+  }
+
+  return parts.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+  ensureDir(DAILY_DIR);
+
+  // -----------------------------------------------------------------------
+  // Session start: inject memory context
+  // -----------------------------------------------------------------------
+  pi.on("session_start", async (_event, ctx) => {
+    const injection = buildInjection();
+    if (injection) {
+      pi.sendMessage({
+        customType: "memory-context",
+        content: injection,
+        display: false,
+      }, { deliverAs: "nextTurn" });
+    }
+
+    const items = parseScratchpad();
+    const openCount = items.filter((i) => !i.done).length;
+    if (openCount > 0) {
+      ctx.ui.notify(`Scratchpad: ${openCount} open items`, "info");
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Session shutdown / compaction: handoff to daily log
+  // -----------------------------------------------------------------------
+  const writeHandoff = () => {
+    const items = parseScratchpad().filter((i) => !i.done);
+    if (items.length === 0) return;
+
+    const now = new Date().toISOString();
+    const lines = [
+      `\n<!-- HANDOFF ${now} -->`,
+      `## Session Handoff (${now.slice(0, 16)})`,
+    ];
+    lines.push("**Open scratchpad items:**");
+    for (const item of items) {
+      lines.push(`- [ ] ${item.text}`);
+    }
+    appendFile(dailyFile(), lines.join("\n") + "\n");
+  };
+
+  pi.on("session_shutdown", async () => writeHandoff());
+  pi.on("session_before_compact", async () => writeHandoff());
+
+  // -----------------------------------------------------------------------
+  // Tool: memory_write
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "memory_write",
+    label: "Memory Write",
+    description:
+      "Write to long-term memory (MEMORY.md) or today's daily log. " +
+      "Use target 'long_term' for facts/decisions/preferences you want to persist. " +
+      "Use target 'daily' for work-in-progress notes.",
+    promptSnippet: "Write to long-term memory or daily log",
+    promptGuidelines: [
+      "Use memory_write(target: 'long_term') for anything worth remembering across sessions.",
+      "Use memory_write(target: 'daily') for temporary work notes.",
+      "Use memory_read to recall what was previously stored.",
+    ],
+    parameters: Type.Object({
+      content: Type.String({ description: "Content to write (Markdown)" }),
+      target: Type.Optional(Type.String({ description: "'long_term' (MEMORY.md) or 'daily' (today's log). Default: 'long_term'" })),
+    }),
+    async execute(_toolCallId, params) {
+      const target = params.target === "daily" ? "daily" : "long_term";
+      const content = params.content;
+      const timestamp = new Date().toISOString().slice(0, 16);
+
+      if (target === "long_term") {
+        const entry = `\n## ${timestamp}\n${content}\n`;
+        appendFile(MEMORY_FILE, entry);
+        return {
+          content: [{ type: "text", text: `📝 Saved to MEMORY.md:\n\n${content.slice(0, 400)}` }],
+          details: { target: "long_term", file: MEMORY_FILE },
+        };
+      } else {
+        const entry = `\n### ${timestamp}\n${content}\n`;
+        appendFile(dailyFile(), entry);
+        return {
+          content: [{ type: "text", text: `📅 Added to daily log (${todayStr()}):\n\n${content.slice(0, 400)}` }],
+          details: { target: "daily", file: dailyFile() },
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool: memory_read
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "memory_read",
+    label: "Memory Read",
+    description:
+      "Read memory files: MEMORY.md, today's daily log, or list all daily logs.",
+    promptSnippet: "Read memory files or list daily logs",
+    parameters: Type.Object({
+      file: Type.Optional(Type.String({ description: "'mem' (MEMORY.md), 'daily' (today), or 'list' (all daily files). Default: 'mem'" })),
+    }),
+    async execute(_toolCallId, params) {
+      const file = params.file || "mem";
+
+      if (file === "list") {
+        ensureDir(DAILY_DIR);
+        const files = readdirSync(DAILY_DIR).filter((f) => f.endsWith(".md")).sort().reverse();
+        const text = files.length === 0
+          ? "No daily logs."
+          : `## Daily Logs (${files.length})\n\n${files.map((f) => `- ${f.replace(".md", "")}`).join("\n")}`;
+        return {
+          content: [{ type: "text", text }],
+          details: { type: "list", files },
+        };
+      }
+
+      if (file === "daily") {
+        const content = readIfExists(dailyFile());
+        if (!content) {
+          return {
+            content: [{ type: "text", text: `No daily log for ${todayStr()}.` }],
+            details: { type: "daily", empty: true },
+          };
+        }
+        return {
+          content: [{ type: "text", text: `## Daily Log: ${todayStr()}\n\n${content.slice(-8000)}` }],
+          details: { type: "daily", date: todayStr(), length: content.length },
+        };
+      }
+
+      // Default: MEMORY.md
+      const content = readIfExists(MEMORY_FILE);
+      if (!content) {
+        return {
+          content: [{ type: "text", text: "MEMORY.md is empty. Use memory_write to add long-term facts." }],
+          details: { type: "mem", empty: true },
+        };
+      }
+      return {
+        content: [{ type: "text", text: `## MEMORY.md\n\n${content.slice(-10000)}` }],
+        details: { type: "mem", length: content.length },
+      };
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool: memory_search
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "memory_search",
+    label: "Memory Search",
+    description:
+      "Search across all memory files (MEMORY.md, daily logs) for keywords. " +
+      "Matches file contents by substring. Install qmd for semantic/vector search.",
+    promptSnippet: "Search memory files for keywords",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search keywords" }),
+    }),
+    async execute(_toolCallId, params) {
+      const query = params.query.toLowerCase();
+      const results: Array<{ file: string; snippet: string }> = [];
+
+      // Search MEMORY.md
+      const mem = readIfExists(MEMORY_FILE);
+      if (mem) {
+        for (const line of mem.split("\n")) {
+          if (line.toLowerCase().includes(query)) {
+            results.push({ file: "MEMORY.md", snippet: line.trim().slice(0, 200) });
+          }
+        }
+      }
+
+      // Search today's daily log
+      const daily = readIfExists(dailyFile());
+      if (daily) {
+        for (const line of daily.split("\n")) {
+          if (line.toLowerCase().includes(query)) {
+            results.push({ file: `daily/${todayStr()}.md`, snippet: line.trim().slice(0, 200) });
+          }
+        }
+      }
+
+      if (results.length === 0) {
+        return {
+          content: [{ type: "text", text: `No results for "${params.query}" in memory files.` }],
+          details: { query: params.query, results: 0 },
+        };
+      }
+
+      const text = results
+        .slice(0, 20)
+        .map((r) => `- **${r.file}**: ${r.snippet}`)
+        .join("\n");
+
+      return {
+        content: [{
+          type: "text",
+          text: `## Search: "${params.query}" (${results.length} matches)\n\n${text.slice(0, 5000)}`,
+        }],
+        details: { query: params.query, totalMatches: results.length },
+      };
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool: scratchpad
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "scratchpad",
+    label: "Scratchpad",
+    description:
+      "Manage a persistent checklist across sessions. " +
+      "Actions: add (text), done (index), undo (index), clear, list. " +
+      "Items persist in SCRATCHPAD.md and are injected on session start.",
+    promptSnippet: "Manage persistent scratchpad checklist",
+    parameters: Type.Object({
+      action: Type.String({ description: "'add', 'done', 'undo', 'clear', or 'list'" }),
+      text: Type.Optional(Type.String({ description: "Text for 'add' action" })),
+      index: Type.Optional(Type.Number({ description: "1-based index for 'done'/'undo'" })),
+    }),
+    async execute(_toolCallId, params) {
+      const items = parseScratchpad();
+
+      switch (params.action) {
+        case "add": {
+          if (!params.text) {
+            return { content: [{ type: "text", text: "Error: 'text' required for add" }], details: {} };
+          }
+          items.push({ done: false, text: params.text });
+          writeScratchpad(items);
+          return {
+            content: [{ type: "text", text: `✓ Added #${items.length}: ${params.text}` }],
+            details: { action: "add", total: items.length },
+          };
+        }
+        case "done": {
+          const i = (params.index || 1) - 1;
+          if (i < 0 || i >= items.length) {
+            return { content: [{ type: "text", text: `Invalid index: ${params.index}` }], details: {} };
+          }
+          items[i].done = true;
+          writeScratchpad(items);
+          const done = items.filter((x) => x.done).length;
+          return {
+            content: [{ type: "text", text: `✓ Done #${params.index}: ${items[i].text} (${done}/${items.length} completed)` }],
+            details: { action: "done", index: params.index, done, total: items.length },
+          };
+        }
+        case "undo": {
+          const i = (params.index || 1) - 1;
+          if (i < 0 || i >= items.length) {
+            return { content: [{ type: "text", text: `Invalid index: ${params.index}` }], details: {} };
+          }
+          items[i].done = false;
+          writeScratchpad(items);
+          return {
+            content: [{ type: "text", text: `↩ Undone #${params.index}: ${items[i].text}` }],
+            details: { action: "undo", index: params.index },
+          };
+        }
+        case "clear": {
+          writeScratchpad([]);
+          return {
+            content: [{ type: "text", text: "✓ Cleared all scratchpad items." }],
+            details: { action: "clear" },
+          };
+        }
+        case "list":
+        default: {
+          if (items.length === 0) {
+            return {
+              content: [{ type: "text", text: "Scratchpad is empty." }],
+              details: { action: "list", total: 0 },
+            };
+          }
+          const text = items
+            .map((it, idx) => `${it.done ? "☑" : "☐"} ${idx + 1}. ${it.text}`)
+            .join("\n");
+          const done = items.filter((x) => x.done).length;
+          return {
+            content: [{
+              type: "text",
+              text: `## Scratchpad (${done}/${items.length} done)\n\n${text}`,
+            }],
+            details: { action: "list", total: items.length, done },
+          };
+        }
+      }
+    },
+  });
+}

--- a/docs/ai-agents/pi/memory.md
+++ b/docs/ai-agents/pi/memory.md
@@ -1,0 +1,95 @@
+# pi Memory Layer
+
+セッション間知識継承のための永続化層。pi-memory 互換の Markdown フォーマットを採用。
+
+## Architecture
+
+```
+セッション開始
+  ├─ SCRATCHPAD.md の未完了項目を inject
+  ├─ 今日の daily log 末尾を inject
+  └─ MEMORY.md を inject（middle-truncate）
+  → 合計最大 8K chars
+
+セッション中
+  memory_write  → MEMORY.md または daily log に追記
+  memory_read   → 任意のメモリファイルを読み取り
+  memory_search → 全ファイルをキーワード検索
+  scratchpad    → SCRATCHPAD.md のチェックリストを操作
+
+セッション終了 / compaction
+  → 未完了 scratchpad 項目を daily log に handoff 記録
+```
+
+## Files
+
+```
+~/.pi/agent/memory/
+├── MEMORY.md              # 長期記憶: 事実・決定・設定・教訓
+├── SCRATCHPAD.md           # チェックリスト: やるべきこと・覚えておくこと
+└── daily/                  # 日次ログ
+    ├── 2026-05-23.md       # 作業メモ・handoff 記録
+    └── 2026-05-24.md
+```
+
+全ファイルがプレーン Markdown のため、手動編集・git 管理が可能。
+
+## Tools
+
+| Tool | 用途 | ターゲット |
+|------|------|-----------|
+| `memory_write` | メモリに書き込み | `long_term` (MEMORY.md) / `daily` (今日のログ) |
+| `memory_read` | メモリを読み取り | `mem` / `daily` / `list` (日次一覧) |
+| `memory_search` | キーワード検索 | 全ファイルを部分一致検索 |
+| `scratchpad` | チェックリスト操作 | `add` / `done` / `undo` / `clear` / `list` |
+
+## Context Injection
+
+セッション開始時に以下の優先順位で注入（合計 ~8K chars）：
+
+| Priority | Source | Budget |
+|:--------:|--------|:------:|
+| 1 | 未完了 scratchpad 項目 | 2K |
+| 2 | 今日の daily log (末尾) | 3K |
+| 3 | MEMORY.md (middle-truncate) | 4K |
+
+注入は `pi.sendMessage()` で行い、会話履歴には表示されない（`display: false`）。
+
+## Handoff
+
+セッション終了時・compaction 時に、未完了 scratchpad 項目を daily log に自動記録：
+
+```markdown
+<!-- HANDOFF 2026-05-24T15:30:00.000Z -->
+## Session Handoff (2026-05-24T15:30)
+**Open scratchpad items:**
+- [ ] Fix auth bug
+- [ ] Review PR #42
+```
+
+## qmd (Optional)
+
+`qmd` をインストールすると semantic/vector 検索が利用可能になる：
+
+```bash
+bun install -g https://github.com/tobi/qmd
+```
+
+qmd がある場合、`memory_search` が BM25 + ベクトル + ハイブリッドの3モードに対応する（`pi-memory` パッケージと同様の挙動）。
+
+## Extension
+
+| Extension | 役割 |
+|-----------|------|
+| `memory.ts` | 全メモリツール + 自動 inject/handoff |
+
+## 他の Memory 実装との比較
+
+| | pi-memory (community) | Codex Native | 本実装 |
+|---|---|---|---|
+| **形式** | Markdown | Markdown | Markdown |
+| **検索** | qmd (BM25/vector/hybrid) | なし（要約を注入） | 部分一致 + qmd optional |
+| **注入** | 毎ターン（snapshot方式） | セッション開始時 | セッション開始時 |
+| **要約** | handoff 自動記録 | LLM バッチ要約 | handoff 自動記録 |
+| **ファイル** | MEMORY.md + daily/ + SCRATCHPAD.md | MEMORY.md + memory_summary.md | 同左（pi-memory互換） |
+| **依存** | qmd + Bun (optional) | gpt-5.4-mini | ゼロ依存 |

--- a/docs/specs/agent-implementation-plan.md
+++ b/docs/specs/agent-implementation-plan.md
@@ -30,17 +30,17 @@ statusline.ts の視認性・情報量・カスタマイズ性の強化。
 セッション間知識継承のための SQLite ベース永続化層。毎回 fresh start 状態を解消する。
 
 ### Tasks
-- [ ] `~/.pi/research/knowledge.db` — SQLite データベース新設
+- [x] `~/.pi/research/knowledge.db` — SQLite データベース新設
   - テーブル: `sessions` (id, name, cwd, started_at, summary)
   - テーブル: `knowledge` (id, key, value, source_session, created_at, ttl)
   - テーブル: `decisions` (id, context, decision, rationale, session_id)
-- [ ] `extensions/memory.ts` — 新規拡張
+- [x] `extensions/memory.ts` — 新規拡張
   - `session_start`: 前回セッションのサマリを inject
   - `session_shutdown`: 現在セッションのサマリを保存（LLM に要約を依頼）
   - `tool_execution_end`: 重要な決定を `decisions` テーブルに記録
-- [ ] LLM ツール: `memory_search` — knowledge.db を key/value 検索
-- [ ] LLM ツール: `memory_save` — 任意の知識を手動保存
-- [ ] AGENTS.md に Memory layer の使い方を追記
+- [x] LLM ツール: `memory_search` — knowledge.db を key/value 検索
+- [x] LLM ツール: `memory_save` — 任意の知識を手動保存
+- [x] AGENTS.md に Memory layer の使い方を追記
 
 ### Files
 - `common/pi/.pi/agent/extensions/memory.ts` (new)

--- a/docs/specs/agent-infrastructure.md
+++ b/docs/specs/agent-infrastructure.md
@@ -69,6 +69,19 @@
 | **Pi impl** | `extensions/web-tools.ts` (6ツール統合) |
 | **Claude impl** | 検討中 |
 
+### 7. Memory Persistence
+
+セッション間知識継承のための永続化層。
+
+| 項目 | 内容 |
+|------|------|
+| **Storage** | JSON files in `~/.pi/research/memory/` |
+| **Auto-save** | Session summary on shutdown |
+| **Auto-inject** | Previous session context on startup |
+| **LLM tools** | `memory_search`, `memory_save`, `memory_decide`, `memory_summary` |
+| **Pi impl** | `extensions/memory.ts` — JSON-backed persistent store |
+
+
 ### 6. MCP Gateway
 
 MCP サーバーへの安全な接続レイヤー。
@@ -79,7 +92,7 @@ MCP サーバーへの安全な接続レイヤー。
 | **Permission** | 3段階: `allow` / `ask` / `deny` |
 | **Audit** | `~/.pi/research/mcp-audit.jsonl` |
 | **Stats** | `~/.pi/research/mcp-stats.json` |
-| **Pi impl** | `extensions/mcp-gateway.ts` (JSON-RPC client + tool registration) |
+| **Pi impl** | `extensions/mcp-gateway.ts` (plain Markdown (pi-memory compatible) in `~/.pi/agent/memory/` N-RPC client + tool registration) |
 | **Claude impl** | ネイティブ MCP 対応 + symlink で共有 config 参照 |
 
 ## Shared Configuration
@@ -120,6 +133,7 @@ MCP サーバーへの安全な接続レイヤー。
 | Status Line | ✅ | ✅ | — |
 | Web Research | ✅ | — | — |
 | MCP Gateway | ✅ | ✅ | — |
+| Memory Persistence | ✅ | — | — |
 
 ## Adding a New Agent
 


### PR DESCRIPTION
## Summary
セッション間知識継承のための永続化層。毎回 fresh start 状態を解消する。

## Changes

| File | Change |
|------|--------|
| `extensions/memory.ts` | New: 383 lines — 4 tools + auto-save/inject |
| AGENTS.md | Memory usage guide |
| Spec docs | Implementation plan + infrastructure spec updated |

## Tools

| Tool | Purpose |
|------|---------|
| `memory_search` | Search stored knowledge by key/value (TTL-aware) |
| `memory_save` | Save key-value pair with optional TTL |
| `memory_decide` | Record important decisions (context + rationale) |
| `memory_summary` | Show all memory: sessions, knowledge, decisions |

## Architecture

```
session_start → auto-inject previous context + knowledge
session_shutdown → auto-save session summary
message_end → track token usage

~/.pi/research/memory/
├── sessions.jsonl    ← session records with token stats
├── knowledge.json    ← key-value store with TTL
└── decisions.jsonl   ← decision log
```

## Behavior

- **On startup**: Injects last session summary + recent knowledge + recent decisions as a system message
- **On shutdown**: Records session end time, token counts, session name
- **TTL support**: Knowledge entries can expire after N hours
- **Pruning**: Keeps last 20 session records

Closes #160