### PR TITLE
fix(notify): C-c 終了(シェル復帰)の残留状態を検出・クリア

### DIFF
--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -39,6 +39,8 @@ humanize() {
 
 # ツール種別(pane_current_command から)
 tool_of() { local c="${1%.exe}"; case "$c" in claude) echo claude;; cmd) echo cmd;; node) echo node;; *) echo "$c";; esac; }
+# 前景コマンドがシェル(=エージェント終了でプロンプト復帰)か
+is_shell() { case "${1#-}" in zsh|bash|sh|fish|dash|ksh|tcsh|nu|xonsh|elvish) return 0;; *) return 1;; esac; }
 # git ブランチ(worktree 含む)
 branch_of() { git -C "$1" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "-"; }
 # 簡易切り詰め(文字数)
@@ -49,6 +51,7 @@ build_local_rows() {
   local now; now=$(date +%s)
   while IFS="$US" read -r pid sess win status hb path cmd title; do
     is_stopped "$status" || continue
+    is_shell "$cmd" && continue   # エージェント終了済み(シェル復帰)→ 残留を表示しない
     local rank icon col task branch elapsed loc
     rank=$(status_rank "$status"); icon=$(status_icon "$status"); col=$(status_color "$status")
     task=$(trunc "${title:-$(basename "${path:-?}")}" 40)

--- a/scripts/tmux-claude-pane.sh
+++ b/scripts/tmux-claude-pane.sh
@@ -41,6 +41,14 @@ status_icon() {
   esac
 }
 
+# ペーンの前景コマンドがシェルか(=エージェント終了でプロンプトに戻った)
+is_shell() {
+  case "${1#-}" in
+    zsh|bash|sh|fish|dash|ksh|tcsh|nu|xonsh|elvish) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # 指定ペーンに状態+アイコンを適用
 apply_status() {
   local pane="$1" status="$2" icon
@@ -132,7 +140,15 @@ case "${1:-}" in
     now=$(date +%s)
     changed=0
     US=$'\x1f'  # 非空白フィールド区切り(タブは IFS 空白で空フィールドが coalesce する)
-    while IFS="$US" read -r pid status hb prevhash; do
+    while IFS="$US" read -r pid status cmd hb prevhash; do
+      [[ -n "$status" ]] || continue
+      # エージェント終了の検出: 状態が残っているが前景がシェル(C-c 等でプロンプトに復帰)
+      # → ペーンは生きているので pane option をクリアし、残留表示を消す
+      if is_shell "$cmd"; then
+        clear_pane "$pid"
+        changed=1
+        continue
+      fi
       [[ "$status" == "running" ]] || continue
       [[ -n "$hb" ]] || continue
       (( now - hb > HANG_THRESHOLD )) || continue
@@ -147,7 +163,7 @@ case "${1:-}" in
       # 出力も停止 → hang
       apply_status "$pid" hang
       changed=1
-    done < <(tmux list-panes -a -F "#{pane_id}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{@agent_outhash}")
+    done < <(tmux list-panes -a -F "#{pane_id}${US}#{@agent_status}${US}#{pane_current_command}${US}#{@agent_heartbeat}${US}#{@agent_outhash}")
 
     [[ $changed -eq 1 ]] && tmux refresh-client -S 2>/dev/null || true
     ;;


### PR DESCRIPTION
## 問題
C-c で claude を終了するとペーンはシェルに戻るが `@agent_status` が残り、横断ビュー/バッジ/枠アイコンが消えない。ペーン消滅クリアはペーンを閉じた時しか効かず、プロセス終了→プロンプト復帰が漏れていた。

## 修正
- `is_shell()` 判定追加
- watcher(hang-scan, 15s): 状態が残るが前景がシェルなら pane option クリア(根本修正→badge/focus も自動是正)
- 横断ビュー: シェル復帰ペーンを即時スキップ

## 検証
shellcheck CLEAN。ライブ tmux で「shell ペーンに idle 残留→横断ビューでスキップ→hang-scan で pane option クリア」を確認。

誤検知低: 停止状態は前景が agent のためシェルに一致しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)