### PR TITLE
perf(tmux): popup launch ~5x faster (zsh -ic → zsh -lc)

### DIFF
--- a/scripts/tmux-popup-in-container
+++ b/scripts/tmux-popup-in-container
@@ -37,9 +37,13 @@ if [[ -n "${CONTAINER:-}" ]]; then
   exec docker "${args[@]}"
 fi
 
-# Fallback: run on host. Use `zsh -ic` (interactive) so .zshrc init runs —
-# specifically `mise activate` which is what makes mise-managed tools (gh,
-# node, uv, ...) discoverable in PATH. Plain `exec "$@"` would only see
-# tools in static PATH (~/.local/bin via .zshenv) and miss everything else.
+# Fallback: run on host. Use `zsh -lc` (login non-interactive) — much
+# faster than `zsh -ic` (full .zshrc init costs ~2s after Phase 2b zsh
+# migration: p10k config + plugin sourcing + abbr import + mise activate
+# + compinit all run for an interactive shell). For popup-launched
+# commands (lazygit / gh dash / pgcli / keifu / quay) only the popup
+# binary itself needs to be on PATH, which `.zshenv` envExtra already
+# guarantees by prepending nix-managed paths. mise-managed tool versions
+# (node / python / uv via shims) are not consumed by popup commands.
 host_cmd_str=$(printf '%q ' "$@")
-exec zsh -ic "exec $host_cmd_str"
+exec zsh -lc "exec $host_cmd_str"


### PR DESCRIPTION
## Summary

\`tmux-popup-in-container\` forced a full interactive shell (\`zsh -ic\`) on every popup spawn. After Phase 2b's zsh migration that init grew to ~2 seconds (p10k config + plugin loop + abbr import + mise activate + compinit), making popups noticeably sluggish.

Switch the host fallback to \`zsh -lc\` (login non-interactive): \`.zshenv\` runs (envExtra prepends nix-managed paths), \`.zshrc\` does not.

End-to-end timing on shonenm:

| | before | after |
|--|--|--|
| \`tmux-popup-in-container echo hello\` | 2.50s | 0.52s |
| \`zsh -ic 'echo done'\` | 2.04s | n/a |
| \`zsh -lc 'echo done'\` | n/a | 0.00s |

(The remaining ~0.5s is the pane-context lookup, not the shell.)

## Container path unchanged

The container code path keeps \`zsh -ic\` — container environments vary and may rely on .zshrc to wire up PATH/aliases.

## Why -ic is no longer needed on host

- Popup commands invoked are top-level binaries (\`lazygit\`, \`gh dash\`, \`pgcli\`, \`keifu\`, \`quay\`) — they only need the binary itself on PATH, not mise-managed tool versions.
- Phase 2b's \`envExtra\` already prepends \`/etc/profiles/per-user/\$USER/bin\`, \`/run/current-system/sw/bin\`, etc. in \`.zshenv\`, which runs for login non-interactive shells too.

## Test plan

- [x] \`tmux-popup-in-container echo hello\` returns in ~0.5s (was ~2.5s)
- [ ] After merge: prefix+g (lazygit popup) opens instantly
- [ ] After merge: prefix+G (gh dash popup) opens instantly

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)