### PR TITLE
feat(notify): 自作サイドバー(常設・自動更新)で opensessions を代替

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -147,6 +147,8 @@ bind a display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh p
 # AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
 # (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
 bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
+# AI Agent サイドバー: 全エージェントを常時表示する pane を開閉(opensessions 代替)
+bind b run-shell "~/dotfiles/scripts/tmux-agent-sidebar.sh toggle"
 bind -r ( switch-client -p
 bind -r ) switch-client -n
 

--- a/common/zsh/.zshenv
+++ b/common/zsh/.zshenv
@@ -1,6 +1,10 @@
 ulimit -S -n 2048
 
-# PATH settings (also needed for non-interactive shells like Claude CLI hooks)
+# PATH settings (also needed for non-interactive shells like Claude CLI hooks
+# and tmux popups launched via `zsh -lc`, which do not source .zshrc)
+# .pixi/bin holds pixi-installed CLIs (gh など)。.local/bin より後ろに置く
+# ことで source-built tmux 等が pixi 版より優先される (.zshrc.common と同順序)。
+[[ -d "$HOME/.pixi/bin" ]] && export PATH="$HOME/.pixi/bin:$PATH"
 [[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
 [[ -d "$HOME/dotfiles/scripts" ]] && export PATH="$HOME/dotfiles/scripts:$PATH"
 

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# AI Agent サイドバー (常設・自動更新)
+# 全エージェント(running 含む)を狭い tmux pane に2行で常時表示する。opensessions の代替。
+# 状態源は pane option(@agent_status)。ヘルパーは tmux-agent-status.sh を source して再利用。
+# 仕様: docs/specs/agent-stop-notification.md §5.3
+#
+# Usage:
+#   tmux-agent-sidebar.sh run      # サイドバー pane 内で動くループ(自動更新)
+#   tmux-agent-sidebar.sh toggle   # サイドバー pane を開閉 (prefix+b)
+
+set -uo pipefail
+
+[[ -z "${TMUX:-}" ]] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/tmux-agent-status.sh"   # ヘルパー(status_icon/color, is_shell, branch_of, trunc, humanize)
+set +e +o pipefail   # status.sh の set -e/pipefail を解除(常駐ループを堅牢に)
+
+REFRESH="${AGENT_SIDEBAR_REFRESH:-3}"
+WIDTH="${AGENT_SIDEBAR_WIDTH:-44}"
+
+# running を含む全エージェントの状態順位(stopped 優先、running は後ろ)
+sb_rank() { case "$1" in permission) echo 0;; hang) echo 1;; error) echo 2;; idle) echo 3;; complete) echo 4;; running) echo 8;; *) echo 9;; esac; }
+
+# 表示幅基準の切り詰め(全角=2幅近似)。狭い pane で折返さないよう文字数でなく桁で切る
+trunc_w() {
+  local s="$1" max="$2" out="" w=0 ch cw i
+  for (( i=0; i<${#s}; i++ )); do
+    ch="${s:i:1}"
+    if [[ "$ch" =~ [[:ascii:]] ]]; then cw=1; else cw=2; fi
+    (( w + cw > max )) && { out+="…"; break; }
+    out+="$ch"; (( w += cw ))
+  done
+  printf '%s' "$out"
+}
+
+# 全エージェント行を生成: rank \t line1 \t line2
+sb_rows() {
+  local now w; now=$(date +%s); w=$(( WIDTH - 4 ))
+  while IFS=$'\x1f' read -r sess win status hb path cmd title; do
+    [[ -z "$status" ]] && continue          # 状態未設定(非エージェント)は除外
+    is_shell "$cmd" && continue             # シェル復帰(終了済み)は除外
+    local rank icon col task branch elapsed loc tool l1 l2
+    rank=$(sb_rank "$status"); icon=$(status_icon "$status")
+    if [[ "$status" == running ]]; then col="$C_DIM"; else col=$(status_color "$status"); fi
+    task=$(trunc_w "${title:-$(basename "${path:-?}")}" "$w")
+    branch=$(branch_of "$path"); tool=$(tool_of "$cmd"); loc="${sess}:${win}"
+    if [[ "$hb" =~ ^[0-9]+$ ]]; then elapsed=$(humanize "$(( now - hb ))"); else elapsed="-"; fi
+    l1=$(printf '%s%s %s%s' "$col" "$icon" "$task" "$C_RST")
+    l2=$(printf '  %s%s · %s · %s · %s前%s' "$C_DIM" "$loc" "$branch" "$tool" "$elapsed" "$C_RST")
+    printf '%s\t%s\t%s\n' "$rank" "$l1" "$l2"
+  done < <(tmux list-panes -a -F \
+    "#{session_name}$(printf '\x1f')#{window_index}$(printf '\x1f')#{@agent_status}$(printf '\x1f')#{@agent_heartbeat}$(printf '\x1f')#{pane_current_path}$(printf '\x1f')#{pane_current_command}$(printf '\x1f')#{pane_title}") \
+    | sort -n -t$'\t' -k1,1
+}
+
+render() {
+  printf '\033[H\033[2J'  # カーソル原点 + クリア
+  printf '%s AGENTS%s  %s\n' "$C_BOLD" "$C_RST" "$(date '+%H:%M:%S')"
+  printf '%s%s%s\n' "$C_DIM" "────────────────────" "$C_RST"
+  local rows; rows=$(sb_rows)
+  if [[ -z "$rows" ]]; then
+    printf '%s(エージェントなし)%s\n' "$C_DIM" "$C_RST"
+    return
+  fi
+  printf '%s\n' "$rows" | while IFS=$'\t' read -r _rank l1 l2; do
+    printf '%s\n%s\n\n' "$l1" "$l2"
+  done
+}
+
+case "${1:-toggle}" in
+  run)
+    # サイドバー pane 内ループ。INT/TERM で抜ける
+    trap 'exit 0' INT TERM
+    while true; do
+      tmux info &>/dev/null || exit 0
+      render
+      sleep "$REFRESH" & wait $! || true
+    done
+    ;;
+  toggle)
+    existing=$(tmux show-options -gqv @agent_sidebar_pane 2>/dev/null || echo "")
+    if [[ -n "$existing" ]] && tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$existing"; then
+      tmux kill-pane -t "$existing" 2>/dev/null || true
+      tmux set-option -gu @agent_sidebar_pane 2>/dev/null || true
+    else
+      pane=$(tmux split-window -h -b -l "$WIDTH" -P -F '#{pane_id}' \
+        "bash '$SCRIPT_DIR/tmux-agent-sidebar.sh' run")
+      tmux set-option -p -t "$pane" @agent_status "" 2>/dev/null || true  # サイドバー自身は対象外
+      tmux set-option -g @agent_sidebar_pane "$pane" 2>/dev/null || true
+      tmux select-pane -L 2>/dev/null || true
+    fi
+    ;;
+  once)
+    render ;;   # 1回だけ描画(デバッグ用)
+  *)
+    echo "Usage: $0 {run|toggle|once}" >&2; exit 1 ;;
+esac

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -131,6 +131,9 @@ render_preview() {
   fi
 }
 
