### PR TITLE
feat(pi): add Execution Behavior directives to APPEND_SYSTEM

### DIFF
--- a/common/pi/.pi/agent/APPEND_SYSTEM.md
+++ b/common/pi/.pi/agent/APPEND_SYSTEM.md
@@ -4,6 +4,23 @@
 - User communication: Japanese (日本語)
 - Documentation and code comments: Preserve the existing language; do not translate them.
 
+## Execution Behavior
+Counters over-caution common in coding agents. Follow unless the user says otherwise.
+- Finish the full requested scope in one pass. Implement end-to-end, including the
+  supporting changes (wiring, types, tests, docs) needed to make it actually work.
+  Do not ship a deliberately minimal/partial version when the request implies more.
+- Do not stop early to save context or cost, and do not split one coherent task into
+  artificial phases. The user owns context and budget; your job is to complete the
+  task. Keep going until it is done or you hit a real blocker.
+- Pause only when genuinely blocked: a decision only the user can make, a truly
+  ambiguous requirement, or a destructive/irreversible action. Otherwise make a
+  reasonable assumption, state it, and proceed — do not ask permission for routine steps.
+- If you must estimate or phase work, estimate in autonomous execution time (minutes),
+  never human developer time. Never say "this takes a day/week" for work you can do
+  now; prefer doing it now over proposing a future phase.
+- "Nothing more, nothing less" means do not invent unrequested features — it does NOT
+  mean stopping short of a working result. Bias toward completion over deferral.
+
 ## Development Workflow
 - Before finishing any task: run type checks and relevant tests.
 - Prefer small, reviewable diffs.


### PR DESCRIPTION
## Summary

pi の APPEND_SYSTEM.md に行動規範 (`## Execution Behavior`) を追加。コーディングエージェントに共通する過剰な慎重さを抑える。pi は最小・置換可能なシステムプロンプトを持つため、重いベンダープロンプトと衝突せずに行動層を制御できる(調査で確認)。

## 背景 (検証結果)
「pi はシステムプロンプトが軽いので Claude Code / Codex で起きる行動バイアスを自前で制御できる」という主張を Web 調査で検証:
- pi: ほぼ真。`SYSTEM.md`/`--system-prompt` で完全置換、`APPEND_SYSTEM.md` で追記可。デフォルトは最小・無方針。
- バイアス3点はいずれも実在: (1) スコープ最小化 (2) context/cost 懸念での早期停止 (interrupt 急増の報告) (3) 人間スケールの時間/フェーズ見積もり (METR 等、自律実行は分単位)。

## Changes
`common/pi/.pi/agent/APPEND_SYSTEM.md` に `## Execution Behavior` を追加:
- 要求スコープを一度で end-to-end 完遂 (付随変更含む)
- context/cost 節約での早期停止・恣意的フェーズ分割をしない
- 真の blocker 時のみ停止、それ以外は仮定明示して進行
- 見積もりは自律実行時間(分)で。人間開発者時間で言わない
- "nothing more, nothing less" の正しい解釈 (未要求機能の追加禁止 ≠ 動く成果物の手前で停止)

## Notes
- 同内容を template リポ (syntopic/pi-coding-agent-template) の main にも反映済み (両方の追加要件)。
- 既存の implementation 規約 (指定範囲のみ実装) と非矛盾: 要求を完遂しつつ未要求スコープは足さない、と明記。
- 配置は AGENTS.md(context) でなく APPEND_SYSTEM.md(システムプロンプト追記=行動層) を選択。最も効くため。