### PR TITLE
feat(nix): phase 4+5 - Linux sudo + sudoless paths in one PR

### DIFF
--- a/docs/install/linux-apt-residue.md
+++ b/docs/install/linux-apt-residue.md
@@ -44,11 +44,37 @@ Everything else from the previous apt list (`config/packages.linux.apt.txt`) is 
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
    ```
-3. Clone dotfiles and activate home-manager:
+3. Clone dotfiles **to `~/dotfiles`** (mandatory path — see "Path assumption" below):
    ```bash
-   ghq get shonenm/dotfiles
-   cd ~/ghq/github.com/shonenm/dotfiles
+   git clone https://github.com/shonenm/dotfiles.git ~/dotfiles
+   # or, if ghq is your convention, symlink:
+   #   ghq get shonenm/dotfiles && ln -s ~/ghq/github.com/shonenm/dotfiles ~/dotfiles
+   cd ~/dotfiles
    nix run home-manager/master -- switch --flake .#matsushimakouta@linux-x86_64
    ```
+
+## Migrating from legacy stow setup
+
+If the host previously ran the stow-based install (pre-Nix), absolute symlinks like `~/.config/atuin → ~/dotfiles/common/atuin/.config/atuin` may remain. `stow -D` silently skips absolute symlinks, so they linger. **Worse**: when home-manager activation writes to e.g. `~/.config/atuin/config.toml`, it follows the dir symlink and overwrites the actual `common/atuin/.config/atuin/config.toml` source file with a `/nix/store/...` symlink — corrupting the repo source.
+
+Clean up before first home-manager activation:
+
+```bash
+# Detect leftover stow dir symlinks pointing into dotfiles
+for d in ~/.config/*; do
+  [ -L "$d" ] || continue
+  case "$(readlink "$d")" in
+    */dotfiles/*) echo "remove: $d"; rm "$d" ;;
+  esac
+done
+# Same for top-level dotfiles (~/.gitconfig pre-Nix etc. — usually relative
+# stow symlinks, those get cleaned by `stow -D` fine; only absolutes linger)
+```
+
+## Path assumption
+
+Several home-manager modules (nvim, claude, pi, gh) use `mkOutOfStoreSymlink` to point at `${config.home.homeDirectory}/dotfiles/...`. The path is hardcoded. If the repo lives elsewhere on the host, either:
+- Symlink: `ln -s ~/ghq/github.com/shonenm/dotfiles ~/dotfiles`
+- Or change the clone target to `~/dotfiles` directly.
 
 See also: `docs/install/nix-sudoless-bootstrap.md` for hosts where step 2 is not possible.

--- a/docs/install/linux-apt-residue.md
+++ b/docs/install/linux-apt-residue.md
@@ -1,0 +1,54 @@
+# Linux apt residue (Phase 4/5)
+
+Packages that **stay on apt** after the Nix migration. Home-manager
+covers user-level tooling; these stay outside Nix because they're
+system-level, require setuid/system services, are too large to ship per
+user, or behave better when integrated with the host distro's package
+manager.
+
+## Stays on apt
+
+| package | reason |
+|---------|--------|
+| `build-essential`, `pkg-config`, `libssl-dev` | system C toolchain; needed by some build-from-source paths; trivially installable via apt |
+| `postgresql` (server) | system service with `postgres` user, systemd unit, data dir at `/var/lib/postgresql`. Use Nix's `pgcli` client + apt server. |
+| `openssh-server` | system service; needs setuid for keys; apt's openssh-server registers a launchd-equivalent service |
+| `zsh` | declared in `/etc/passwd` as login shell; system zsh is what `login(1)` execs. Nix-managed zsh also installed (programs.zsh.enable), referenced via PATH. |
+| fonts (PlemolJP, Nerd Fonts, etc.) | installed system-wide via apt or `fc-cache`; share across all users |
+| `luarocks` | needed by Neovim plugin packaging in some Lua plugin builds; apt's version is fine |
+| `imagemagick` (system) | sometimes pulled by system services / cron; Nix's imagemagick coexists in user PATH |
+
+## Replaced by Nix (home-manager)
+
+Everything else from the previous apt list (`config/packages.linux.apt.txt`) is now installed via Nix home-manager:
+
+| previously apt | now Nix |
+|---------------|---------|
+| ripgrep, fd-find | `nix/modules/packages/linux.nix` |
+| jq, stow, unzip | `nix/modules/packages/linux.nix` |
+| tmux | `programs.tmux.enable = true` |
+| autossh, pueue | `nix/modules/packages/linux.nix` |
+| ghq, gh | `nix/modules/packages/linux.nix` / `programs.gh.enable = true` |
+| eza, bat, lazygit | `programs.<name>.enable = true` |
+
+## Setup steps for a fresh ailab-style Linux host
+
+1. Install apt residue:
+   ```bash
+   sudo apt update && sudo apt install -y \
+     build-essential pkg-config libssl-dev \
+     postgresql openssh-server zsh \
+     luarocks fontconfig
+   ```
+2. Install Nix (Determinate Systems installer):
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+3. Clone dotfiles and activate home-manager:
+   ```bash
+   ghq get shonenm/dotfiles
+   cd ~/ghq/github.com/shonenm/dotfiles
+   nix run home-manager/master -- switch --flake .#matsushimakouta@linux-x86_64
+   ```
+
+See also: `docs/install/nix-sudoless-bootstrap.md` for hosts where step 2 is not possible.

--- a/docs/install/nix-sudoless-bootstrap.md
+++ b/docs/install/nix-sudoless-bootstrap.md
@@ -1,0 +1,117 @@
+# Nix sudoless bootstrap (Phase 5)
+
+Hosts where the Determinate / multi-user Nix installer can't run because
+the user lacks root. Picks the lowest-overhead bootstrap that still
+gives us the same home-manager config as a sudo Linux host.
+
+## Decision tree
+
+Run the preflight first:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/shonenm/dotfiles/main/scripts/nix-preflight.sh)
+```
+
+(or `bash ~/dotfiles/scripts/nix-preflight.sh` if dotfiles already on the host)
+
+The script prints one of:
+
+| preflight result | bootstrap path | what to do |
+|-----------------|----------------|------------|
+| `READY-NATIVE` | Determinate installer | not a sudoless host — use [linux-apt-residue.md](linux-apt-residue.md) |
+| `READY-CHROOT` | nix-user-chroot | section A below |
+| `READY-PORTABLE` | nix-portable | section B below |
+| `BLOCKED` | none | use pixi only (section C) |
+
+## Section A — `nix-user-chroot` (user namespaces available)
+
+`nix-user-chroot` creates a tiny `/nix` mount in the user's namespace
+without needing root. The same home-manager config from
+`#matsushimakouta@linux-x86_64` works unmodified.
+
+```bash
+# 1. Install nix-user-chroot (single static binary, no root needed)
+NUC_VERSION="1.3.1"
+NUC_ARCH="$(uname -m)"
+curl -fsSL "https://github.com/nix-community/nix-user-chroot/releases/download/${NUC_VERSION}/nix-user-chroot-bin-${NUC_VERSION}-${NUC_ARCH}-unknown-linux-musl" \
+  -o ~/.local/bin/nix-user-chroot
+chmod +x ~/.local/bin/nix-user-chroot
+
+# 2. Allocate a user-owned /nix directory (lives at ~/.nix-store/nix)
+mkdir -p ~/.nix-store/nix
+
+# 3. Enter the chroot and run the regular Nix installer
+nix-user-chroot ~/.nix-store/nix bash -lc '
+  curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+  . ~/.nix-profile/etc/profile.d/nix.sh
+  nix-shell -p nix-info --run "nix-info -m"
+'
+
+# 4. Activate home-manager from within the chroot
+nix-user-chroot ~/.nix-store/nix bash -lc '
+  . ~/.nix-profile/etc/profile.d/nix.sh
+  cd ~/ghq/github.com/shonenm/dotfiles
+  nix run home-manager/master -- switch --flake .#matsushimakouta@linux-x86_64
+'
+```
+
+For ease of use, wrap the `nix-user-chroot ~/.nix-store/nix` prefix in a shell alias
+inside `~/.zshrc.local` or similar so every Nix-managed binary is reachable.
+
+## Section B — `nix-portable` (no user namespaces, proot fallback)
+
+`nix-portable` is a single self-extracting binary that bundles Nix with
+its own proot/bubblewrap implementation. ~3x slower than nix-user-chroot
+but works on hosts where user namespaces are disabled (some kernel
+configurations + corporate locked-down Linux).
+
+```bash
+# 1. Download nix-portable
+curl -L https://github.com/DavHau/nix-portable/releases/latest/download/nix-portable-$(uname -m) \
+  -o ~/.local/bin/nix-portable
+chmod +x ~/.local/bin/nix-portable
+
+# 2. Activate home-manager via nix-portable
+cd ~/ghq/github.com/shonenm/dotfiles
+~/.local/bin/nix-portable nix run home-manager/master -- \
+  switch --flake .#matsushimakouta@linux-x86_64
+```
+
+Notes:
+- `nix-portable` keeps its store at `~/.nix-portable/store` by default.
+- Build performance is degraded — fine for occasional switches.
+- Some kernel features (e.g. `extended-attributes`) may not be available;
+  most home-manager modules don't need them.
+
+## Section C — Pixi only (Nix bootstrap blocked)
+
+If preflight reports `BLOCKED` (no namespaces, no proot fallback, kernel
+too old, SELinux/AppArmor blocking proot), give up on Nix and keep using
+the existing pixi-based no-sudo flow:
+
+- `config/pixi-packages.txt` lists what to install
+- `scripts/install-in-container.sh` handles the bootstrap
+- `~/.pixi/bin` is already in PATH via legacy `.zshrc.common` PATH line
+  (still present on Linux hosts; only the mac sudo path migrated to Nix)
+
+This is the same setup the repo had pre-Nix migration. Documented as a
+permanent fallback rather than something we plan to remove.
+
+## What survives across bootstrap modes
+
+All three Nix bootstrap modes (`READY-NATIVE`, `READY-CHROOT`,
+`READY-PORTABLE`) use **the same** `homeConfigurations."matsushimakouta@linux-..."`
+output from `flake.nix`. Don't fork the home-manager config per bootstrap
+mode — the difference is just *how* `nix` gets invoked, not *what* it
+builds.
+
+## Verification after bootstrap
+
+Same checks regardless of mode:
+
+```bash
+which fd          # → ~/.nix-profile/bin/fd  (or ~/.nix-portable/...)
+which starship   # → ~/.nix-profile/bin/starship
+echo $ZSH_VERSION # → should be the Nix-managed zsh
+abbr list | wc -l # → 66
+```

--- a/docs/install/nix-sudoless-bootstrap.md
+++ b/docs/install/nix-sudoless-bootstrap.md
@@ -47,10 +47,14 @@ nix-user-chroot ~/.nix-store/nix bash -lc '
   nix-shell -p nix-info --run "nix-info -m"
 '
 
-# 4. Activate home-manager from within the chroot
+# 4. Make sure dotfiles is at ~/dotfiles (path is hardcoded in some
+#    home-manager modules — nvim, claude, pi, gh — via mkOutOfStoreSymlink).
+[ -e ~/dotfiles ] || ln -s ~/ghq/github.com/shonenm/dotfiles ~/dotfiles
+
+# 5. Activate home-manager from within the chroot
 nix-user-chroot ~/.nix-store/nix bash -lc '
   . ~/.nix-profile/etc/profile.d/nix.sh
-  cd ~/ghq/github.com/shonenm/dotfiles
+  cd ~/dotfiles
   nix run home-manager/master -- switch --flake .#matsushimakouta@linux-x86_64
 '
 ```
@@ -71,8 +75,11 @@ curl -L https://github.com/DavHau/nix-portable/releases/latest/download/nix-port
   -o ~/.local/bin/nix-portable
 chmod +x ~/.local/bin/nix-portable
 
-# 2. Activate home-manager via nix-portable
-cd ~/ghq/github.com/shonenm/dotfiles
+# 2. Ensure dotfiles is at ~/dotfiles (mkOutOfStoreSymlink hardcoded path)
+[ -e ~/dotfiles ] || ln -s ~/ghq/github.com/shonenm/dotfiles ~/dotfiles
+
+# 3. Activate home-manager via nix-portable
+cd ~/dotfiles
 ~/.local/bin/nix-portable nix run home-manager/master -- \
   switch --flake .#matsushimakouta@linux-x86_64
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,18 @@
     let
       supportedSystems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" "aarch64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Helper to build a home-manager standalone configuration for Linux.
+      # Used for both sudo and sudoless Linux paths — they share the same
+      # home-manager modules; the difference is how Nix itself is bootstrapped
+      # on the host (Determinate vs nix-user-chroot vs nix-portable).
+      mkLinuxHome = system: home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+        modules = [ ./nix/home/linux.nix ];
+      };
     in
     {
       devShells = forAllSystems (system:
@@ -42,6 +54,7 @@
         nixpkgs.legacyPackages.${system}.nixpkgs-fmt
       );
 
+      # === macOS (nix-darwin + home-manager) ============================
       darwinConfigurations.shonenm = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         modules = [
@@ -51,10 +64,21 @@
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
             home-manager.backupFileExtension = "stow-backup";
-            home-manager.users.matsushimakouta = import ./nix/home/default.nix;
+            home-manager.users.matsushimakouta = import ./nix/home/mac.nix;
           }
         ];
         specialArgs = { inherit nixpkgs; };
+      };
+
+      # === Linux (home-manager standalone) ==============================
+      # Works for both sudo and sudoless paths — same config; the
+      # bootstrap differs (see docs/install/nix-sudoless-bootstrap.md).
+      # Activation:
+      #   nix run home-manager/master -- switch \
+      #     --flake .#matsushimakouta@linux-$ARCH
+      homeConfigurations = {
+        "matsushimakouta@linux-x86_64" = mkLinuxHome "x86_64-linux";
+        "matsushimakouta@linux-aarch64" = mkLinuxHome "aarch64-linux";
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,12 +22,17 @@
       # Used for both sudo and sudoless Linux paths — they share the same
       # home-manager modules; the difference is how Nix itself is bootstrapped
       # on the host (Determinate vs nix-user-chroot vs nix-portable).
-      mkLinuxHome = system: home-manager.lib.homeManagerConfiguration {
+      # Pass username so per-host accounts (matsushimakouta on ailab,
+      # shonenm on pi-500, etc.) resolve home.* correctly.
+      mkLinuxHome = { system, username }: home-manager.lib.homeManagerConfiguration {
         pkgs = import nixpkgs {
           inherit system;
           config.allowUnfree = true;
         };
-        modules = [ ./nix/home/linux.nix ];
+        modules = [
+          ./nix/home/linux.nix
+          { home.username = username; home.homeDirectory = "/home/${username}"; }
+        ];
       };
     in
     {
@@ -77,8 +82,13 @@
       #   nix run home-manager/master -- switch \
       #     --flake .#matsushimakouta@linux-$ARCH
       homeConfigurations = {
-        "matsushimakouta@linux-x86_64" = mkLinuxHome "x86_64-linux";
-        "matsushimakouta@linux-aarch64" = mkLinuxHome "aarch64-linux";
+        "matsushimakouta@linux-x86_64" =
+          mkLinuxHome { system = "x86_64-linux"; username = "matsushimakouta"; };
+        "matsushimakouta@linux-aarch64" =
+          mkLinuxHome { system = "aarch64-linux"; username = "matsushimakouta"; };
+        # pi-500 (Raspberry Pi 5, aarch64) runs as `shonenm` user.
+        "shonenm@linux-aarch64" =
+          mkLinuxHome { system = "aarch64-linux"; username = "shonenm"; };
       };
     };
 }

--- a/linux/zsh/.zshrc.local
+++ b/linux/zsh/.zshrc.local
@@ -17,7 +17,7 @@ fi
 [[ -o interactive ]] || return
 
 # --- Linux Tools Init ---
-command -v sheldon &>/dev/null && eval "$(sheldon source)"
+# sheldon removed in Phase 2b: zsh plugins now managed by programs.zsh.plugins (zsh-completions, zsh-autosuggestions, zsh-abbr, forgit, zsh-syntax-highlighting).
 command -v atuin &>/dev/null && eval "$(atuin init zsh)"
 # Ctrl+P で atuin の履歴検索を有効化（Up Arrow と同じ動作）
 bindkey -M emacs '^p' atuin-up-search

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -1,7 +1,12 @@
 { config, pkgs, ... }:
 
 {
+  # Cross-platform home-manager programs shared by mac.nix and linux.nix.
+  # Platform-specific entries (aerospace, ghostty, sketchybar — mac UI;
+  # any future linux-only modules) stay in the platform entry file.
+
   imports = [
+    # Phase 2a — simple configs
     ./programs/bat.nix
     ./programs/fd.nix
     ./programs/gh.nix
@@ -11,18 +16,15 @@
     ./programs/mise.nix
     ./programs/sesh.nix
     ./programs/aerc.nix
-    # Phase 2b additions
+    # Phase 2b — shell stack
     ./programs/zsh.nix
     ./programs/zsh-abbr.nix
     ./programs/starship.nix
     ./programs/tmux.nix
-    # Phase 2c additions
+    # Phase 2c — editor (mac-only UI modules live in mac.nix)
     ./programs/nvim.nix
     ./programs/vim.nix
-    ./programs/aerospace.nix
-    ./programs/ghostty.nix
-    ./programs/sketchybar.nix
-    # Phase 2d additions (final Phase 2)
+    # Phase 2d — stateful + scripts
     ./programs/atuin.nix
     ./programs/claude.nix
     ./programs/codex.nix
@@ -33,9 +35,6 @@
     ./programs/scripts.nix
   ];
 
-  home.username = "matsushimakouta";
-  home.homeDirectory = "/Users/matsushimakouta";
   home.stateVersion = "25.05";
-
   programs.home-manager.enable = true;
 }

--- a/nix/home/linux.nix
+++ b/nix/home/linux.nix
@@ -16,6 +16,7 @@
     ../modules/packages/linux.nix
   ];
 
-  home.username = "matsushimakouta";
-  home.homeDirectory = "/home/matsushimakouta";
+  # home.username + home.homeDirectory provided by mkLinuxHome in flake.nix
+  # so per-host accounts (matsushimakouta on ailab, shonenm on pi-500, …)
+  # all reuse this module.
 }

--- a/nix/home/linux.nix
+++ b/nix/home/linux.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, lib, ... }:
+
+{
+  # Linux home-manager entry. Common cross-platform programs + Linux
+  # user-level packages. Same configuration works for:
+  #   - sudo Linux hosts (ailab, full dev workstations): Nix installed
+  #     system-wide via Determinate; `home-manager switch --flake .#matsushimakouta@linux`
+  #     runs at user level identically to mac.
+  #   - sudoless Linux hosts (rcon containers, pi-500, locked-down):
+  #     Nix bootstrapped via nix-user-chroot (user namespaces) or
+  #     nix-portable (proot fallback) — same home-manager config applies.
+  #     See docs/install/nix-sudoless-bootstrap.md.
+
+  imports = [
+    ./common.nix
+    ../modules/packages/linux.nix
+  ];
+
+  home.username = "matsushimakouta";
+  home.homeDirectory = "/home/matsushimakouta";
+}

--- a/nix/home/mac.nix
+++ b/nix/home/mac.nix
@@ -1,0 +1,17 @@
+{ config, pkgs, ... }:
+
+{
+  # macOS home-manager entry. Common cross-platform programs + macOS-only
+  # UI modules (aerospace window manager, Ghostty terminal config,
+  # SketchyBar status bar).
+
+  imports = [
+    ./common.nix
+    ./programs/aerospace.nix
+    ./programs/ghostty.nix
+    ./programs/sketchybar.nix
+  ];
+
+  home.username = "matsushimakouta";
+  home.homeDirectory = "/Users/matsushimakouta";
+}

--- a/nix/modules/packages/linux.nix
+++ b/nix/modules/packages/linux.nix
@@ -1,0 +1,88 @@
+{ pkgs, lib, ... }:
+
+{
+  # Linux user-level packages (home-manager).
+  #
+  # Counterpart to nix/modules/packages/core.nix (mac, nix-darwin
+  # environment.systemPackages). On Linux we don't have nix-darwin so
+  # everything goes through home.packages.
+  #
+  # Excluded vs mac core.nix:
+  #   sketchybar / borders / macmon  — macOS UI
+  #   postgresql_17                  — large; use apt's postgresql-client
+  #                                    on hosts that need it
+  # Excluded vs both (already installed by programs.* home-manager modules):
+  #   bat, fd, gh, git, lazygit, mise — programs.<name>.enable = true
+  #   starship, tmux, zsh             — programs.<name>.enable = true
+  #
+  # System-level (not installable via home.packages on a regular user
+  # account) stays on apt:
+  #   build-essential, pkg-config, libssl-dev, openssh-server, fonts,
+  #   postgresql server, system X libs.
+  # See docs/install/linux-apt-residue.md.
+
+  home.packages = with pkgs; [
+    # --- Shell & Terminal ---
+    atuin
+    sesh
+    aerc
+    stow
+
+    # --- Image Processing ---
+    imagemagick
+    qrencode
+
+    # --- Development ---
+    neovim
+    typst
+    lazydocker
+    delta # git-delta
+    ghq
+    uv
+    rustup
+    bun
+
+    # --- Development Workflow ---
+    direnv
+    just
+    watchexec
+    hyperfine
+    autossh
+    pueue
+
+    # --- Database ---
+    pgcli
+    # postgresql_17 omitted — heavy; use apt postgresql-client where needed
+
+    # --- Security ---
+    gitleaks
+
+    # --- Modern CLI tools ---
+    eza
+    lsd
+    ripgrep
+    fzf
+    jq
+    yazi
+    tokei
+    tealdeer
+    procs
+    sd
+    dust
+    bottom
+    fastfetch
+    xh
+    git-absorb
+    ouch
+    glow
+    viddy
+    doggo
+    topgrade
+    grex
+
+    # --- Misc ---
+    zsh-completions
+  ];
+
+  nixpkgs.config.allowUnfree = true;
+}


### PR DESCRIPTION
## Summary

Wrap up the Linux side of the Nix migration. **One** home-manager configuration generator (\`mkLinuxHome { system, username }\`) covers both sudo and sudoless paths and per-host accounts — they share the same modules; the bootstrap differs (Determinate vs nix-user-chroot vs nix-portable).

Verified live on pi-500 (Raspberry Pi 5, Debian 13 trixie, aarch64, READY-NATIVE).

## What's in

### Refactoring (no behaviour change for mac)

- \`nix/home/default.nix\` → \`nix/home/common.nix\` (cross-platform programs only)
- \`nix/home/mac.nix\` — common + macOS-only UI (aerospace, ghostty, sketchybar) + mac home.* paths
- \`nix/home/linux.nix\` — common + Linux package set; home.username/homeDirectory provided by the helper so a single module serves multiple accounts
- \`nix/modules/packages/linux.nix\` — home.packages list (counterpart to mac core.nix systemPackages)

### flake.nix

- \`darwinConfigurations.shonenm\` now imports \`./nix/home/mac.nix\`
- \`mkLinuxHome { system, username }\` helper
- \`homeConfigurations\`:
  - \`matsushimakouta@linux-x86_64\` (ailab and other x86_64 dev hosts)
  - \`matsushimakouta@linux-aarch64\` (ARM Linux dev hosts)
  - \`shonenm@linux-aarch64\` (pi-500, Raspberry Pi 5)

### Documentation

- \`docs/install/linux-apt-residue.md\` — packages that stay on apt + path assumption + legacy stow cleanup
- \`docs/install/nix-sudoless-bootstrap.md\` — decision tree based on existing \`scripts/nix-preflight.sh\` output

### Legacy fix

- \`linux/zsh/.zshrc.local\` drops \`eval "$(sheldon source)"\` (mirrors the Phase 2b mac fix in \`mac/zsh/.zshrc.local\`)

## Bootstrap decision tree

| preflight result | bootstrap | how |
|---|---|---|
| READY-NATIVE | Determinate installer | standard Linux sudo flow |
| READY-CHROOT | nix-user-chroot | section A in sudoless-bootstrap.md |
| READY-PORTABLE | nix-portable | section B |
| BLOCKED | pixi fallback | section C — Nix not viable |

Same home-manager modules apply across READY-NATIVE / READY-CHROOT / READY-PORTABLE — the bootstrap is *how* nix gets invoked, not *what* it builds.

## Validation

### Mac (refactor)

- [x] \`nix flake check\` passes
- [x] \`nix build .#darwinConfigurations.shonenm.system --no-link\` passes

### Linux configs (eval-only on mac)

- [x] \`nix eval .#homeConfigurations.\"matsushimakouta@linux-x86_64\".activationPackage.drvPath\` returns drvPath
- [x] same for \`matsushimakouta@linux-aarch64\` and \`shonenm@linux-aarch64\`

### pi-500 live (Raspberry Pi 5, aarch64, Debian 13)

- [x] \`scripts/nix-preflight.sh\` → READY-NATIVE
- [x] Determinate Systems installer succeeded
- [x] \`nix build .#homeConfigurations.\"shonenm@linux-aarch64\".activationPackage --no-link\` passes (after SD-card cleanup, see Issues below)
- [x] \`nix run home-manager/master -- switch --flake .#shonenm@linux-aarch64 -b stow-backup\` activates
- [x] PATH: \`~/.nix-profile/bin\` + \`/nix/var/nix/profiles/default/bin\` ahead of system paths
- [x] zsh 5.9 (Nix-managed), abbr 66 entries loaded, ZSH_HIGHLIGHT_REGEXP type=association count=1
- [x] highlighters: \`main, brackets, regexp\`
- [x] starship 1.25.1, tmux 3.6a, nvim, git, lazygit, mise, gh, atuin all from \`~/.nix-profile/bin/\`
- [x] mkOutOfStoreSymlink chains (nvim/claude/pi/gh) resolve to \`~/dotfiles/common/...\`
- [x] git aliases (\`secrets\`/\`absorb\`), delta config, init.defaultBranch active
- [x] 87 entries in \`~/.local/bin/\` (scripts.nix + bin.nix + Nix-installed)

### Issues hit during pi-500 setup (all fixed)

1. **SD card full** (29/29 GB used) → cleared \`~/.cache\`/\`~/.npm/_cacache\` → 5 GB freed → build succeeded.
2. **username mismatch** (pi-500 is \`shonenm\`, not \`matsushimakouta\`) → parameterised \`mkLinuxHome\` and added \`shonenm@linux-aarch64\` (commit ee40ab4).
3. **28 orphan stow symlinks** in \`~/.config/\` + top-level \`~/.zshrc\`/\`~/.zshenv\`/etc. blocking home-manager activation → bulk-removed all symlinks whose target lived under \`*/dotfiles/*\` (one-time cleanup; documented in linux-apt-residue.md so future bootstraps avoid the trap).
4. **\`linux/zsh/.zshrc.local\` still ran \`eval \"\$(sheldon source)\"\`** even though sheldon was retired in Phase 2b → mirrored the mac fix (commit 904a68a).
5. **\`~/.zshrc.local\` not linked** after stow-symlink purge → manually symlinked \`~/dotfiles/linux/zsh/.zshrc.local\` (operational step on pi-500; Phase 6 will formalise).

## Out of scope (deferred / documented separately)

| item | reason |
|---|---|
| Apply to ailab and other Linux hosts | pi-500 validates the sudo path end-to-end; same flake config covers them once preflight is run |
| Sudoless path (\`nix-user-chroot\`/\`nix-portable\`) **live verification** | no host currently classifies as such; docs + flake support are in place |
| Phase 0 preflight matrix on all 7 target hosts | operational task; not blocking code |
| Phase 6 legacy cleanup (common/* removal, install.sh rewrite) | separate PR |
| Karabiner / SketchyBar nix-darwin migration | deferred from Phase 3b |
| pi-500 \`chsh\` to Nix-managed zsh | optional; current default shell still works, \`zsh\` invokable directly |
| \`common/atuin/.config/atuin/config.toml\` typechange loop on mac | recurring symlink-on-build artifact; root cause documented (legacy stow dir symlinks); cleaned up live |

## Refs

- Plan: \`docs/plans/nix-migration-plan.md\` § Phase 4-5
- Phase 0: #138/#139, Phase 1a: #149, Phase 2a/b/c/d: #153/#155/#161/#168
- Phase 3a/3b: #170/#174, fix-zsh-highlight: #175

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)