### PR TITLE
feat(nix): phase 2d - configs + scripts/ → PATH (final Phase 2)

### DIFF
--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -22,6 +22,15 @@
     ./programs/aerospace.nix
     ./programs/ghostty.nix
     ./programs/sketchybar.nix
+    # Phase 2d additions (final Phase 2)
+    ./programs/atuin.nix
+    ./programs/claude.nix
+    ./programs/codex.nix
+    ./programs/opensessions.nix
+    ./programs/pi.nix
+    ./programs/traefik-dev.nix
+    ./programs/bin.nix
+    ./programs/scripts.nix
   ];
 
   home.username = "matsushimakouta";

--- a/nix/home/programs/atuin.nix
+++ b/nix/home/programs/atuin.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  # atuin shell history sync. Binary installed via core.nix (Phase 1a).
+  # History database lives at ~/.local/share/atuin (mutable, untouched).
+
+  xdg.configFile."atuin/config.toml".source =
+    ../../../common/atuin/.config/atuin/config.toml;
+}

--- a/nix/home/programs/bin.nix
+++ b/nix/home/programs/bin.nix
@@ -1,0 +1,31 @@
+{ ... }:
+
+{
+  # Conflict-resolution helpers shipped via stow at ~/.local/bin/. These
+  # are referenced from .gitconfig's `[merge "conflict-driver"]` driver.
+
+  home.file.".local/bin/conflict-driver" = {
+    source = ../../../common/bin/.local/bin/conflict-driver;
+    executable = true;
+  };
+  home.file.".local/bin/conflict-resolve-file" = {
+    source = ../../../common/bin/.local/bin/conflict-resolve-file;
+    executable = true;
+  };
+  home.file.".local/bin/conflict-review" = {
+    source = ../../../common/bin/.local/bin/conflict-review;
+    executable = true;
+  };
+  home.file.".local/bin/conflict-save" = {
+    source = ../../../common/bin/.local/bin/conflict-save;
+    executable = true;
+  };
+  home.file.".local/bin/rebase-review" = {
+    source = ../../../common/bin/.local/bin/rebase-review;
+    executable = true;
+  };
+  home.file.".local/bin/validate-resolved" = {
+    source = ../../../common/bin/.local/bin/validate-resolved;
+    executable = true;
+  };
+}

--- a/nix/home/programs/claude.nix
+++ b/nix/home/programs/claude.nix
@@ -1,0 +1,33 @@
+{ ... }:
+
+{
+  # Claude Code harness static config. Runtime state (projects/, sessions/,
+  # cache/, file-history/, plugins/, etc.) is excluded — those are written
+  # by Claude Code at runtime and coexist in ~/.claude/.
+
+  home.file.".claude/.gitignore".source =
+    ../../../common/claude/.claude/.gitignore;
+  home.file.".claude/news-profile.example.yaml".source =
+    ../../../common/claude/.claude/news-profile.example.yaml;
+  home.file.".claude/statusline-command.sh" = {
+    source = ../../../common/claude/.claude/statusline-command.sh;
+    executable = true;
+  };
+
+  home.file.".claude/agents" = {
+    source = ../../../common/claude/.claude/agents;
+    recursive = true;
+  };
+  home.file.".claude/hooks" = {
+    source = ../../../common/claude/.claude/hooks;
+    recursive = true;
+  };
+  home.file.".claude/rules" = {
+    source = ../../../common/claude/.claude/rules;
+    recursive = true;
+  };
+  home.file.".claude/skills" = {
+    source = ../../../common/claude/.claude/skills;
+    recursive = true;
+  };
+}

--- a/nix/home/programs/codex.nix
+++ b/nix/home/programs/codex.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  # Codex CLI config. Runtime state (auth.json, history.jsonl, sessions/,
+  # cache/, memories/, etc.) is excluded — those are written by Codex at
+  # runtime and live alongside config.toml in ~/.codex/.
+  # The .gitignore is stowed so that if someone `git init`s in ~/.codex
+  # those runtime files don't get tracked.
+
+  home.file.".codex/config.toml".source =
+    ../../../common/codex/.codex/config.toml;
+  home.file.".codex/.gitignore".source =
+    ../../../common/codex/.codex/.gitignore;
+}

--- a/nix/home/programs/opensessions.nix
+++ b/nix/home/programs/opensessions.nix
@@ -1,0 +1,9 @@
+{ ... }:
+
+{
+  # opensessions tmux plugin desktop config (separate from the TPM-installed
+  # plugin itself, which lives under ~/.tmux/plugins/opensessions).
+
+  xdg.configFile."opensessions/config.json".source =
+    ../../../common/opensessions/.config/opensessions/config.json;
+}

