### PR TITLE
feat(nix): phase 3b - tier 2/3 macOS preferences + services.aerospace (Phase 3 complete)

### DIFF
--- a/common/aerospace/.config/aerospace/aerospace.toml
+++ b/common/aerospace/.config/aerospace/aerospace.toml
@@ -14,8 +14,6 @@ exec-on-workspace-change = ['/bin/bash', '-c',
   'sketchybar --trigger aerospace_workspace_change FOCUSED_WORKSPACE=$AEROSPACE_FOCUSED_WORKSPACE'
 ]
 
-# Start AeroSpace at login
-start-at-login = true
 
 # Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
 enable-normalization-flatten-containers = true

--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -19,48 +19,112 @@
   # behaviour still comes from home-manager-managed ~/.zshrc.
   programs.zsh.enable = true;
 
-  # === Phase 3a: macOS preferences (Tier 1) ===========================
-  # Settings here are written to the relevant plist on `darwin-rebuild
-  # switch`. Some require killall Dock / Finder / SystemUIServer or a
-  # logout to fully reflect in the System Settings UI.
+  # === macOS preferences =============================================
+  # Tier 1 (Phase 3a, low-risk universal):
+  #   key repeat, accent picker, file extensions, Dock auto-hide, Finder
+  #   path/status bar + list view + sort folders first, screenshot
+  #   location + format, LSQuarantine disabled.
+  # Tier 2 (Phase 3b, opinionated dev defaults):
+  #   Dark mode lock, all NSAutomatic*Enabled disabled, no iCloud default
+  #   save, hot corners disabled (aerospace boundaries), trackpad
+  #   tap-to-click.
+  # Tier 3 (Phase 3b, security baseline):
+  #   immediate lock on screensaver.
+  #
+  # Settings are written to plists on `darwin-rebuild switch`. Some
+  # require killall Dock / Finder / SystemUIServer or a re-login to
+  # fully reflect in the System Settings UI.
 
   system.defaults = {
     NSGlobalDomain = {
-      # Fastest key repeat (System Settings → Keyboard slider can't reach this)
+      # --- Tier 1 ---
       KeyRepeat = 2;
       InitialKeyRepeat = 15;
-      # Disable the accent picker so vim-style j/k hold works in any text field
       ApplePressAndHoldEnabled = false;
-      # Always show file extensions in the Finder
       AppleShowAllExtensions = true;
+      # --- Tier 2 ---
+      # Lock OS UI to dark — repo theme stack (tmux, Ghostty, starship,
+      # p10k) is dark; macOS UI matching avoids palette clashes.
+      AppleInterfaceStyle = "Dark";
+      # All NSAutomatic* off (incompatible with dev workflows: code,
+      # CLI commands, single quotes in strings, etc.)
+      NSAutomaticSpellingCorrectionEnabled = false;
+      NSAutomaticCapitalizationEnabled = false;
+      NSAutomaticQuoteSubstitutionEnabled = false;
+      NSAutomaticDashSubstitutionEnabled = false;
+      NSAutomaticPeriodSubstitutionEnabled = false;
+      # Default Save dialog → local disk, not iCloud
+      NSDocumentSaveNewDocumentsToCloud = false;
     };
 
     dock = {
+      # --- Tier 1 ---
       autohide = true;
       show-recents = false;
       tilesize = 36;
-      # Required for aerospace's workspace switching — when true, macOS
-      # auto-reorders Spaces based on recency and aerospace's index-based
-      # navigation breaks.
       mru-spaces = false;
+      # --- Tier 2 ---
+      # Hot corners off: aerospace uses screen edges for workspace
+      # navigation; macOS triggering Mission Control / sleep on those
+      # edges interferes.
+      wvous-tl-corner = 1;
+      wvous-tr-corner = 1;
+      wvous-bl-corner = 1;
+      wvous-br-corner = 1;
     };
 
     finder = {
+      # --- Tier 1 ---
       ShowPathbar = true;
       ShowStatusBar = true;
-      # List view by default
       FXPreferredViewStyle = "Nlsv";
       _FXSortFoldersFirst = true;
     };
 
     screencapture = {
+      # --- Tier 1 ---
       location = "~/Pictures/Screenshots";
       type = "png";
     };
 
     LaunchServices = {
-      # Skip the "this app was downloaded from the internet" warning
+      # --- Tier 1 ---
       LSQuarantine = false;
     };
+
+    # --- Tier 2: trackpad ---
+    trackpad = {
+      # Tap-to-click (no need to press down)
+      Clicking = true;
+    };
+
+    # --- Tier 3: screensaver password ---
+    screensaver = {
+      askForPassword = true;
+      # Lock immediately on sleep / screensaver (0 = no grace period)
+      askForPasswordDelay = 0;
+    };
   };
