### PR TITLE
feat(pi): sub-agents and delegation automation with pueue integration

### DIFF
--- a/common/agent/.config/agent/skills/github/delegate.md
+++ b/common/agent/.config/agent/skills/github/delegate.md
@@ -1,0 +1,19 @@
+---
+name: github-delegate
+description: サブエージェントにタスクを委譲します。設計・レビュー・デバッグ・実装を並列化します。
+user-invocable: true
+arguments: "<task-description> [high|medium|low]"
+---
+
+# Delegate - サブエージェント委譲
+
+## 手順
+1. タスクの難易度を判定（high=設計/レビュー/デバッグ, medium=実装, low=要約/抽出）
+2. `delegate_agent` ツールでサブエージェントを起動
+3. 非同期の場合は `check_delegation` + `wait_delegation` で結果を回収
+4. 結果を親セッションに統合
+
+## 注意事項
+- 独立したタスクは async で並列化する
+- 依存関係がある場合は sync で逐次実行
+- 親セッションのコンテキストを明示的に渡す

--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -21,16 +21,6 @@ Tool-agnostic config is in `~/.config/agent/`:
 Invoke via `/skill:<name>`. Shared skills are auto-discovered from `~/.config/agent/skills/`.
 Claude-specific skills under `~/.claude/skills/` are also available.
 
-## Agent Delegation
-
-- Delegate yak shaving and work outside current focus to a sub-agent.
-- `pi --model <provider/model:effort> --fallback-models <...> -p '<instructions>'`
-- Model selection:
-  - High difficulty: `openai-codex/gpt-5.5:high` / `opencode-go/kimi-k2.6:high`
-  - Medium: `opencode-go/deepseek-v4-pro:high` / `openai-codex/gpt-5.4:low`
-  - Low: `opencode-go/deepseek-v4-flash:off`
-
-## Long-running Tasks
 
 Use `pueue` for background processes: `pueue add -- <command>`
 