--- a/nix/home/programs/pi.nix
+++ b/nix/home/programs/pi.nix
@@ -1,0 +1,34 @@
+{ ... }:
+
+{
+  # pi-coding-agent harness static config. Runtime state (sessions/, cache/,
+  # packages/, logs/, history/, telemetry/, credentials.json) is excluded —
+  # written by pi at runtime in ~/.pi/.
+  # services/ (docker-compose for SearXNG etc.) intentionally stays in the
+  # repo at common/pi/services/; it's not stowed/home-managed anywhere.
+
+  home.file.".pi/.gitignore".source =
+    ../../../common/pi/.pi/.gitignore;
+
+  home.file.".pi/agent/AGENTS.md".source =
+    ../../../common/pi/.pi/agent/AGENTS.md;
+  home.file.".pi/agent/APPEND_SYSTEM.md".source =
+    ../../../common/pi/.pi/agent/APPEND_SYSTEM.md;
+  home.file.".pi/agent/keybindings.json".source =
+    ../../../common/pi/.pi/agent/keybindings.json;
+  home.file.".pi/agent/settings.json".source =
+    ../../../common/pi/.pi/agent/settings.json;
+
+  home.file.".pi/agent/extensions" = {
+    source = ../../../common/pi/.pi/agent/extensions;
+    recursive = true;
+  };
+  home.file.".pi/agent/prompts" = {
+    source = ../../../common/pi/.pi/agent/prompts;
+    recursive = true;
+  };
+  home.file.".pi/agent/skills" = {
+    source = ../../../common/pi/.pi/agent/skills;
+    recursive = true;
+  };
+}

--- a/nix/home/programs/scripts.nix
+++ b/nix/home/programs/scripts.nix
@@ -1,0 +1,31 @@
+{ lib, ... }:
+
+let
+  scriptsDir = ../../../scripts;
+
+  # Only top-level regular files (skip the git-hooks/ subdir — that
+  # template directory is wired up via programs.git's runCommand).
+  entries = builtins.readDir scriptsDir;
+  scriptFiles = lib.filter
+    (name: entries.${name} == "regular")
+    (builtins.attrNames entries);
+in
+{
+  # All scripts in dotfiles/scripts/ → ~/.local/bin/<name>.
+  # This replaces the legacy `export PATH="$HOME/dotfiles/scripts:$PATH"`
+  # line in .zshrc.common (removed from zsh.nix in the same PR).
+  # ~/.local/bin is already prepended in .zshenv, so no PATH work needed.
+  #
+  # Lib scripts (*-lib.sh, etc.) are NOT executable but still co-located
+  # with their consumers under ~/.local/bin so the conventional
+  # `source "$(dirname "$0")/foo-lib.sh"` pattern keeps resolving.
+  home.file = builtins.listToAttrs (map
+    (name: {
+      name = ".local/bin/${name}";
+      value = {
+        source = scriptsDir + "/${name}";
+        executable = true;
+      };
+    })
+    scriptFiles);
+}

--- a/nix/home/programs/traefik-dev.nix
+++ b/nix/home/programs/traefik-dev.nix
@@ -1,0 +1,11 @@
+{ ... }:
+
+{
+  # traefik-dev: dev-gateway reverse proxy config + compose file. The
+  # compose file is launched via the `wt traefik up` workflow.
+
+  xdg.configFile."traefik-dev/traefik.yml".source =
+    ../../../common/traefik-dev/.config/traefik-dev/traefik.yml;
+  xdg.configFile."traefik-dev/compose.yml".source =
+    ../../../common/traefik-dev/.config/traefik-dev/compose.yml;
+}

--- a/nix/home/programs/zsh.nix
+++ b/nix/home/programs/zsh.nix
@@ -139,7 +139,9 @@ in
         [[ -d "$HOME/.bun/bin" ]] && export PATH="$HOME/.bun/bin:$PATH"
         [[ -d "$HOME/.atuin/bin" ]] && export PATH="$HOME/.atuin/bin:$PATH"
         [[ -d "$HOME/.cargo/bin" ]] && export PATH="$HOME/.cargo/bin:$PATH"
-        export PATH="$HOME/dotfiles/scripts:$PATH"
+        # dotfiles/scripts/ PATH line removed in Phase 2d: all scripts are
+        # now symlinked into ~/.local/bin via programs/scripts.nix and
+        # ~/.local/bin is already prepended above.
         [[ -d "$DENO_INSTALL/bin" ]] && export PATH="$DENO_INSTALL/bin:$PATH"
         [[ -x "$HOME/syntopic/tools/packages/syntopic/bin/syntopic" ]] && \
           export PATH="$HOME/syntopic/tools/packages/syntopic/bin:$PATH"