+# source された場合(サイドバー等がヘルパー再利用)はディスパッチしない
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
+
 case "${1:-popup}" in
   list)
     build_rows | while IFS=$'\t' read -r _r _jt _wl _st l1 l2; do


### PR DESCRIPTION
## 概要
全エージェント(running 含む)を狭い tmux pane に2行で常時表示する自作サイドバーを追加。独自のハング検知・`@agent_status` を表示源とし opensessions を置換。

## 変更
- `tmux-agent-sidebar.sh`: toggle / run(自動更新ループ) / once(デバッグ)
  - 状態順(permission→hang→error→idle→complete→running)で2行表示
  - 1行目: icon + タスク(pane_title、表示幅基準で切り詰め=全角考慮で折返さない)
  - 2行目: loc · branch · tool · 経過前
  - シェル復帰・非エージェントは除外。REFRESH/WIDTH は env で調整可
- `tmux-agent-status.sh`: source 時はディスパッチせずヘルパー再利用可能に
- `prefix+b` で開閉

## 検証
shellcheck CLEAN。ライブ tmux で開閉・自動更新・幅44で折返さないこと・実エージェント表示を確認。

## 備考
opensessions(現在 MAIN:1.1 で稼働中)は本サイドバーで代替可能。停止はプラグイン側の autostart 無効化で別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)