### PR TITLE
fix(pi): phase 4 - low-severity polish for agent harness (L1-L4)

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -3,7 +3,7 @@
 ## Infrastructure Spec
 
 The canonical specification for all agent infrastructure components is at:
-`docs/specs/agent-infrastructure.md`
+`~/dotfiles/docs/specs/agent-infrastructure.md` (in the dotfiles repo).
 
 Implementations:
 - **Pi**: `~/.pi/agent/extensions/` (TypeScript)

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -42,12 +42,21 @@ function ensureLogDir() {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 }
 
+// Best-effort secret redaction before writing the delegation audit log.
+function redactSecrets(s: string): string {
+  return s
+    .replace(/("?(?:api[_-]?key|token|secret|password|authorization)"?\s*[:=]\s*"?)[^",}\s]+/gi, "$1[REDACTED]")
+    .replace(/sk-[a-zA-Z0-9]{20,}/g, "[REDACTED]")
+    .replace(/gh[pousr]_[a-zA-Z0-9]{20,}/g, "[REDACTED]")
+    .replace(/xox[bprs]-[a-zA-Z0-9-]{10,}/g, "[REDACTED]");
+}
+
 function logDelegation(difficulty: string, task: string, taskId?: string) {
   ensureLogDir();
   appendFileSync(DELEGATION_LOG, JSON.stringify({
     timestamp: new Date().toISOString(),
     difficulty,
-    task: task.slice(0, 300),
+    task: redactSecrets(task).slice(0, 300),
     taskId: taskId ?? null,
   }) + "\n");
 }

