### PR TITLE
feat(nix): phase 3a - macOS preferences (Tier 1) + zsh delegation

### DIFF
--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -14,6 +14,53 @@
   # Allow unfree packages (1password CLI, raycast, etc. may require this)
   nixpkgs.config.allowUnfree = true;
 
-  # Shells managed by nix-darwin; /etc/zshrc bootstrap remains untouched in Phase 1a
-  # programs.zsh.enable = true;  # Phase 2 (dotfiles migration)
+  # Delegate /etc/zshrc bootstrap to nix-darwin so it ships our zsh setup
+  # (FPATH, completion site-functions, etc.) cleanly. User-level interactive
+  # behaviour still comes from home-manager-managed ~/.zshrc.
+  programs.zsh.enable = true;
+
+  # === Phase 3a: macOS preferences (Tier 1) ===========================
+  # Settings here are written to the relevant plist on `darwin-rebuild
+  # switch`. Some require killall Dock / Finder / SystemUIServer or a
+  # logout to fully reflect in the System Settings UI.
+
+  system.defaults = {
+    NSGlobalDomain = {
+      # Fastest key repeat (System Settings → Keyboard slider can't reach this)
+      KeyRepeat = 2;
+      InitialKeyRepeat = 15;
+      # Disable the accent picker so vim-style j/k hold works in any text field
+      ApplePressAndHoldEnabled = false;
+      # Always show file extensions in the Finder
+      AppleShowAllExtensions = true;
+    };
+
+    dock = {
+      autohide = true;
+      show-recents = false;
+      tilesize = 36;
+      # Required for aerospace's workspace switching — when true, macOS
+      # auto-reorders Spaces based on recency and aerospace's index-based
+      # navigation breaks.
+      mru-spaces = false;
+    };
+
+    finder = {
+      ShowPathbar = true;
+      ShowStatusBar = true;
+      # List view by default
+      FXPreferredViewStyle = "Nlsv";
+      _FXSortFoldersFirst = true;
+    };
+
+    screencapture = {
+      location = "~/Pictures/Screenshots";
+      type = "png";
+    };
+
+    LaunchServices = {
+      # Skip the "this app was downloaded from the internet" warning
+      LSQuarantine = false;
+    };
+  };
 }


### PR DESCRIPTION
## Summary

Phase 3 first chunk. Two changes:

1) Delegate \`/etc/zshrc\` to nix-darwin via \`programs.zsh.enable\` so the system-level zsh bootstrap (FPATH, completion site-functions, etc.) is ours instead of macOS's default. Per-user interactive behaviour still comes from home-manager's \`.zshrc\`.

2) Declare Tier 1 macOS preferences via \`system.defaults.*\` (commonly-needed, low-risk):

| domain | settings |
|--|--|
| NSGlobalDomain | \`KeyRepeat=2\`, \`InitialKeyRepeat=15\`, \`ApplePressAndHoldEnabled=false\`, \`AppleShowAllExtensions=true\` |
| dock | \`autohide=true\`, \`show-recents=false\`, \`tilesize=36\`, \`mru-spaces=false\` (required for aerospace) |
| finder | \`ShowPathbar=true\`, \`ShowStatusBar=true\`, \`FXPreferredViewStyle="Nlsv"\` (list view), \`_FXSortFoldersFirst=true\` |
| screencapture | \`location="~/Pictures/Screenshots"\`, \`type="png"\` |
| LaunchServices | \`LSQuarantine=false\` |

## Validation (shonenm)

\`\`\`
NSGlobalDomain
  KeyRepeat                     → 2     ✓
  InitialKeyRepeat              → 15    ✓
  ApplePressAndHoldEnabled      → 0     ✓
  AppleShowAllExtensions        → 1     ✓
Dock
  autohide                      → 1     ✓
  show-recents                  → 0     ✓
  tilesize                      → 36    ✓
  mru-spaces                    → 0     ✓
Finder
  ShowPathbar                   → 1     ✓
  ShowStatusBar                 → 1     ✓
  FXPreferredViewStyle          → Nlsv  ✓
  _FXSortFoldersFirst           → 1     ✓
Screencapture
  location                      → ~/Pictures/Screenshots  ✓
  type                          → png                     ✓
LaunchServices
  LSQuarantine                  → 0     ✓
/etc/zshrc                      → nix-darwin generated    ✓
\`\`\`

## Out of scope (follow-up)

- **Tier 2**: Dark mode lock, auto-correct disable, trackpad tweaks, hot corner disable
- **Tier 3**: security policies (password delay, guest disable, software update policy)
- **launchd jobs** for aerospace/karabiner/sketchybar — current OS-level auto-start works fine
- **Dock persistent-apps** — needs user-specific list

## Refs

- Phase 0: #138/#139, Phase 1a: #142/#149, Phase 2a/b/c/d: #153/#155/#161/#168
- Plan: \`docs/plans/nix-migration-plan.md\` § Phase 3

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)