### PR TITLE
fix(nix): mkOutOfStoreSymlink for hot-loop edited dirs

### DIFF
--- a/nix/home/programs/claude.nix
+++ b/nix/home/programs/claude.nix
@@ -1,10 +1,11 @@
-{ ... }:
+{ config, ... }:
 
 {
-  # Claude Code harness static config. Runtime state (projects/, sessions/,
-  # cache/, file-history/, plugins/, etc.) is excluded — those are written
-  # by Claude Code at runtime and coexist in ~/.claude/.
+  # Claude Code harness. Runtime state (projects/, sessions/, cache/,
+  # file-history/, plugins/, etc.) is excluded — those are written by
+  # Claude Code at runtime and coexist in ~/.claude/.
 
+  # === Static config (store-managed, atomic switch) ===
   home.file.".claude/.gitignore".source =
     ../../../common/claude/.claude/.gitignore;
   home.file.".claude/news-profile.example.yaml".source =
@@ -13,21 +14,25 @@
     source = ../../../common/claude/.claude/statusline-command.sh;
     executable = true;
   };
-
+  # agents/ houses long-lived subagents (ralph-worker / ralph-reviewer)
+  # that don't change often — keep them in /nix/store for atomic switch.
   home.file.".claude/agents" = {
     source = ../../../common/claude/.claude/agents;
     recursive = true;
   };
-  home.file.".claude/hooks" = {
-    source = ../../../common/claude/.claude/hooks;
-    recursive = true;
-  };
-  home.file.".claude/rules" = {
-    source = ../../../common/claude/.claude/rules;
-    recursive = true;
-  };
-  home.file.".claude/skills" = {
-    source = ../../../common/claude/.claude/skills;
-    recursive = true;
-  };
+
+  # === Hot-loop dirs (mkOutOfStoreSymlink → dotfiles repo) ===
+  # hooks / rules / skills are actively iterated (shell hook tweaks, rule
+  # adjustments, d-* skill development). Store-copying them would force
+  # darwin-rebuild switch per edit. Same pattern as nvim (Phase 2c) and
+  # gh/hosts.yml (Phase 2a). HM #2085: must use absolute path.
+  home.file.".claude/hooks".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/claude/.claude/hooks";
+  home.file.".claude/rules".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/claude/.claude/rules";
+  home.file.".claude/skills".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/claude/.claude/skills";
 }

--- a/nix/home/programs/pi.nix
+++ b/nix/home/programs/pi.nix
@@ -1,15 +1,15 @@
-{ ... }:
+{ config, ... }:
 
 {
-  # pi-coding-agent harness static config. Runtime state (sessions/, cache/,
-  # packages/, logs/, history/, telemetry/, credentials.json) is excluded —
-  # written by pi at runtime in ~/.pi/.
-  # services/ (docker-compose for SearXNG etc.) intentionally stays in the
-  # repo at common/pi/services/; it's not stowed/home-managed anywhere.
+  # pi-coding-agent harness. Runtime state (sessions/, cache/, packages/,
+  # logs/, history/, telemetry/, credentials.json) is excluded — written
+  # by pi at runtime in ~/.pi/.
+  # services/ (docker-compose for SearXNG etc.) intentionally stays in
+  # the repo at common/pi/services/; it's not stowed/home-managed anywhere.
 
+  # === Static config (store-managed, atomic switch) ===
   home.file.".pi/.gitignore".source =
     ../../../common/pi/.pi/.gitignore;
-
   home.file.".pi/agent/AGENTS.md".source =
     ../../../common/pi/.pi/agent/AGENTS.md;
   home.file.".pi/agent/APPEND_SYSTEM.md".source =
@@ -19,16 +19,22 @@
   home.file.".pi/agent/settings.json".source =
     ../../../common/pi/.pi/agent/settings.json;
 
-  home.file.".pi/agent/extensions" = {
-    source = ../../../common/pi/.pi/agent/extensions;
-    recursive = true;
-  };
-  home.file.".pi/agent/prompts" = {
-    source = ../../../common/pi/.pi/agent/prompts;
-    recursive = true;
-  };
-  home.file.".pi/agent/skills" = {
-    source = ../../../common/pi/.pi/agent/skills;
-    recursive = true;
-  };
+  # === Hot-loop dirs (mkOutOfStoreSymlink → dotfiles repo) ===
+  # These are edited frequently and consumed via pi's /reload (which
+  # re-reads from the symlink target). Store-copying them would force
+  # darwin-rebuild switch per edit. mkOutOfStoreSymlink points the
+  # symlink at the dotfiles checkout instead so /reload picks up changes
+  # immediately. Trade-off: no atomic rollback for these dirs (git
+  # handles versioning), no remote --target-host deploy of these
+  # specific files. Same pattern as nvim (Phase 2c) and gh/hosts.yml
+  # (Phase 2a). HM #2085: must use absolute path.
+  home.file.".pi/agent/extensions".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/pi/.pi/agent/extensions";
+  home.file.".pi/agent/prompts".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/pi/.pi/agent/prompts";
+  home.file.".pi/agent/skills".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/dotfiles/common/pi/.pi/agent/skills";
 }