--- a/common/pi/.pi/agent/extensions/mcp-gateway.ts
+++ b/common/pi/.pi/agent/extensions/mcp-gateway.ts
@@ -401,8 +401,8 @@ class MCPManager {
     const serverCfg = this.config.mcpServers[server];
     const permission = serverCfg?.permission ?? "ask";
 
-    // Build details for audit
-    const argsSummary = JSON.stringify(params).slice(0, 200);
+    // Build details for audit (secrets redacted)
+    const argsSummary = redactSecrets(JSON.stringify(params)).slice(0, 200);
 
     // Handle permission: deny
     if (permission === "deny") {
@@ -519,6 +519,17 @@ class MCPManager {
 
 function ensureResearchDir() {
   if (!existsSync(RESEARCH_DIR)) mkdirSync(RESEARCH_DIR, { recursive: true });
+}
+
+// Redact obvious secrets before they hit the audit log (MCP tool args can carry
+// tokens). Best-effort — covers key/token/password assignments and common token
+// shapes, not a guarantee.
+function redactSecrets(s: string): string {
+  return s
+    .replace(/("?(?:api[_-]?key|token|secret|password|authorization)"?\s*[:=]\s*"?)[^",}\s]+/gi, "$1[REDACTED]")
+    .replace(/sk-[a-zA-Z0-9]{20,}/g, "[REDACTED]")
+    .replace(/gh[pousr]_[a-zA-Z0-9]{20,}/g, "[REDACTED]")
+    .replace(/xox[bprs]-[a-zA-Z0-9-]{10,}/g, "[REDACTED]");
 }
 
 function logMCPAudit(

--- a/common/pi/.pi/agent/extensions/web-tools.ts
+++ b/common/pi/.pi/agent/extensions/web-tools.ts
@@ -165,14 +165,14 @@ function curl(args: string[], opts: { timeout: number; maxBuffer?: number }): st
   }
 }
 
-function searxngSearch(query: string): string | null {
+function searxngSearch(query: string, num: number): string | null {
   const url = `${SEARXNG_URL}/search?q=${encodeURIComponent(query)}&format=json`;
   const result = curl(["-fsSL", "--max-time", "15", url], { timeout: 16000 });
   if (!result) return null;
   try {
     const data = JSON.parse(result);
     if (!data.results || data.results.length === 0) return null;
-    return JSON.stringify(data.results.slice(0, 10), null, 2);
+    return JSON.stringify(data.results.slice(0, num), null, 2);
   } catch {
     return null;
   }
@@ -236,6 +236,7 @@ export default function (pi: ExtensionAPI) {
     }),
     async execute(_toolCallId, params, _signal, onUpdate) {
       const { query, num = 5 } = params;
+      const n = Math.min(Math.max(num, 1), 10);
       const trimmedQuery = query.trim().slice(0, 500);
 
       // Secret guard
@@ -251,7 +252,7 @@ export default function (pi: ExtensionAPI) {
       onUpdate?.({ content: [{ type: "text", text: `🔍 Searching: ${trimmedQuery.slice(0, 100)}...` }] });
 
       // Try SearXNG first
-      let result = searxngSearch(trimmedQuery);
+      let result = searxngSearch(trimmedQuery, n);
       let backend = "searxng";
 
       if (!result) {
@@ -508,7 +509,7 @@ export default function (pi: ExtensionAPI) {
   // Notify on startup
   // -----------------------------------------------------------------------
   pi.on("session_start", async (_event, ctx) => {
-    const searxngUp = searxngSearch("test") !== null;
+    const searxngUp = searxngSearch("test", 1) !== null;
     const jinaKeySet = !!process.env.JINA_API_KEY;
     const parts: string[] = [];
     if (searxngUp) parts.push("SearXNG✅");

--- a/docs/specs/agent-infrastructure.md
+++ b/docs/specs/agent-infrastructure.md
@@ -104,7 +104,7 @@ MCP サーバーへの安全な接続レイヤー。
 | **Permission** | 3段階: `allow` / `ask` / `deny` |
 | **Audit** | `~/.pi/research/mcp-audit.jsonl` |
 | **Stats** | `~/.pi/research/mcp-stats.json` |
-| **Pi impl** | `extensions/mcp-gateway.ts` (plain Markdown (pi-memory compatible) in `~/.pi/agent/memory/` N-RPC client + tool registration) |
+| **Pi impl** | `extensions/mcp-gateway.ts` — JSON-RPC stdio client + tool registration. allow/ask/deny enforced via `tool_call` gate; protocol version negotiated (advertises latest). stdio only (HTTP deferred) |
 | **Claude impl** | ネイティブ MCP 対応 + symlink で共有 config 参照 |
 
 ## Shared Configuration


### PR DESCRIPTION
## Summary

pi エージェントハーネスレビューの Phase 4 (Low / polish)。Phase 1-3 (#183/#184/#185) の続き、これでレビュー由来の C/H/M/L 修正は一通り完了。

## Changes
- **L1 監査ログの secret redaction** (`mcp-gateway.ts`, `agent-delegation.ts`): MCP tool 引数 / delegation task をログ書き込み前に redact (api_key/token/password/authorization 代入、`sk-`/`ghX_`/`xox-` トークン形を `[REDACTED]`)。ベストエフォート。
- **L2 web_search num 未反映** (`web-tools.ts`): searxng backend が `num` を無視し常に 10 件返していたのを、1–10 クランプの `num` 件に修正。
- **L3 spec 誤記** (`docs/specs/agent-infrastructure.md`): MCP Gateway の Pi impl セルに混入していた memory 説明文を正しい記述へ。tool_call ゲートでの allow/ask/deny 強制、version ネゴシエーション、stdio-only を明記。
- **L4 spec 参照パス** (`AGENTS.md`): 相対 `docs/specs/...` → `~/dotfiles/docs/specs/...` に明示。

## Test plan
- [x] 3 TS を `node --check --experimental-strip-types` で構文確認
- [x] `redactSecrets` を Node 単体テスト (キー代入・GitHub/sk- トークン redact、通常テキスト不変)
- [ ] pi 実行下の E2E (audit ログ redaction・web_search num) ※pi 起動環境で要確認

## Notes
- secret redaction はベストエフォート (全パターン網羅の保証ではない)。
- 残: UX 追加 (/goal の memory 拡張、sub-agent status widget) は別途。