### PR TITLE
fix(pi): phase 2 - high-severity correctness fixes for agent harness (H1-H6)

### DIFF
--- a/common/pi/.pi/agent/APPEND_SYSTEM.md
+++ b/common/pi/.pi/agent/APPEND_SYSTEM.md
@@ -15,11 +15,12 @@
 - Do not read .env*, private keys, credentials, or production dumps.
 - Before large refactors, write a plan to TODO.md or docs/agent-plan.md.
 
-## Web Access Fallback
-- Pi has no built-in WebSearch/WebFetch. Use Jina AI via bash tool:
-  - WebFetch: `curl -fsSL 'https://r.jina.ai/<URL>'`
-  - WebSearch: `curl -fsSL 'https://s.jina.ai/<QUERY>'`
-- Rate limit: ~20 RPM without JINA_API_KEY. Set JINA_API_KEY for higher limits.
+## Web Access
+- Use the `web_search` and `web_fetch` tools (provided by the web-tools extension).
+  They cache, cite, and guard against secret/SSRF leakage — prefer them over raw curl.
+- Protocol: `web_search` (discovery) → `web_cache_lookup` → `web_fetch` → `web_cache_write` → `web_citation_add`.
+- Raw `curl 'https://r.jina.ai/<URL>'` / `curl 'https://s.jina.ai/<QUERY>'` is a last-resort
+  fallback only if the tools are unavailable. Rate limit ~20 RPM without JINA_API_KEY.
 
 ## Background Processes
 - Do not start long-running processes (servers, watchers, daemons) directly from CLI; use `pueue` instead.

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -16,7 +16,7 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { execSync, spawn } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -66,16 +66,9 @@ function logDelegation(difficulty: string, task: string, taskId?: string) {
   }) + "\n");
 }
 