### PR DESCRIPTION
## Problem

Phase 2d (#168) wired pi extensions/prompts/skills + claude hooks/rules/skills via \`home.file recursive = true\`, which copies the trees into \`/nix/store\` (immutable). These dirs are actively iterated — TypeScript extensions, prompts, skills, hooks, rules — and the dev loop is:

\`\`\`
edit file in dotfiles/common/... → /reload → see effect
\`\`\`

With Nix store copies, edits don't propagate until \`darwin-rebuild switch\` (~15-30s per cycle).

## Community consensus (researched)

[NixOS Discourse 2026-05](https://discourse.nixos.org/t/managing-config-files-why-not-use-mkoutofstoresymlink-for-everything/77643): hybrid pattern — \`mkOutOfStoreSymlink\` for hot-loop dirs, store for everything else. Already used in this repo for nvim (Phase 2c) and gh/hosts.yml (Phase 2a).

## Fix

| dir | mode change |
|--|--|
| \`~/.pi/agent/extensions\` | \`recursive\` → \`mkOutOfStoreSymlink\` |
| \`~/.pi/agent/prompts\` | \`recursive\` → \`mkOutOfStoreSymlink\` |
| \`~/.pi/agent/skills\` | \`recursive\` → \`mkOutOfStoreSymlink\` |
| \`~/.claude/hooks\` | \`recursive\` → \`mkOutOfStoreSymlink\` |
| \`~/.claude/rules\` | \`recursive\` → \`mkOutOfStoreSymlink\` |
| \`~/.claude/skills\` | \`recursive\` → \`mkOutOfStoreSymlink\` |

Static config (AGENTS.md / settings.json / keybindings.json / news-profile.example.yaml / statusline-command.sh / .gitignore / claude/agents/) stays store-managed for atomic switch.

HM #2085 caveat: absolute path via \`config.home.homeDirectory\` (not \`./relative\`).

## Validation (shonenm)

Symlink chain after switch:
\`\`\`
~/.pi/agent/extensions
  → /nix/store/.../home-manager-files/.pi/agent/extensions
  → /nix/store/.../hm_extensions
  → /Users/matsushimakouta/dotfiles/common/pi/.pi/agent/extensions  ← final target
\`\`\`

\`readlink -f\` resolves all 6 hot-loop dirs to dotfiles paths. Edits → /reload → instant.

## Trade-offs accepted

- No atomic rollback for these dirs (git handles versioning)
- No \`--target-host\` remote deploy of these specific files
- Initial install on fresh mac needs dotfiles checkout to exist first (already true for our setup)

## Refs

- Pattern source: Phase 2c (nvim, #161), Phase 2a (gh hosts.yml, #153)
- Community: [Discourse #77643](https://discourse.nixos.org/t/managing-config-files-why-not-use-mkoutofstoresymlink-for-everything/77643), [HM #2085](https://github.com/nix-community/home-manager/issues/2085)

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)