### PR TITLE
feat(pi): phase 5 - pinned goal command and sub-agent statusline indicator

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -51,8 +51,9 @@ guarantees, prefer adopting it over maintaining the custom one.
 - Persistent across sessions via plain Markdown files in `~/.pi/agent/memory/`
 - Tools: `memory_write`, `memory_read`, `memory_search`, `scratchpad`
 - Format: pi-memory compatible (MEMORY.md, SCRATCHPAD.md, daily/)
-- Context auto-injected on session start (scratchpad + today's log + MEMORY.md)
+- Context auto-injected on session start (goal + scratchpad + today/yesterday log + MEMORY.md)
 - Install `qmd` for semantic/vector search upgrade
+- `/goal <text>` — set a pinned session goal (injected as context + shown in the statusline). `/goal` shows it, `/goal clear` clears it.
 
 ## Agent Delegation (pi-subagents + custom)
 
@@ -68,6 +69,8 @@ guarantees, prefer adopting it over maintaining the custom one.
 
 - pi-subagents provides: chain/parallel execution, TUI visualization, built-in agents
 - agent-delegation.ts adds: pueue async execution, difficulty-based model auto-selection
+- Async sub-agents are pueue tasks labeled `pi-delegate`; the statusline shows their
+  running/queued count (`agents r:N q:M`) so background work is visible.
 
 ## Session Management
 

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -26,6 +26,8 @@ import { join } from "node:path";
 // ---------------------------------------------------------------------------
 
 const DELEGATION_LOG = join(homedir(), ".pi", "research", "delegation.jsonl");
+// pueue label applied to delegated sub-agents (statusline filters on this).
+const DELEGATE_LABEL = "pi-delegate";
 
 const MODEL_TIERS: Record<string, string> = {
   high: "opencode-go/kimi-k2.6:high",
@@ -137,7 +139,9 @@ export default function (pi: ExtensionAPI) {
         // through a shell internally); arg array prevents word-splitting here.
         const pueueResult = execFileSync(
           "pueue",
-          ["add", "--escape", "--immediate", "--print-task-id", "--", "pi", "--model", m, "-p", params.task],
+          // --label pi-delegate marks these tasks so the statusline can count
+          // active sub-agents separately from the user's other pueue jobs.
+          ["add", "--escape", "--immediate", "--print-task-id", "--label", DELEGATE_LABEL, "--", "pi", "--model", m, "-p", params.task],
           { encoding: "utf-8", timeout: 30_000, stdio: ["ignore", "pipe", "pipe"] }
         );
         const taskId = pueueResult.trim();

--- a/common/pi/.pi/agent/extensions/memory.ts
+++ b/common/pi/.pi/agent/extensions/memory.ts
@@ -30,6 +30,8 @@ const MEMORY_DIR = join(homedir(), ".pi", "agent", "memory");
 const MEMORY_FILE = join(MEMORY_DIR, "MEMORY.md");
 const SCRATCHPAD_FILE = join(MEMORY_DIR, "SCRATCHPAD.md");
 const DAILY_DIR = join(MEMORY_DIR, "daily");
+// Pinned session goal (set via /goal). statusline.ts reads the same path.
+const GOAL_FILE = join(homedir(), ".pi", "agent", "goal");
 
 const INJECTION_MAX = 8000;
 // Soft cap for MEMORY.md — beyond this, memory_write nudges the agent to curate.
@@ -102,6 +104,14 @@ function writeScratchpad(items: ScratchItem[]) {
 function buildInjection(): string {
   const parts: string[] = [];
   let used = 0;
+
+  // 0. Pinned goal (set via /goal)
+  const goal = readIfExists(GOAL_FILE).trim();
+  if (goal) {
+    const text = `## Current Goal\n${goal}`;
+    parts.push(text.slice(0, 1000));
+    used += Math.min(text.length, 1000);
+  }
 
   // 1. Open scratchpad items
   const items = parseScratchpad().filter((i) => !i.done);
@@ -207,6 +217,35 @@ export default function (pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async () => writeHandoff());
   pi.on("session_before_compact", async () => writeHandoff());
+
+  // -----------------------------------------------------------------------
+  // Command: /goal <text> | /goal | /goal clear
+  // Pinned goal: injected as context (session start + on set) and shown in the
+  // statusline (statusline.ts reads GOAL_FILE).
+  // -----------------------------------------------------------------------
+  pi.registerCommand("goal", {
+    description: "Set/show/clear the pinned session goal (injected as context + shown in statusline)",
+    handler: async (args, ctx) => {
+      const arg = (args || "").trim();
+      if (!arg) {
+        const g = readIfExists(GOAL_FILE).trim();
+        ctx.ui.notify(g ? `🎯 Goal: ${g}` : "No goal set. Usage: /goal <text> (or /goal clear)", "info");
+        return;
+      }
+      if (arg === "clear") {
+        writeFile(GOAL_FILE, "");
+        ctx.ui.notify("Goal cleared", "info");
+        return;
+      }
+      writeFile(GOAL_FILE, arg);
+      // Inject now so the model sees the goal this turn, not only next session.
+      pi.sendMessage(
+        { customType: "goal", content: `## Current Goal\n${arg}`, display: false },
+        { deliverAs: "nextTurn" }
+      );
+      ctx.ui.notify(`🎯 Goal set: ${arg}`, "info");
+    },
+  });
 
   // -----------------------------------------------------------------------
   // Tool: memory_write

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -102,6 +102,34 @@ function readStats(): StatsSnapshot {
   return s;
 }
 
+// Pinned goal (set via /goal in the memory extension). Tiny file — read directly.
+const GOAL_FILE = join(homedir(), ".pi", "agent", "goal");
+function readGoal(): string {
+  try { return readFileSync(GOAL_FILE, "utf-8").trim(); } catch { return ""; }
+}
+
+// Active delegated sub-agents (pueue tasks labeled pi-delegate). Refreshed off
+// the render path (turn_end / session_start) since `pueue status` shells out.
+let agentStatus = { running: 0, queued: 0 };
+function refreshAgents(): void {
+  let running = 0, queued = 0;
+  try {
+    const out = execSync("pueue status --json", {
+      encoding: "utf-8", timeout: 1500, stdio: ["pipe", "pipe", "ignore"],
+    });
+    const data = JSON.parse(out);
+    const tasks = (data.tasks ?? {}) as Record<string, { label?: string; status?: unknown }>;
+    for (const id of Object.keys(tasks)) {
+      const t = tasks[id];
+      if (t?.label !== "pi-delegate") continue;
+      const state = typeof t.status === "string" ? t.status : Object.keys(t.status ?? {})[0];
+      if (state === "Running") running++;
+      else if (state === "Queued" || state === "Paused") queued++;
+    }
+  } catch { /* pueue not running / unparseable — show nothing */ }
+  agentStatus = { running, queued };
+}
+
 /**
  * Plain-character progress gauge. Safe to use inside theme.fg() because the
  * characters have no ANSI codes. Returns something like "████░░░░  29%".
@@ -149,6 +177,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("turn_end", async (_event, ctx) => {
     if (mode === "off") return;
     recomputeTokens(ctx.sessionManager.getBranch());
+    refreshAgents();
     const now = Date.now();
     if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
       dirtyState = checkGitDirty(); lastDirtyCheck = now;
@@ -164,6 +193,7 @@ export default function (pi: ExtensionAPI) {
   // -----------------------------------------------------------------------
   pi.on("session_start", async (_event, ctx) => {
     recomputeTokens(ctx.sessionManager.getBranch());
+    refreshAgents();
     ctx.ui.setFooter((tui, theme, footerData) => {
       const unsub = footerData.onBranchChange(() => tui.requestRender());
       return {
@@ -212,14 +242,23 @@ export default function (pi: ExtensionAPI) {
             return [truncateToWidth(`${tokIn} ${tokOut} ${tokCost}  ${modelStr}`, width)];
           }
 
+          const lines: string[] = [];
+
+          // Pinned goal (top, most visible)
+          const goal = readGoal();
+          if (goal) lines.push(truncateToWidth(theme.fg("warning", `🎯 ${goal}`), width));
+
           const l1 = [tokIn, tokOut, gaugeStr].filter(Boolean).join(" │ ");
-          const lines = [truncateToWidth(l1, width)];
+          lines.push(truncateToWidth(l1, width));
 
           const l2 = [branchStr, modelStr].filter(Boolean).join(" · ");
           if (l2) lines.push(truncateToWidth(l2, width));
 
           const l3: string[] = [];
           l3.push(tokCost);
+          if (agentStatus.running > 0 || agentStatus.queued > 0) {
+            l3.push(theme.fg("accent", `agents r:${agentStatus.running} q:${agentStatus.queued}`));
+          }
           if (stats.webSearch > 0 || stats.webFetch > 0) {
             l3.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
           }


### PR DESCRIPTION
## Summary

pi エージェントハーネスレビューの最終 Phase (UX 追加)。Phase 1–4 (#183/#184/#185/#186) で C/H/M/L 修正が完了した上の機能追加。

## Changes
- **`/goal` コマンド** (`memory.ts`): pinned なセッション目標を設定/表示/クリア。`~/.pi/agent/goal` に永続化、session_start の context injection 先頭に追加、設定時は `sendMessage` で即時注入。standalone でなく memory 拡張に同居 (scratchpad と関心が近い)。
- **statusline 表示** (`statusline.ts`): goal を最上段に `🎯` 表示。pueue の `pi-delegate` ラベル付きタスクを集計し稼働中サブエージェント数を `agents r:N q:M` 表示。pueue 呼び出しは render 外 (turn_end / session_start) でキャッシュ。
- **delegation ラベル** (`agent-delegation.ts`): async サブエージェントの pueue タスクに `--label pi-delegate` を付与 (statusline が一般 pueue ジョブと区別できるよう)。
- **AGENTS.md**: `/goal` と sub-agent インジケータを記載。

## 設計選択
- sub-agent 表示は現行の pueue 非同期 (detached) モデルを維持する**案A (状態ポーリング)**。`tool_execution_*` による in-process live ストリーム (案B) は delegation アーキの変更を要するため不採用。
- live 度は粗い (running/queued 件数)。「今どのツールを実行中か」までは出さない。

## Test plan
- [x] 3 TS を `node --check --experimental-strip-types` で構文確認
- [x] `pueue status --json` 集計ロジックを実機 pueue で確認 (pi-delegate ラベル抽出・status オブジェクトからの state 抽出・running/queued 分類・他ラベル除外)
- [ ] pi 実行下の E2E (/goal 発火・injection・statusline 描画・サブエージェント数反映) ※pi 起動環境で要確認

## Notes
- `session-manager.ts` の未コミット変更は本 PR と無関係なため除外。
- これでレビュー由来タスク (C/H/M/L + UX) は一通り完了。残るは別 WIP の M3 session-manager mtime 化と、deferred な M6 Streamable HTTP のみ。