-function shellSafe(s: string): string {
-  // Escape for use inside single-quoted shell string
-  return s.replace(/'/g, "'\\''");
-}
-
-function buildPiCommand(task: string, difficulty: string, model?: string): string {
+function resolveModel(difficulty: string, model?: string): string {
   const tier = MODEL_TIERS[difficulty] ?? MODEL_TIERS.medium;
-  const m = model || tier.model;
-  // sh -c wraps the command so < /dev/null is not hijacked by the outer shell
-  return `sh -c 'pi --model ${m} -p ${shellSafe(task)} < /dev/null'`;
+  return model || tier.model;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,16 +106,18 @@ export default function (pi: ExtensionAPI) {
     async execute(_toolCallId, params, _signal, onUpdate) {
       const difficulty = params.difficulty || "medium";
       const mode = params.mode || "async";
-      const cmd = buildPiCommand(params.task, difficulty, params.model);
+      const m = resolveModel(difficulty, params.model);
 
       if (mode === "sync") {
         onUpdate?.({ content: [{ type: "text", text: `🔄 Spawning sub-agent (${difficulty}, sync)...` }] });
         try {
-          const result = execSync(cmd, {
+          // Arg array (no shell) — task/model are passed literally, no injection
+          // or word-splitting. stdin ignored to replace `< /dev/null`.
+          const result = execFileSync("pi", ["--model", m, "-p", params.task], {
             encoding: "utf-8",
             timeout: 600_000, // 10 min
             maxBuffer: 50 * 1024 * 1024,
-            stdio: ["pipe", "pipe", "pipe"],
+            stdio: ["ignore", "pipe", "pipe"],
           });
           logDelegation(difficulty, params.task);
           return {
@@ -130,7 +125,7 @@ export default function (pi: ExtensionAPI) {
               type: "text",
               text: `## Sub-agent Result (${difficulty}, sync)\n\n${result.slice(0, 15000)}`,
             }],
-            details: { difficulty, mode: "sync", model: cmd.split("--model ")[1]?.split(" ")[0] },
+            details: { difficulty, mode: "sync", model: m },
           };
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -144,11 +139,13 @@ export default function (pi: ExtensionAPI) {
       // Async mode: pueue
       onUpdate?.({ content: [{ type: "text", text: `📋 Queuing sub-agent (${difficulty}, async)...` }] });
       try {
-        const pueueResult = execSync(`pueue add -i --print-task-id -- ${cmd} < /dev/null`, {
-          encoding: "utf-8",
-          timeout: 30_000,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+        // --escape makes pueue treat each arg literally (pueue runs the command
+        // through a shell internally); arg array prevents word-splitting here.
+        const pueueResult = execFileSync(
+          "pueue",
+          ["add", "--escape", "--immediate", "--print-task-id", "--", "pi", "--model", m, "-p", params.task],
+          { encoding: "utf-8", timeout: 30_000, stdio: ["ignore", "pipe", "pipe"] }
+        );
         const taskId = pueueResult.trim();
         logDelegation(difficulty, params.task, taskId);
 
@@ -161,7 +158,7 @@ export default function (pi: ExtensionAPI) {
               `View log: \`pueue log ${taskId}\`\n` +
               `Wait for completion: \`pueue wait ${taskId}\``,
           }],
-          details: { difficulty, mode: "async", pueueTaskId: taskId, model: cmd.split("--model ")[1]?.split(" ")[0] },
+          details: { difficulty, mode: "async", pueueTaskId: taskId, model: m },
         };
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -187,9 +184,9 @@ export default function (pi: ExtensionAPI) {
     async execute(_toolCallId, params) {
       try {
         if (params.taskId) {
-          const log = execSync(`pueue log ${params.taskId}`, {
+          const log = execFileSync("pueue", ["log", params.taskId], {
             encoding: "utf-8", timeout: 5000,
-            stdio: ["pipe", "pipe", "pipe"],
+            stdio: ["ignore", "pipe", "pipe"],
           });
           return {
             content: [{ type: "text", text: `## Task ${params.taskId}\n\n\`\`\`\n${log.slice(-5000)}\n\`\`\`` }],
@@ -197,9 +194,9 @@ export default function (pi: ExtensionAPI) {
           };
         }
 
-        const status = execSync("pueue status", {
+        const status = execFileSync("pueue", ["status"], {
           encoding: "utf-8", timeout: 5000,
-          stdio: ["pipe", "pipe", "pipe"],
+          stdio: ["ignore", "pipe", "pipe"],
         });
         return {
           content: [{ type: "text", text: `## Pueue Status\n\n\`\`\`\n${status.slice(0, 5000)}\n\`\`\`` }],
@@ -229,13 +226,13 @@ export default function (pi: ExtensionAPI) {
     async execute(_toolCallId, params, _signal, onUpdate) {
       onUpdate?.({ content: [{ type: "text", text: `⏳ Waiting for task ${params.taskId}...` }] });
       try {
-        execSync(`pueue wait ${params.taskId}`, {
+        execFileSync("pueue", ["wait", params.taskId], {
           encoding: "utf-8", timeout: 600_000, // 10 min
-          stdio: ["pipe", "pipe", "pipe"],
+          stdio: ["ignore", "pipe", "pipe"],
         });
-        const log = execSync(`pueue log ${params.taskId}`, {
+        const log = execFileSync("pueue", ["log", params.taskId], {
           encoding: "utf-8", timeout: 5000,
-          stdio: ["pipe", "pipe", "pipe"],
+          stdio: ["ignore", "pipe", "pipe"],
         });
         return {
           content: [{
@@ -259,7 +256,7 @@ export default function (pi: ExtensionAPI) {
   // -----------------------------------------------------------------------
   pi.on("session_start", async (_event, ctx) => {
     try {
-      execSync("pueued -d", { timeout: 2000, stdio: "ignore" });
+      execFileSync("pueued", ["-d"], { timeout: 2000, stdio: "ignore" });
     } catch {
       // daemon may already be running
     }

--- a/common/pi/.pi/agent/extensions/mcp-gateway.ts
+++ b/common/pi/.pi/agent/extensions/mcp-gateway.ts
@@ -12,7 +12,7 @@
 //       → MCP server process
 //
 // Config sources (merged, later overrides earlier):
-//   1. ~/.config/mcp/mcp.json     (global)
+//   1. ~/.config/agent/mcp.json   (global, shared across agents — see AGENTS.md)
 //   2. .mcp.json                   (project)
 //   3. .pi/mcp.json                (pi overrides)
 
@@ -81,8 +81,8 @@ const DEFAULT_MAX_RESULT = 8000;
 function loadConfig(cwd: string): MCPConfig {
   const merged: MCPConfig = { mcpServers: {} };
 
-  // 1. Global: ~/.config/mcp/mcp.json
-  const globalPath = join(homedir(), ".config", "mcp", "mcp.json");
+  // 1. Global: ~/.config/agent/mcp.json (shared location per AGENTS.md / spec)
+  const globalPath = join(homedir(), ".config", "agent", "mcp.json");
   if (existsSync(globalPath)) {
     try {
       const g = JSON.parse(readFileSync(globalPath, "utf-8"));
@@ -337,35 +337,27 @@ class MCPManager {
       const perm = serverCfg?.permission ?? "ask";
       const desc = serverCfg?.description ?? server;
 
-      // Build TypeBox schema from JSON schema
+      // Build TypeBox schema from JSON schema. Keys listed in the MCP tool's
+      // `required` array are registered as non-optional so the LLM is forced to
+      // supply them (otherwise every param was Optional → frequent tool errors).
       const props: Record<string, unknown> = {};
-      const required: string[] = [];
+      const requiredSet = new Set<string>(tool.inputSchema?.required ?? []);
 
       if (tool.inputSchema?.properties) {
         for (const [key, val] of Object.entries(tool.inputSchema.properties)) {
           const v = val as Record<string, unknown>;
           const jtype = v.type as string | undefined;
-          if (jtype === "string") {
-            props[key] = Type.Optional(Type.String({
-              description: (v.description as string) ?? "",
-            }));
-          } else if (jtype === "number" || jtype === "integer") {
-            props[key] = Type.Optional(Type.Number({
-              description: (v.description as string) ?? "",
-            }));
+          const description = (v.description as string) ?? "";
+          let base;
+          if (jtype === "number" || jtype === "integer") {
+            base = Type.Number({ description });
           } else if (jtype === "boolean") {
-            props[key] = Type.Optional(Type.Boolean({
-              description: (v.description as string) ?? "",
-            }));
+            base = Type.Boolean({ description });
           } else {
-            // Default to string for complex types
-            props[key] = Type.Optional(Type.String({
-              description: (v.description as string) ?? "",
-            }));
+            // string, plus default for complex/unknown types
+            base = Type.String({ description });
           }
-        }
-        if (tool.inputSchema.required) {
-          required.push(...tool.inputSchema.required);
+          props[key] = requiredSet.has(key) ? base : Type.Optional(base);
         }
       }
 

--- a/common/pi/.pi/agent/extensions/memory.ts
+++ b/common/pi/.pi/agent/extensions/memory.ts
@@ -310,12 +310,17 @@ export default function (pi: ExtensionAPI) {
         }
       }
 
-      // Search today's daily log
-      const daily = readIfExists(dailyFile());
-      if (daily) {
-        for (const line of daily.split("\n")) {
+      // Search all daily logs (newest first), not just today's
+      ensureDir(DAILY_DIR);
+      const dailyFiles = readdirSync(DAILY_DIR)
+        .filter((f) => f.endsWith(".md"))
+        .sort()
+        .reverse();
+      for (const f of dailyFiles) {
+        const content = readIfExists(join(DAILY_DIR, f));
+        for (const line of content.split("\n")) {
           if (line.toLowerCase().includes(query)) {
-            results.push({ file: `daily/${todayStr()}.md`, snippet: line.trim().slice(0, 200) });
+            results.push({ file: `daily/${f}`, snippet: line.trim().slice(0, 200) });
           }
         }
       }

--- a/common/pi/.pi/agent/skills/deep-research/SKILL.md
+++ b/common/pi/.pi/agent/skills/deep-research/SKILL.md
@@ -14,7 +14,9 @@ Follow this exact sequence for all research:
 ```
 web_search (discovery)
   ↓
-web_fetch / web_fetch_many (source retrieval)
+web_cache_lookup (check cache first)
+  ↓
+web_fetch (source retrieval — call once per URL)
   ↓
 web_cache_write (persist findings)
   ↓

--- a/common/pi/.pi/agent/skills/docs-research/SKILL.md
+++ b/common/pi/.pi/agent/skills/docs-research/SKILL.md
@@ -33,10 +33,11 @@ go list -m <module-path>
 
 ### 2. Search for Documentation
 
-Use `web_search_docs` with the package name and version:
+Use `web_search` with the package name and the installed version in the query:
 
 ```
-web_search_docs("<package-name>", version="<installed-version>")
+web_search("<package-name> <installed-version> documentation")
+web_search("<package-name> <installed-version> changelog OR release notes")
 ```
 
 ### 3. Fetch Official Sources
@@ -44,16 +45,18 @@ web_search_docs("<package-name>", version="<installed-version>")
 Prioritize in this order:
 
 1. **Official documentation** — docs.{package}.com, package docs URL
-2. **GitHub README / docs directory** — `web_search_github` → `web_clone_github`
+2. **GitHub README / docs directory** — find the repo via `web_search`, then `git clone --depth 1` and read locally (see the github-research skill)
 3. **Release notes / changelog** — GitHub releases, CHANGELOG.md
 4. **API reference** — JSDoc, OpenAPI spec, type definitions
 
 ### 4. Cache Findings
 
-After fetching useful documentation:
+After fetching useful documentation (`web_fetch` already auto-caches; use
+`web_cache_write` only to store content you assembled yourself):
 
 ```
-web_cache_write(url, content, provider, sourceType: "official_docs", tags: ["<package>", "<topic>"])
+web_cache_write(url, content)
+web_citation_add(url, title, note)
 ```
 
 ### 5. Present Findings

--- a/common/pi/.pi/agent/skills/github-research/SKILL.md
+++ b/common/pi/.pi/agent/skills/github-research/SKILL.md
@@ -17,10 +17,10 @@ Investigate GitHub repositories, issues, PRs, and source code using a clone-firs
 
 ### 1. Locate the Repository
 
-Use `web_search_github` to find the repository:
+Use `web_search` to find the repository (restrict to GitHub):
 
 ```
-web_search_github("topic OR package-name", repo?: "owner/repo")
+web_search("site:github.com <topic OR package-name>")
 ```
 
 ### 2. Clone the Repository


### PR DESCRIPTION
## Summary

pi エージェントハーネスレビューの Phase 2。High 項目 (H1–H6) の正しさ・整合性修正。Phase 1 (#183, Critical C1–C4) の続き。

## Changes

- **H1 コマンドインジェクション / 引数破綻** (`agent-delegation.ts`): シェル文字列 + `execSync` を全廃し `execFileSync`(arg 配列) 化。delegate のタスク未引用による複数語破綻と、task/model/taskId 補間によるインジェクションを解消。pueue は `--escape` でシェル特殊文字を literal 扱い。
- **H2 MCP required 未反映** (`mcp-gateway.ts`): `required` を計算するだけで TypeBox スキーマに反映しておらず全引数 optional だった。required キーを非 optional で登録。
- **H3 skill の幽霊ツール参照** (`skills/{deep-research,docs-research,github-research}`): 存在しないツールを実在ツールへ修正 (`web_fetch_many`→`web_fetch`/`web_cache_lookup`、`web_search_docs`/`web_search_github`/`web_clone_github`→`web_search`+`git clone`、`web_cache_write` の誤シグネチャ修正)。
- **H4 MCP config パス不一致** (`mcp-gateway.ts`): グローバル config を doc に合わせ `~/.config/mcp/mcp.json`→`~/.config/agent/mcp.json` に統一。
- **H5 web ツール矛盾** (`APPEND_SYSTEM.md`): 「組み込み web なし→curl 使え」が `web_search`/`web_fetch` 拡張を無視させていた。正規ツール優先・curl は最終手段へ。
- **H6 memory_search の範囲** (`memory.ts`): 当日 daily のみ検索だったのを DAILY_DIR 全ログ(新しい順)対象に。

## Test plan
- [x] `agent-delegation.ts` / `mcp-gateway.ts` / `memory.ts` を `node --check --experimental-strip-types` で構文確認
- [x] 幽霊ツール参照・残存 `execSync` が無いことを grep で確認
- [ ] pi 実行下の E2E (delegate 実行・pueue 投入・MCP required 強制・memory_search) ※pi 起動環境で要確認

## Notes
- H4 はコードを doc に合わせる変更。MCP config は `~/.config/agent/mcp.json` に配置すること (ローカルに既存ファイルは無いため破壊なし)。
- `session-manager.ts` の未コミット変更は本 PR と無関係なため除外。
- 残: Medium (M1–M6) と UX 追加は後続 phase。