### PR DESCRIPTION
## Summary

Final Phase 2 closeout: migrate remaining 7 stateful/misc packages and replace the legacy \`~/dotfiles/scripts\` PATH-prepend with declarative \`home.file."local/bin/<name>"\` for the ~70 scripts.

## Packages

| package | files | approach |
|--|--|--|
| atuin | 1 | xdg.configFile (config.toml) |
| opensessions | 1 | xdg.configFile (config.json) |
| traefik-dev | 2 | xdg.configFile (traefik.yml + compose.yml) |
| codex | 2 | home.file (.codex/config.toml + .gitignore) |
| bin | 6 | home.file (.local/bin/conflict-* etc.) |
| claude | 39 | home.file individual + recursive (agents/hooks/rules/skills) |
| pi | 28 | home.file individual + recursive (extensions/prompts/skills) |
| mcp | 0 | skipped (empty) |

Runtime state (claude: projects/sessions/cache/file-history/plugins, pi: sessions/cache/packages/logs/history/telemetry/credentials.json) is excluded — these are written at runtime and coexist with the home-manager symlinks.

\`common/pi/services/\` (docker-compose for SearXNG) intentionally stays in the repo; it's not stowed/home-managed anywhere.

## scripts/ migration

\`nix/home/programs/scripts.nix\` uses \`builtins.readDir\` + \`listToAttrs\` to programmatically create \`home.file."local/bin/<name>"\` entries for every regular file under \`dotfiles/scripts/\`. \`executable = true\` so they're invocable. \`git-hooks/\` subdir is skipped (the post-merge hook is wired up separately).

\`nix/home/programs/zsh.nix\` drops the \`export PATH="\$HOME/dotfiles/scripts:\$PATH"\` line from initContent. \`~/.local/bin\` is already prepended above, so no additional PATH work is needed.

## Validation (shonenm)

- [x] \`nix flake check\` + \`nix build .#darwinConfigurations.shonenm.system\` pass
- [x] \`sudo darwin-rebuild switch --flake .#shonenm\` succeeds
- [x] All 4 simple configs (atuin/opensessions/traefik-dev/codex) symlink to \`/nix/store/.../home-manager-files/\`
- [x] \`~/.claude/{agents,hooks,rules,skills}\` populated via recursive home.file
- [x] \`~/.pi/agent/{extensions,prompts,skills}\` populated, individual files (AGENTS.md / settings.json / etc.) too
- [x] Runtime state preserved: \`~/.claude/sessions\`, \`~/.pi/sessions\`, etc. untouched
- [x] \`~/.local/bin/\` contains 85 entries (6 from bin + ~70 from scripts + atuin/cargo etc. preexisting)
- [x] \`beacon\` resolves to \`~/.local/bin/beacon\` (was previously \`~/dotfiles/scripts/beacon\`)
- [x] \`type beacon\` reports the new location, no \`dotfiles/scripts\` reference

## Pre-switch cleanup (executed)

\`\`\`bash
for pkg in atuin codex opensessions traefik-dev bin; do
  stow -D -d common -t ~ "\$pkg" 2>/dev/null
done
for sub in agents hooks rules skills news-profile.example.yaml statusline-command.sh; do
  /bin/rm -f ~/.claude/"\$sub"
done
/bin/rm -f ~/.claude/.gitignore
for sub in AGENTS.md APPEND_SYSTEM.md keybindings.json settings.json; do
  /bin/rm -f ~/.pi/agent/"\$sub"
done
/bin/rm -f ~/.pi/agent/extensions/*.ts ~/.pi/agent/prompts/* ~/.pi/agent/skills/*
/bin/rm -f ~/.pi/.gitignore ~/.pi/agent/settings.json.dotfiles-bak
\`\`\`

## Phase 2 completion

This PR closes Phase 2 (mac dotfiles migration). After merge, all of common/ is home-manager-managed except runtime state. Phase 3+ work (mac system defaults, Linux migration) begins next.

## Out of scope (Phase 6)

- Removal of \`common/{atuin,claude,codex,opensessions,pi,traefik-dev,bin,mcp}/\` legacy stow trees
- Removal of \`common/zsh/.zshenv\` legacy \`dotfiles/scripts\` PATH line (file no longer stowed)

## Refs

- Phase 0: #138/#139, Phase 1a: #142/#149, Phase 2a: #151/#153, Phase 2b: #154/#155, Phase 2c: #156/#161
- Plan: \`docs/nix-migration-plan.md\` § Phase 2

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)