+
+  # === services.aerospace ============================================
+  # nix-darwin's launchd-managed startup for AeroSpace. Replaces
+  # AeroSpace's own `start-at-login = true` (removed from aerospace.toml).
+  # launchd label: org.nixos.aerospace (KeepAlive + RunAtLoad).
+  #
+  # Settings sourced from common/aerospace/.config/aerospace/aerospace.toml
+  # via builtins.fromTOML so the existing config remains the source of
+  # truth. Module assertions: !settings.start-at-login (removed).
+  services.aerospace = {
+    enable = true;
+    settings = builtins.fromTOML
+      (builtins.readFile ../../../common/aerospace/.config/aerospace/aerospace.toml);
+  };
+
+  # === Karabiner-Elements / SketchyBar deferred =======================
+  # services.karabiner-elements: v15 architecture rewrite + recurring
+  # post-rebuild breakage reports (nix-darwin#564, #639). Defer until a
+  # focused migration window with TCC re-grant rehearsal.
+  # services.sketchybar: inline cfg.config takes shell lines; user's
+  # setup is sketchybarrc + 14 plugins/*.sh referencing $PLUGIN_DIR.
+  # Inline conversion non-trivial and currently working via OS auto-start.
 }


### PR DESCRIPTION
## Summary

Complete Phase 3. Three changes in this PR:

1. **Tier 2 macOS preferences** (opinionated dev defaults): dark mode lock, all NSAutomatic* off, no iCloud default save, hot corners disabled (aerospace boundaries), tap-to-click
2. **Tier 3 minimal security baseline**: immediate screensaver lock
3. **\`services.aerospace\` migration**: nix-darwin launchd takes over AeroSpace startup

Karabiner-Elements + SketchyBar service migration deferred (documented in commit + code comments).

## Settings added

### Tier 2 — NSGlobalDomain
- \`AppleInterfaceStyle = "Dark"\` — repo theme stack is dark
- \`NSAutomaticSpellingCorrectionEnabled = false\`
- \`NSAutomaticCapitalizationEnabled = false\`
- \`NSAutomaticQuoteSubstitutionEnabled = false\`
- \`NSAutomaticDashSubstitutionEnabled = false\`
- \`NSAutomaticPeriodSubstitutionEnabled = false\`
- \`NSDocumentSaveNewDocumentsToCloud = false\`

### Tier 2 — Dock
- \`wvous-{tl,tr,bl,br}-corner = 1\` — hot corners disabled (aerospace boundaries)

### Tier 2 — Trackpad
- \`Clicking = true\` (tap-to-click)

### Tier 3 — Screensaver
- \`askForPassword = true\`
- \`askForPasswordDelay = 0\` (immediate lock)

### services.aerospace
- \`enable = true\` with \`settings = builtins.fromTOML (readFile aerospace.toml)\`
- \`aerospace.toml\` edited: \`start-at-login = true\` removed (module assertion)
- launchd label: \`org.nixos.aerospace\` (KeepAlive=true, RunAtLoad=true)

## Out of scope (deferred, documented)

| app | reason |
|--|--|
| **karabiner-elements** | services.karabiner-elements rewritten for v15, but recurring "stops working after rebuild" reports ([nix-darwin#564](https://github.com/nix-darwin/nix-darwin/issues/564), [#639](https://github.com/nix-darwin/nix-darwin/issues/639)). Recovery: \`launchctl kickstart system/org.pqrs.karabiner.karabiner_grabber\`. Defer to focused window with TCC re-grant rehearsal. |
| **sketchybar** | services.sketchybar.config takes inline shell lines; user's setup is sketchybarrc + 14 plugins/*.sh referencing \`$PLUGIN_DIR\`. Inline conversion non-trivial; current OS auto-start works. |

## Pre-switch manual step

1. **Remove AeroSpace from Login Items**: System Settings → General → Login Items → Open at Login → select AeroSpace → \`−\`
   - Without this, OS Login Items + launchd both try to start aerospace → singleton lock conflict
2. Run switch
3. Optional: reboot or \`killall AeroSpace; launchctl kickstart -k gui/$(id -u)/org.nixos.aerospace\` for clean handoff

## Validation

\`\`\`
defaults read NSGlobalDomain AppleInterfaceStyle              → "Dark"
defaults read NSGlobalDomain NSAutomaticSpellingCorrectionEnabled → 0
defaults read com.apple.dock wvous-tl-corner                   → 1
defaults read com.apple.AppleMultitouchTrackpad Clicking       → 1
defaults read com.apple.screensaver askForPasswordDelay        → 0
launchctl list | grep org.nixos.aerospace                       → present
\`\`\`

## Refs

- Phase 0: #138/#139, Phase 1a: #149, Phase 2a/b/c/d: #153/#155/#161/#168
- Phase 3a: #170 (Tier 1 + zsh delegation)
- Hot-loop fix: #172
- Service research: nix-darwin services modules (master)

Closes #173, completes Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)