@@ -49,3 +39,15 @@ Use `pueue` for background processes: `pueue add -- <command>`
 - Format: pi-memory compatible (MEMORY.md, SCRATCHPAD.md, daily/)
 - Context auto-injected on session start (scratchpad + today's log + MEMORY.md)
 - Install `qmd` for semantic/vector search upgrade
+
+## Agent Delegation
+
+- Use `delegate_agent` tool to spawn sub-agents for parallel or specialized work.
+- `check_delegation` to view pueue task status. `wait_delegation` to block until complete.
+- Difficulty auto-selects model:
+  - `high` → gpt-5.5:high / kimi-k2.6:high (design, review, debugging)
+  - `medium` → deepseek-v4-pro:high / gpt-5.4:low (coding from design)
+  - `low` → deepseek-v4-flash:off / gpt-5.4-mini:off (summaries, extraction)
+- Async mode uses pueue for background execution.
+- Sync mode blocks until completion (use for sequential dependencies).
+- When delegating, communicate: background, goal, expected output, constraints.

--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -40,7 +40,7 @@ Use `pueue` for background processes: `pueue add -- <command>`
 - Context auto-injected on session start (scratchpad + today's log + MEMORY.md)
 - Install `qmd` for semantic/vector search upgrade
 
-## Agent Delegation
+## Agent Delegation (pi-subagents + custom)
 
 - Use `delegate_agent` tool to spawn sub-agents for parallel or specialized work.
 - `check_delegation` to view pueue task status. `wait_delegation` to block until complete.
@@ -51,3 +51,6 @@ Use `pueue` for background processes: `pueue add -- <command>`
 - Async mode uses pueue for background execution.
 - Sync mode blocks until completion (use for sequential dependencies).
 - When delegating, communicate: background, goal, expected output, constraints.
+
+- pi-subagents provides: chain/parallel execution, TUI visualization, built-in agents
+- agent-delegation.ts adds: pueue async execution, difficulty-based model auto-selection

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -1,8 +1,13 @@
 // Agent Delegation Extension for pi
 //
 // Spawn sub-agents for parallel work via pueue + pi -p.
-// Supports explicit delegation (delegate_agent tool) and
-// difficulty-based model auto-selection.
+// Supports natural language delegation and difficulty-based model auto-selection.
+//
+// Built-in agent roles (use in prompt/task description):
+//   reviewer   — Code review, correctness, security audit
+//   scout      — Codebase exploration, read-only research
+//   worker     — Implementation from approved plan
+//   oracle     — Second opinion, challenge assumptions, architecture advice
 //
 // Model selection tiers (from AGENTS.md):
 //   high   → gpt-5.5:high / kimi-k2.6:high
@@ -82,14 +87,19 @@ export default function (pi: ExtensionAPI) {
     name: "delegate_agent",
     label: "Delegate Agent",
     description:
-      "Spawn a sub-agent (separate pi instance) to handle a task. " +
+      "Spawn a sub-agent (separate pi instance) for focused work. " +
+      "Built-in roles: reviewer (code review), scout (codebase research), " +
+      "worker (implement from plan), oracle (second opinion). " +
       "Supports sync (wait for result) and async (background via pueue) modes. " +
+      "Use natural language in the task: 'Use reviewer to audit auth module for security issues'. " +
       "Difficulty auto-selects model: high=gpt-5.5, medium=deepseek-v4-pro, low=deepseek-v4-flash.",
-    promptSnippet: "Delegate a task to a sub-agent",
+    promptSnippet: "Delegate a task to a sub-agent (reviewer/scout/worker/oracle)",
     promptGuidelines: [
-      "Use delegate_agent for tasks that can be parallelized or need a different model.",
-      "Use difficulty='high' for design, review, or debugging. Use 'medium' for coding from design. Use 'low' for summaries.",
-      "Prefer async mode with pueue for independent tasks that can run in background.",
+      "Use delegate_agent for tasks that benefit from a second set of model eyes.",
+      "Prefer role names in the task: 'Use reviewer to...', 'Use scout to explore...', 'Use oracle for a second opinion on...'.",
+      "Run parallel reviewers for different concerns: correctness, tests, complexity.",
+      "Use async mode (default) for independent work. Use sync for sequential dependencies.",
+      "Difficulty: high=review/design/debug, medium=coding from plan, low=summaries.",
     ],
     parameters: Type.Object({
       task: Type.String({ description: "Task description/instructions for the sub-agent" }),

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -1,0 +1,259 @@
+// Agent Delegation Extension for pi
+//
+// Spawn sub-agents for parallel work via pueue + pi -p.
+// Supports explicit delegation (delegate_agent tool) and
+// difficulty-based model auto-selection.
+//
+// Model selection tiers (from AGENTS.md):
+//   high   → gpt-5.5:high / kimi-k2.6:high
+//   medium → deepseek-v4-pro:high / gpt-5.4:low
+//   low    → deepseek-v4-flash:off / gpt-5.4-mini:off
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { execSync, spawn } from "node:child_process";
+import { existsSync, readFileSync, appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const DELEGATION_LOG = join(homedir(), ".pi", "research", "delegation.jsonl");
+
+interface ModelTier {
+  model: string;
+  fallbackModels: string[];
+}
+
+const MODEL_TIERS: Record<string, ModelTier> = {
+  high: {
+    model: "openai-codex/gpt-5.5:high",
+    fallbackModels: ["opencode-go/kimi-k2.6:high"],
+  },
+  medium: {
+    model: "opencode-go/deepseek-v4-pro:high",
+    fallbackModels: ["openai-codex/gpt-5.4:low", "openai-codex/gpt-5.3-codex-spark:low"],
+  },
+  low: {
+    model: "opencode-go/deepseek-v4-flash:off",
+    fallbackModels: ["openai-codex/gpt-5.4-mini:off"],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureLogDir() {
+  const dir = join(join(homedir(), ".pi", "research"));
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function logDelegation(difficulty: string, task: string, taskId?: string) {
+  ensureLogDir();
+  appendFileSync(DELEGATION_LOG, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    difficulty,
+    task: task.slice(0, 300),
+    taskId: taskId ?? null,
+  }) + "\n");
+}
+
+function buildPiCommand(task: string, difficulty: string, model?: string, fallback?: string): string {
+  const tier = MODEL_TIERS[difficulty] ?? MODEL_TIERS.medium;
+  const m = model || tier.model;
+  const fb = fallback || tier.fallbackModels.join(",");
+  // Escape single quotes in task
+  const escaped = task.replace(/'/g, "'\\''");
+  return `pi --model '${m}' --fallback-models '${fb}' -p '${escaped}'`;
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function (pi: ExtensionAPI) {
+  // -----------------------------------------------------------------------
+  // Tool: delegate_agent
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "delegate_agent",
+    label: "Delegate Agent",
+    description:
+      "Spawn a sub-agent (separate pi instance) to handle a task. " +
+      "Supports sync (wait for result) and async (background via pueue) modes. " +
+      "Difficulty auto-selects model: high=gpt-5.5, medium=deepseek-v4-pro, low=deepseek-v4-flash.",
+    promptSnippet: "Delegate a task to a sub-agent",
+    promptGuidelines: [
+      "Use delegate_agent for tasks that can be parallelized or need a different model.",
+      "Use difficulty='high' for design, review, or debugging. Use 'medium' for coding from design. Use 'low' for summaries.",
+      "Prefer async mode with pueue for independent tasks that can run in background.",
+    ],
+    parameters: Type.Object({
+      task: Type.String({ description: "Task description/instructions for the sub-agent" }),
+      difficulty: Type.Optional(Type.String({ description: "high, medium, or low. Default: medium" })),
+      mode: Type.Optional(Type.String({ description: "'async' (pueue background) or 'sync' (wait). Default: 'async'" })),
+      model: Type.Optional(Type.String({ description: "Override model (e.g., 'openai-codex/gpt-5.5:high')" })),
+      fallback: Type.Optional(Type.String({ description: "Override fallback models" })),
+    }),
+    async execute(_toolCallId, params, _signal, onUpdate) {
+      const difficulty = params.difficulty || "medium";
+      const mode = params.mode || "async";
+      const cmd = buildPiCommand(params.task, difficulty, params.model, params.fallback);
+
+      if (mode === "sync") {
+        onUpdate?.({ content: [{ type: "text", text: `🔄 Spawning sub-agent (${difficulty}, sync)...` }] });
+        try {
+          const result = execSync(cmd, {
+            encoding: "utf-8",
+            timeout: 600_000, // 10 min
+            maxBuffer: 50 * 1024 * 1024,
+            stdio: ["pipe", "pipe", "pipe"],
+          });
+          logDelegation(difficulty, params.task);
+          return {
+            content: [{
+              type: "text",
+              text: `## Sub-agent Result (${difficulty}, sync)\n\n${result.slice(0, 15000)}`,
+            }],
+            details: { difficulty, mode: "sync", model: cmd.split("--model ")[1]?.split(" ")[0] },
+          };
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{ type: "text", text: `❌ Sub-agent failed: ${msg.slice(0, 500)}` }],
+            details: { difficulty, mode: "sync", error: msg.slice(0, 200) },
+          };
+        }
+      }
+
+      // Async mode: pueue
+      onUpdate?.({ content: [{ type: "text", text: `📋 Queuing sub-agent (${difficulty}, async)...` }] });
+      try {
+        const pueueResult = execSync(`pueue add -i --print-task-id -- ${cmd} < /dev/null`, {
+          encoding: "utf-8",
+          timeout: 10_000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        const taskId = pueueResult.trim();
+        logDelegation(difficulty, params.task, taskId);
+
+        return {
+          content: [{
+            type: "text",
+            text: `## Sub-agent Queued (${difficulty}, async)\n\n` +
+              `**Pueue task ID**: ${taskId}\n\n` +
+              `Check status: \`pueue status\`\n` +
+              `View log: \`pueue log ${taskId}\`\n` +
+              `Wait for completion: \`pueue wait ${taskId}\``,
+          }],
+          details: { difficulty, mode: "async", pueueTaskId: taskId, model: cmd.split("--model ")[1]?.split(" ")[0] },
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `❌ Failed to queue task: ${msg}. Is pueue daemon running? (\`pueued -d\`)` }],
+          details: { difficulty, mode: "async", error: msg.slice(0, 200) },
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool: check_delegation
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "check_delegation",
+    label: "Check Delegation",
+    description: "Check the status of pueue tasks (sub-agents). Shows running, queued, and completed tasks.",
+    promptSnippet: "Check status of delegated sub-agent tasks",
+    parameters: Type.Object({
+      taskId: Type.Optional(Type.String({ description: "Specific pueue task ID to check" })),
+    }),
+    async execute(_toolCallId, params) {
+      try {
+        if (params.taskId) {
+          const log = execSync(`pueue log ${params.taskId}`, {
+            encoding: "utf-8", timeout: 5000,
+            stdio: ["pipe", "pipe", "pipe"],
+          });
+          return {
+            content: [{ type: "text", text: `## Task ${params.taskId}\n\n\`\`\`\n${log.slice(-5000)}\n\`\`\`` }],
+            details: { taskId: params.taskId },
+          };
+        }
+
+        const status = execSync("pueue status", {
+          encoding: "utf-8", timeout: 5000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        return {
+          content: [{ type: "text", text: `## Pueue Status\n\n\`\`\`\n${status.slice(0, 5000)}\n\`\`\`` }],
+          details: {},
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Pueue status unavailable: ${msg.slice(0, 300)}` }],
+          details: { error: msg.slice(0, 200) },
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool: wait_delegation
+  // -----------------------------------------------------------------------
+  pi.registerTool({
+    name: "wait_delegation",
+    label: "Wait Delegation",
+    description: "Wait for a specific pueue task to complete and return its output.",
+    promptSnippet: "Wait for a delegated task to finish",
+    parameters: Type.Object({
+      taskId: Type.String({ description: "Pueue task ID to wait for" }),
+    }),
+    async execute(_toolCallId, params, _signal, onUpdate) {
+      onUpdate?.({ content: [{ type: "text", text: `⏳ Waiting for task ${params.taskId}...` }] });
+      try {
+        execSync(`pueue wait ${params.taskId}`, {
+          encoding: "utf-8", timeout: 600_000, // 10 min
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        const log = execSync(`pueue log ${params.taskId}`, {
+          encoding: "utf-8", timeout: 5000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        return {
+          content: [{
+            type: "text",
+            text: `## Task ${params.taskId} Complete\n\n\`\`\`\n${log.slice(-8000)}\n\`\`\``,
+          }],
+          details: { taskId: params.taskId, completed: true },
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `❌ Task ${params.taskId} failed or timed out: ${msg.slice(0, 500)}` }],
+          details: { taskId: params.taskId, error: msg.slice(0, 200) },
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Notify on startup
+  // -----------------------------------------------------------------------
+  pi.on("session_start", async (_event, ctx) => {
+    try {
+      execSync("pueued -d", { timeout: 2000, stdio: "ignore" });
+    } catch {
+      // daemon may already be running
+    }
+    ctx.ui.notify(
+      "Delegation: sync + async (pueue) sub-agents available",
+      "info"
+    );
+  });
+}

--- a/common/pi/.pi/agent/settings.json
+++ b/common/pi/.pi/agent/settings.json
@@ -69,7 +69,9 @@
     "~/.pi/agent/prompts"
   ],
   "themes": [],
-  "packages": [],
+  "packages": [
+    "npm:pi-subagents"
+  ],
   "enabledModels": [
     "opencode-go/*",
     "openai-codex/*",

--- a/docs/ai-agents/pi/agent-delegation.md
+++ b/docs/ai-agents/pi/agent-delegation.md
@@ -1,0 +1,128 @@
+# pi Agent Delegation Layer
+
+サブエージェントによる並列作業委譲の仕組み。pi-subagents（コミュニティ） + agent-delegation.ts（カスタム）の2層構成。
+
+## Architecture
+
+```
+親セッション (pi)
+  ├─ subagent (pi-subagents)        ← chain/parallel + TUI進捗
+  │   └─ reviewer / scout / worker / oracle
+  └─ delegate_agent (custom)        ← pueue非同期 + 自動モデル選択
+      └─ pueue queue → pi -p → 結果回収
+```
+
+## Tools
+
+### pi-subagents (community)
+
+| Tool | 用途 |
+|------|------|
+| `subagent` | 単一/チェーン/並列実行。TUI進捗表示付き |
+
+自然言語で委譲可能:
+```
+"Use reviewer to audit auth module for security issues"
+"Use scout to explore how the payment flow works"
+"Run parallel reviewers: one for correctness, one for tests"
+```
+
+### agent-delegation.ts (custom)
+
+| Tool | 用途 |
+|------|------|
+| `delegate_agent` | sync/async (pueue) サブエージェント起動。難易度自動モデル選択 |
+| `check_delegation` | pueue タスク状態確認 |
+| `wait_delegation` | タスク完了待ち + 結果取得 |
+
+## Built-in Agent Roles
+
+| ロール | 用途 | 推奨難易度 | モデル |
+|--------|------|:--:|--------|
+| `reviewer` | コードレビュー、セキュリティ監査、品質チェック | high | gpt-5.5 / kimi-k2.6 |
+| `scout` | コードベース探索、read-only調査、依存関係分析 | medium | deepseek-v4-pro |
+| `worker` | 承認済み計画からの実装 | medium | deepseek-v4-pro |
+| `oracle` | セカンドオピニオン、設計レビュー、前提検証 | high | gpt-5.5 / kimi-k2.6 |
+
+## Model Auto-Selection
+
+`delegate_agent` は difficulty に応じて自動的にモデルを選択する:
+
+| Difficulty | Primary Model | Fallback |
+|:----------:|---------------|----------|
+| `high` | openai-codex/gpt-5.5:high | opencode-go/kimi-k2.6:high |
+| `medium` | opencode-go/deepseek-v4-pro:high | openai-codex/gpt-5.4:low |
+| `low` | opencode-go/deepseek-v4-flash:off | openai-codex/gpt-5.4-mini:off |
+
+モデル・フォールバックは手動オーバーライド可能。
+
+## Execution Modes
+
+| Mode | 動作 | 用途 |
+|------|------|------|
+| **async** (default) | pueue でバックグラウンド実行。`check_delegation` + `wait_delegation` で結果回収 | 独立タスクの並列化 |
+| **sync** | 完了までブロック。結果を直接返す | 依存関係のある逐次タスク |
+
+## pueue Integration
+
+非同期実行には pueue デーモンが必要:
+
+```bash
+pueued -d        # デーモン起動
+pueue status     # 状態確認
+pueue log <id>   # ログ確認
+pueue wait <id>  # 完了待ち
+```
+
+セッション開始時に自動でデーモン起動を試みる。
+
+## Audit
+
+全委譲は `~/.pi/research/delegation.jsonl` に記録:
+
+```json
+{"timestamp":"2026-05-24T...","difficulty":"high","task":"review auth module","taskId":"0"}
+```
+
+## pi-subagents vs agent-delegation.ts
+
+| | pi-subagents | agent-delegation.ts |
+|---|---|---|
+| **chain/parallel** | ✅ | ❌ |
+| **TUI 進捗表示** | ✅ chain visualization | ❌ |
+| **pueue 非同期** | ❌ | ✅ |
+| **自動モデル選択** | ❌ | ✅ difficulty tiers |
+| **audit log** | ❌ | ✅ delegation.jsonl |
+| **check/wait** | ❌ | ✅ |
+| **自然言語委譲** | ✅ | ✅ |
+| **インストール** | `pi install npm:pi-subagents` | dotfiles 内蔵 |
+
+両方インストールして併用するのが推奨構成。
+
+## Extensions
+
+| Extension | 役割 |
+|-----------|------|
+| `agent-delegation.ts` | pueue非同期実行 + 自動モデル選択 |
+| `pi-subagents` (package) | chain/parallel実行 + TUI表示 |
+
+## Skills
+
+| Skill | 用途 |
+|-------|------|
+| `github-delegate` | 委譲ワークフローガイドライン |
+
+## 使用例
+
+```
+# コードレビュー（非同期）
+delegate_agent(task: "Use reviewer to audit src/auth/ for security issues", difficulty: "high")
+
+# 並列レビュー
+delegate_agent(task: "Review for correctness", difficulty: "high")
+delegate_agent(task: "Review for performance", difficulty: "high")
+
+# 結果確認
+check_delegation()
+wait_delegation(taskId: "0")
+```

--- a/docs/specs/agent-infrastructure.md
+++ b/docs/specs/agent-infrastructure.md
@@ -69,6 +69,18 @@
 | **Pi impl** | `extensions/web-tools.ts` (6ツール統合) |
 | **Claude impl** | 検討中 |
 
+### 8. Agent Delegation
+
+サブエージェントによる並列作業の委譲。
+
+| 項目 | 内容 |
+|------|------|
+| **Tools** | `delegate_agent`, `check_delegation`, `wait_delegation` |
+| **Modes** | sync (blocking) / async (pueue background) |
+| **Model tiers** | high (gpt-5.5), medium (deepseek-v4-pro), low (flash) |
+| **Pi impl** | `extensions/agent-delegation.ts` — pueue + pi -p integration |
+
+
 ### 7. Memory Persistence
 
 セッション間知識継承のための永続化層。
@@ -134,6 +146,7 @@ MCP サーバーへの安全な接続レイヤー。
 | Web Research | ✅ | — | — |
 | MCP Gateway | ✅ | ✅ | — |
 | Memory Persistence | ✅ | — | — |
+| Agent Delegation | ✅ | — | — |
 
 ## Adding a New Agent
 


### PR DESCRIPTION
## Summary
サブエージェント委譲の自動化。手動 `pi -p` を `delegate_agent` ツールで置き換え、pueue による非同期並列実行を実現。

## Changes

| File | Change |
|------|--------|
| `extensions/agent-delegation.ts` | New: 259 lines — 3 tools + pueue integration |
| `skills/github/delegate.md` | New: delegation workflow skill |
| AGENTS.md | Updated delegation section |
| Spec docs | Agent Delegation component added |

## Tools

| Tool | Purpose |
|------|---------|
| `delegate_agent` | Spawn sub-agent (sync blocking / async pueue) with auto model selection |
| `check_delegation` | View pueue status or specific task log |
| `wait_delegation` | Block until task completes, return output |

## Model Tiers

| Difficulty | Model | Use case |
|------------|-------|----------|
| `high` | gpt-5.5:high / kimi-k2.6:high | Design, review, debugging |
| `medium` | deepseek-v4-pro:high / gpt-5.4:low | Coding from design |
| `low` | deepseek-v4-flash:off / gpt-5.4-mini:off | Summaries, extraction |

## Usage

```
# Async (background via pueue)
delegate_agent(task: "Review PR #162 for security issues", difficulty: "high")

# Check status
check_delegation(taskId: "0")

# Wait for result
wait_delegation(taskId: "0")

# Sync (blocking)
delegate_agent(task: "Summarize CHANGELOG.md", difficulty: "low", mode: "sync")
```

Closes #166