### PR TITLE
fix(pi): phase 3 - medium-severity fixes for agent harness (M1-M5)

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -32,6 +32,20 @@ Use `pueue` for background processes: `pueue add -- <command>`
 - `mcp-gateway` — MCP tool bridge with permission control and audit
 - `statusline` — footer with token stats, context, git branch, research activity
 
+## Custom vs Community Packages
+
+These extensions are maintained in-house (`~/.pi/agent/extensions/`) rather than
+adopting community packages (`pi-mcp`, `pi-web-access`, `pi-subagents`) because
+they add value the packages don't: pueue-based async delegation with
+difficulty-tiered model selection (`agent-delegation`), secret/SSRF guards +
+cache/citation audit trail (`web-tools`), and unified allow/ask/deny gating with
+audit logging (`mcp-gateway`). When a community package gains equivalent
+guarantees, prefer adopting it over maintaining the custom one.
+
+- `mcp-gateway` transport: **stdio only**. SSE is deprecated upstream; Streamable
+  HTTP support is intentionally deferred until a remote MCP server is actually
+  needed (avoid speculative implementation). stdio is the recommended local transport.
+
 ## Memory
 
 - Persistent across sessions via plain Markdown files in `~/.pi/agent/memory/`

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -10,9 +10,9 @@
 //   oracle     — Second opinion, challenge assumptions, architecture advice
 //
 // Model selection tiers (from AGENTS.md):
-//   high   → gpt-5.5:high / kimi-k2.6:high
-//   medium → deepseek-v4-pro:high / gpt-5.4:low
-//   low    → deepseek-v4-flash:off / gpt-5.4-mini:off
+//   high   → kimi-k2.6:high       (design, review, debugging)
+//   medium → deepseek-v4-pro:high (coding from a plan)
+//   low    → deepseek-v4-flash:off (summaries, extraction)
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -27,24 +27,10 @@ import { join } from "node:path";
 
 const DELEGATION_LOG = join(homedir(), ".pi", "research", "delegation.jsonl");
 
