### PR TITLE
feat(notify): リロードコマンド + watcher 多重起動(TERM握り潰し)修正

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -144,6 +144,8 @@ bind Tab switch-client -l
 
 # AI Agent 横断ビュー: 停止中エージェント一覧を popup 表示し、選択でジャンプ
 bind a display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
+# AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
+bind A run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
 bind -r ( switch-client -p
 bind -r ) switch-client -n
 

--- a/scripts/tmux-agent-hang-watch.sh
+++ b/scripts/tmux-agent-hang-watch.sh
@@ -21,11 +21,17 @@ if [[ -f "$LOCK_FILE" ]] && kill -0 "$(cat "$LOCK_FILE" 2>/dev/null)" 2>/dev/nul
   exit 0
 fi
 echo $$ > "$LOCK_FILE"
-trap 'rm -f "$LOCK_FILE"' EXIT INT TERM
+# INT/TERM は cleanup 後に必ず exit する。exit しないと TERM を握り潰してループ継続し、
+# pkill で死なず多重起動の原因になる。
+cleanup() { rm -f "$LOCK_FILE"; }
+trap cleanup EXIT
+trap 'cleanup; exit 0' INT TERM
 
 while true; do
   # tmux サーバが消えたら終了
   tmux info &>/dev/null || exit 0
   "$SCRIPT_DIR/tmux-claude-pane.sh" hang-scan 2>/dev/null || true
-  sleep "$INTERVAL"
+  # sleep を背景+wait にすることで INT/TERM を sleep 中でも即座に trap できる
+  # (前景 sleep だと bash が trap を sleep 終了まで保留し、pkill が最大 INTERVAL 遅延する)
+  sleep "$INTERVAL" & wait $! || true
 done

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -171,6 +171,23 @@ case "${1:-popup}" in
     tmux select-window -t "$target" 2>/dev/null || true
     tmux select-pane -t "$target" 2>/dev/null || true
     ;;
+  reload)
+    # エージェント通知サブシステムを最新化:
+    #   watcher を単一インスタンスに再起動 + 即時 hang-scan(残留/シェル復帰の GC・ハング検出)
+    # ※ テーマ/キーバインド等 tmux 設定の再読込は別途 prefix+r
+    reload_dir="$(dirname "$SELF")"
+    pkill -f tmux-agent-hang-watch.sh 2>/dev/null || true
+    # 旧インスタンスの終了を最大3s待つ(多重起動防止)
+    for _ in 1 2 3 4 5 6; do
+      ps axo command 2>/dev/null | grep 'tmux-agent-hang-watch.sh' | grep -v grep | grep -q '/bin/bash' || break
+      sleep 0.5
+    done
+    rm -f /tmp/claude/hang-watch.pid
+    tmux run-shell -b "$reload_dir/tmux-agent-hang-watch.sh >/dev/null 2>&1 || true"
+    bash "$reload_dir/tmux-claude-pane.sh" hang-scan 2>/dev/null || true
+    tmux refresh-client -S 2>/dev/null || true
+    tmux display-message "agent-notify reloaded (watcher 再起動 + 状態スキャン)"
+    ;;
   *)
-    echo "Usage: $0 {list|popup|preview <target> <status>}" >&2; exit 1 ;;
+    echo "Usage: $0 {list|popup|reload|preview <target> <status>}" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
## 追加
- `tmux-agent-status.sh reload` / `prefix+A`: watcher を単一再起動 + 即時 hang-scan で状態最新化(残留・シェル復帰 GC、ハング検出)

## 修正(多重起動の真因)
- watcher の trap が INT/TERM で lock 削除のみ・exit せず → TERM を握り潰しループ継続 → pkill で死なず蓄積。cleanup 後 exit するよう修正
- `sleep` → `sleep & wait` で sleep 中の TERM 即応(前景 sleep は trap が最大 INTERVAL 遅延)
- reload は旧終了を待ってから起動

## 検証
shellcheck CLEAN。reload 連続実行で watcher が常に1へ収束することをライブ確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)