### PR TITLE
fix(notify): reload キーバインドを prefix+A→prefix+R(衝突回避)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -145,7 +145,8 @@ bind Tab switch-client -l
 # AI Agent 横断ビュー: 停止中エージェント一覧を popup 表示し、選択でジャンプ
 bind a display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
 # AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
-bind A run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
+# (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
+bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
 bind -r ( switch-client -p
 bind -r ) switch-client -n
 


### PR DESCRIPTION
prefix+A は tmux-layout menu が使用済みで衝突。prefix+r(設定リロード)と対の prefix+R に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)