-interface ModelTier {
-  model: string;
-  fallbackModels: string[];
-}
-
-const MODEL_TIERS: Record<string, ModelTier> = {
-  high: {
-    model: "opencode-go/kimi-k2.6:high",
-    fallbackModels: [],
-  },
-  medium: {
-    model: "opencode-go/deepseek-v4-pro:high",
-    fallbackModels: [],
-  },
-  low: {
-    model: "opencode-go/deepseek-v4-flash:off",
-    fallbackModels: [],
-  },
+const MODEL_TIERS: Record<string, string> = {
+  high: "opencode-go/kimi-k2.6:high",
+  medium: "opencode-go/deepseek-v4-pro:high",
+  low: "opencode-go/deepseek-v4-flash:off",
 };
 
 // ---------------------------------------------------------------------------
@@ -67,8 +53,7 @@ function logDelegation(difficulty: string, task: string, taskId?: string) {
 }
 
 function resolveModel(difficulty: string, model?: string): string {
-  const tier = MODEL_TIERS[difficulty] ?? MODEL_TIERS.medium;
-  return model || tier.model;
+  return model || MODEL_TIERS[difficulty] || MODEL_TIERS.medium;
 }
 
 // ---------------------------------------------------------------------------

--- a/common/pi/.pi/agent/extensions/mcp-gateway.ts
+++ b/common/pi/.pi/agent/extensions/mcp-gateway.ts
@@ -77,6 +77,10 @@ const RESEARCH_DIR = join(homedir(), ".pi", "research");
 const MCP_AUDIT_FILE = join(RESEARCH_DIR, "mcp-audit.jsonl");
 const MCP_STATS_FILE = join(RESEARCH_DIR, "mcp-stats.json");
 const DEFAULT_MAX_RESULT = 8000;
+// Preferred MCP protocol version we advertise in `initialize`. The actual
+// version is negotiated: the server replies with the version it will use, which
+// we accept (tools/list and tools/call are stable across these revisions).
+const PREFERRED_PROTOCOL_VERSION = "2025-11-25";
 
 function loadConfig(cwd: string): MCPConfig {
   const merged: MCPConfig = { mcpServers: {} };
@@ -127,6 +131,7 @@ class MCPClient {
   private pending = new Map<number, (res: JSONRPCResponse) => void>();
   private buffer = "";
   private initialized = false;
+  private negotiatedVersion = "";
   private serverName: string;
 
   constructor(private config: MCPServerConfig, name: string) {
@@ -188,7 +193,7 @@ class MCPClient {
 
       // Send initialize
       this.send("initialize", {
-        protocolVersion: "2024-11-05",
+        protocolVersion: PREFERRED_PROTOCOL_VERSION,
         capabilities: {},
         clientInfo: { name: "pi-mcp-gateway", version: "1.0.0" },
       })
@@ -198,6 +203,9 @@ class MCPClient {
             reject(new Error(`MCP initialize failed: ${res.error.message}`));
             return;
           }
+          // Accept the server's negotiated protocol version.
+          const initResult = res.result as { protocolVersion?: string } | undefined;
+          this.negotiatedVersion = initResult?.protocolVersion ?? PREFERRED_PROTOCOL_VERSION;
           this.initialized = true;
           // Send initialized notification
           if (this.proc?.stdin) {
@@ -569,12 +577,6 @@ export default async function (pi: ExtensionAPI) {
       const msg = err instanceof Error ? err.message : String(err);
       ctx.ui.notify(`MCP Gateway init failed: ${msg}`, "error");
     }
-  });
-
-  // Reload on /reload
-  pi.on("session_start", async (_event, ctx) => {
-    // Reload config (picks up changes to .mcp.json)
-    manager.reloadConfig();
   });
 
   // Permission gate for MCP tools. pi only exposes interactive ctx.ui in the

--- a/common/pi/.pi/agent/extensions/memory.ts
+++ b/common/pi/.pi/agent/extensions/memory.ts
@@ -32,6 +32,10 @@ const SCRATCHPAD_FILE = join(MEMORY_DIR, "SCRATCHPAD.md");
 const DAILY_DIR = join(MEMORY_DIR, "daily");
 
 const INJECTION_MAX = 8000;
+// Soft cap for MEMORY.md — beyond this, memory_write nudges the agent to curate.
+// (Injection already only surfaces ~4KB, so unbounded growth wastes storage and
+// dilutes relevance rather than helping.)
+const MEMORY_SOFT_CAP = 50 * 1024;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -43,6 +47,12 @@ function ensureDir(dir: string) {
 
 function todayStr(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+function dateStrDaysAgo(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
 }
 
 function dailyFile(date?: string): string {
@@ -110,6 +120,20 @@ function buildInjection(): string {
     if (budget > 0) {
       parts.push(`## Today (${todayStr()})\n${tail.slice(-budget)}`);
       used += budget;
+    }
+  }
+
+  // 2b. Yesterday's daily log (tail) — continuity across the day boundary
+  if (used < INJECTION_MAX) {
+    const yStr = dateStrDaysAgo(1);
+    const yday = readIfExists(dailyFile(yStr));
+    if (yday) {
+      const tail = yday.split("\n").slice(-30).join("\n");
+      const budget = Math.min(tail.length, 1500, INJECTION_MAX - used);
+      if (budget > 0) {
+        parts.push(`## Yesterday (${yStr})\n${tail.slice(-budget)}`);
+        used += budget;
+      }
     }
   }
 
@@ -212,9 +236,13 @@ export default function (pi: ExtensionAPI) {
       if (target === "long_term") {
         const entry = `\n## ${timestamp}\n${content}\n`;
         appendFile(MEMORY_FILE, entry);
+        const size = readIfExists(MEMORY_FILE).length;
+        const hint = size > MEMORY_SOFT_CAP
+          ? `\n\n⚠️ MEMORY.md is ${(size / 1024).toFixed(0)}KB (soft cap ${MEMORY_SOFT_CAP / 1024}KB). Consider curating stale entries — only ~4KB is injected at session start.`
+          : "";
         return {
-          content: [{ type: "text", text: `📝 Saved to MEMORY.md:\n\n${content.slice(0, 400)}` }],
-          details: { target: "long_term", file: MEMORY_FILE },
+          content: [{ type: "text", text: `📝 Saved to MEMORY.md:\n\n${content.slice(0, 400)}${hint}` }],
+          details: { target: "long_term", file: MEMORY_FILE, sizeBytes: size },
         };
       } else {
         const entry = `\n### ${timestamp}\n${content}\n`;

--- a/common/pi/.pi/agent/extensions/permission-gate.ts
+++ b/common/pi/.pi/agent/extensions/permission-gate.ts
@@ -4,28 +4,43 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
+// Defense-in-depth only. This is a denylist and is inherently bypassable
+// (e.g. `rm -r -f`, base64-encoded commands, obscure flag spellings); it is not
+// a security boundary. Its job is to catch the obvious-footgun cases and force
+// a human decision, not to stop a determined adversary.
 const DANGEROUS_PATTERNS = [
-  /rm\s+-rf/,
+  /\brm\b(?=[^|;&\n]*\s-[a-z]*r)(?=[^|;&\n]*\s-[a-z]*f)/i, // rm with both -r and -f (rf/fr/-r -f)
   /\bsudo\b/,
   /chmod\s+(-R\s+)?777/,
   /\bchown\b/,
   /\bdocker\s+system\s+prune\b/,
   /\bkubectl\s+delete\b/,
-  /\bterraform\s+apply\b/,
+  /\bterraform\s+(apply|destroy)\b/,
   /\bpnpm\s+publish\b/,
   /\bnpm\s+publish\b/,
-  /\bgit\s+push\s+--force\b/,
+  /\bgit\s+push\s+.*--force(-with-lease)?\b/,
   /\bgit\s+reset\s+--hard\b/,
-  /\b DROP\s+/i,
-  /\b DELETE\s+FROM\s+/i,
+  /\bgit\s+clean\s+-[a-z]*f[a-z]*d|\bgit\s+clean\s+-[a-z]*d[a-z]*f/, // git clean -fd
+  /\bdd\s+(if|of)=/,
+  /\bmkfs(\.\w+)?\b/,
+  />\s*\/dev\/(sd|nvme|disk|hd)/, // overwrite raw block device
+  /\b(curl|wget)\b[^|]*\|\s*(sudo\s+)?(sh|bash|zsh)\b/, // pipe-to-shell
+  /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/, // fork bomb
+  /\bDROP\s+(TABLE|DATABASE|SCHEMA)\b/i,
+  /\bDELETE\s+FROM\b/i,
   /\btruncate\s+table\b/i,
 ];
 
+// Tool names that execute shell commands. `bash` is pi's real tool; the others
+// are matched defensively (harmless if they don't exist — the gate never fires).
+const SHELL_TOOLS = new Set(["bash", "shell", "sh", "exec", "run"]);
+
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, ctx) => {
-    if (event.toolName !== "bash") return;
+    if (!SHELL_TOOLS.has(event.toolName)) return;
 
-    const command = String(event.input?.command ?? "");
+    const command = String(event.input?.command ?? event.input?.cmd ?? "");
+    if (!command) return;
 
     const matched = DANGEROUS_PATTERNS.find((p) => p.test(command));
     if (!matched) return;

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -12,7 +12,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -21,10 +21,38 @@ import { join } from "node:path";
 // ---------------------------------------------------------------------------
 
 type DisplayMode = "off" | "compact" | "detailed";
-let mode: DisplayMode = "detailed";
+
+// Persist the chosen mode across sessions.
+const MODE_FILE = join(homedir(), ".pi", "agent", "statusline-mode");
+function loadMode(): DisplayMode {
+  try {
+    const v = readFileSync(MODE_FILE, "utf-8").trim();
+    if (v === "off" || v === "compact" || v === "detailed") return v;
+  } catch { /* default below */ }
+  return "detailed";
+}
+function saveMode(m: DisplayMode): void {
+  try { writeFileSync(MODE_FILE, m); } catch { /* non-fatal */ }
+}
+
+let mode: DisplayMode = loadMode();
 let dirtyState = false;
 let lastDirtyCheck = 0;
 const DIRTY_CHECK_INTERVAL_MS = 5000;
+
+// Cached token totals — recomputed on turn_end / session_start instead of
+// re-summing the entire branch on every footer render (cheap on large sessions).
+let tokCache = { input: 0, output: 0, cost: 0 };
+function recomputeTokens(branch: Iterable<{ type: string; message?: { role: string } }>): void {
+  let input = 0, output = 0, cost = 0;
+  for (const e of branch) {
+    if (e.type === "message" && e.message?.role === "assistant") {
+      const m = e.message as unknown as AssistantMessage;
+      input += m.usage.input; output += m.usage.output; cost += m.usage.cost.total;
+    }
+  }
+  tokCache = { input, output, cost };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -105,6 +133,7 @@ export default function (pi: ExtensionAPI) {
         const cycle: DisplayMode[] = ["detailed", "compact", "off"];
         mode = cycle[(cycle.indexOf(mode) + 1) % cycle.length];
       }
+      saveMode(mode);
       if (mode === "off") {
         ctx.ui.setFooter(undefined);
         ctx.ui.notify("Statusline: off", "info");
@@ -117,8 +146,9 @@ export default function (pi: ExtensionAPI) {
   // -----------------------------------------------------------------------
   // Git dirty check
   // -----------------------------------------------------------------------
-  pi.on("turn_end", async () => {
+  pi.on("turn_end", async (_event, ctx) => {
     if (mode === "off") return;
+    recomputeTokens(ctx.sessionManager.getBranch());
     const now = Date.now();
     if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
       dirtyState = checkGitDirty(); lastDirtyCheck = now;
@@ -133,6 +163,7 @@ export default function (pi: ExtensionAPI) {
   // Footer renderer
   // -----------------------------------------------------------------------
   pi.on("session_start", async (_event, ctx) => {
+    recomputeTokens(ctx.sessionManager.getBranch());
     ctx.ui.setFooter((tui, theme, footerData) => {
       const unsub = footerData.onBranchChange(() => tui.requestRender());
       return {
@@ -141,14 +172,8 @@ export default function (pi: ExtensionAPI) {
         render(width: number): string[] {
           if (mode === "off") return [];
 
-          // ---- Accumulate token stats ----
-          let input = 0, output = 0, cost = 0;
-          for (const e of ctx.sessionManager.getBranch()) {
-            if (e.type === "message" && e.message.role === "assistant") {
-              const m = e.message as AssistantMessage;
-              input += m.usage.input; output += m.usage.output; cost += m.usage.cost.total;
-            }
-          }
+          // ---- Token stats (cached; recomputed on turn_end / session_start) ----
+          const { input, output, cost } = tokCache;
 
           // ---- Context ----
           const usage = ctx.getContextUsage();


### PR DESCRIPTION
## Summary

pi エージェントハーネスレビューの Phase 3 (Medium)。Phase 2 (#184, H1–H6) にスタック。

## Changes
- **M1 MCP protocolVersion** (`mcp-gateway.ts`): `2024-11-05` 固定 → 最新 `2025-11-25` 送出 + サーバ応答受容のネゴシエーション。
- **M2 permission-gate 強化** (`permission-gate.ts`): SQL 正規表現の空白バグ修正、対象を shell 系ツールへ拡張、危険パターン追加 (`dd`/`mkfs`/`>/dev`、`curl|sh`、`git clean -fd`、`--force-with-lease`、fork bomb、`terraform destroy`)、`rm` の分離フラグ (`-r -f`) も lookahead で検出。denylist は defense-in-depth と明記。
- **M3 軽微品質**: mcp-gateway の重複 `session_start` 削除、agent-delegation の dead `fallbackModels` 削除 + tier doc drift 訂正、statusline のトークン合計キャッシュ化 (render 毎再走査回避) + mode 永続化。
- **M4 build-vs-adopt** (`AGENTS.md`): 自作 extension と community package の方針を明記。
- **M5 memory** (`memory.ts`): 前日 daily ログを injection に追加、MEMORY.md ソフト上限 (50KB) 超で curation 促し。

## Deferred
- **M6 Streamable HTTP transport**: リモート MCP サーバ未使用のため投機的実装になる。`AGENTS.md` に「stdio only、必要時まで deferred」と記載。
- **M3 session-manager timestamp (mtime化)**: 同ファイルに無関係な未コミット WIP があるため本 phase では見送り。

## Test plan
- [x] 6 TS を `node --check --experimental-strip-types` で構文確認
- [x] permission-gate の検出/誤検出を Node 単体テスト (rm 変種・git clean・DROP・fork bomb 等 BLOCK / `npm run`・通常 push 等 allow)
- [ ] pi 実行下の E2E (MCP negotiation・statusline 描画・memory injection・permission confirm) ※pi 起動環境で要確認

## Notes
- `session-manager.ts` の未コミット変更は本 PR と無関係なため除外。