### PR TITLE
feat(notify): pi/cursor/codex を通知システムに配線

### DIFF
--- a/common/pi/.pi/agent/extensions/agent-notify.ts
+++ b/common/pi/.pi/agent/extensions/agent-notify.ts
@@ -1,0 +1,37 @@
+// AI Agent 通知連携 (pi)
+//
+// pi のライフサイクルを tmux pane option (@agent_status) に反映し、
+// 横断ビュー(prefix+a) / サイドバー(prefix+b) / ペーン枠アイコン / ウィンドウバッジに
+// pi セッションを表示させる。Claude Code の hooks 配線と同等のことを pi extension で行う。
+//
+// 状態源スクリプト: ~/dotfiles/scripts/tmux-claude-pane.sh
+// 仕様: ~/dotfiles/docs/specs/agent-stop-notification.md §4.1
+//
+// マッピング:
+//   session_start    -> start      (running 化 + heartbeat)
+//   tool_call        -> heartbeat   (実行中の生存信号。hang からの復帰も担う)
+//   turn_end         -> set idle    (ターン終了=入力待ちで停止)
+//   session_shutdown -> clear       (終了時に通知をクリア)
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const PANE = process.env.TMUX_PANE;
+const SCRIPT = join(homedir(), "dotfiles", "scripts", "tmux-claude-pane.sh");
+
+// tmux pane option を更新する。tmux 外では何もしない。fire-and-forget(非ブロッキング)。
+function agent(...args: string[]): void {
+  if (!PANE) return;
+  execFile("bash", [SCRIPT, ...args], { env: process.env, timeout: 2000 }, () => {
+    /* 失敗は致命的でないため無視 */
+  });
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async () => agent("start"));
+  pi.on("tool_call", async () => agent("heartbeat"));
+  pi.on("turn_end", async () => agent("set", "idle"));
+  pi.on("session_shutdown", async () => agent("clear"));
+}

--- a/docs/specs/agent-stop-notification.md
+++ b/docs/specs/agent-stop-notification.md
@@ -259,10 +259,23 @@
 
 注: 全て dotfiles 内の編集のみ。反映には settings 再生成（install.sh 相当）+ tmux 設定リロードが必要。
 
-### 11.2 既知の制約・残課題
+### 11.2 ツール別の配線状況・制約
 
-- pi 未配線: pi は extensions ベースで hooks ブロックを持たない。pane option 連携には pi extension が必要（別途）。
-- cursor/codex のハング検知なし: 単一フックのため heartbeat を送れず、`complete` 等のみ。`hang` 対象外。
+全ツールが pane option (@agent_status) を立て、横断ビュー/サイドバー/ペーンアイコンに出る。
+codex/cursor/pi は pane_current_command が全て `node` でコマンド識別不可のため、コマンド/title
+ヒューリスティック検出は採らず、各ツールのネイティブ機構で push する方式に統一した。
+
+| ツール | 配線 | start/running | heartbeat(hang検知) | 停止表示 |
+|--------|------|:--:|:--:|------|
+| Claude / Command Code | hooks(settings.json) | ◯ | ◯ | complete/idle/permission |
+| pi | extension(`agent-notify.ts`) | ◯(session_start) | ◯(tool_call) | turn_end→idle |
+| cursor | hooks(`cursor-hooks.json`) | ◯(beforeSubmitPrompt) | ◯(shell/edit) | stop→idle |
+| codex | notify(単一・turn完了のみ) | × | × | turn完了→idle |
+
+- codex の制約: notify は turn 完了時しか発火しない。実行中の running 表示・ハング検知は不可
+  （idle のみ）。codex 側に他フックが無いための根本制約。
+- 反映には各ツールの設定再生成(install.sh 相当)+ 当該エージェントの再起動が必要
+  （hooks/extension はプロセス起動時に読まれるため）。
 - リモートの `error` 欠落: リモート/コンテナ経路は `ai-notify` の SketchyBar 状態（idle/permission/complete/none）でファイルへ書くため `error` が `none` に丸められ横断ビューに出ない。修正は `ai-notify` リモート分岐の状態マッピング要改修。
 - SketchyBar 派生化(4b)保留: 現行ファイルベース経路で動作。pane option 集約への一本化は未実施。
 - クリア契機（§9）: フォーカス/時間減衰クリアの是非は未確定。現状は `complete` の10秒自動消去のみ既存挙動として維持。

--- a/templates/codex-config.toml
+++ b/templates/codex-config.toml
@@ -1,1 +1,4 @@
-notify = ["__HOME__/dotfiles/scripts/ai-notify.sh", "codex", "complete"]
+# codex は notify(単一プログラム)のみで turn 完了時に呼ばれる。引数末尾に JSON が
+# 付くが tmux-claude-pane.sh set は $2 のみ参照するため無害。turn 完了=入力待ち→ idle。
+# 注: codex は実行中の heartbeat イベントが無いため running/ハング検知は対象外。
+notify = ["__HOME__/dotfiles/scripts/tmux-claude-pane.sh", "set", "idle"]

--- a/templates/cursor-hooks.json
+++ b/templates/cursor-hooks.json
@@ -1,9 +1,24 @@
 {
   "version": 1,
   "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh start"
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat"
+      }
+    ],
     "stop": [
       {
-        "command": "__HOME__/dotfiles/scripts/ai-notify.sh cursor complete"
+        "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh set idle"
       }
     ]
   }


### PR DESCRIPTION
## 概要
codex/cursor/pi は pane_current_command が全て node で識別不可のため、各ツールのネイティブ機構で @agent_status を push。

## 変更
- pi: extension agent-notify.ts (session_start→start/tool_call→heartbeat/turn_end→idle/shutdown→clear)
- cursor: cursor-hooks.json 拡張 (beforeSubmitPrompt→start / shell・edit→heartbeat / stop→idle)
- codex: notify→tmux-claude-pane.sh set idle (turn完了=入力待ち。running/hang は不可=制約)
- 仕様 §11.2 ツール別配線表

## 反映
各ツール設定の再生成 + 当該エージェント再起動が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)