### PR TITLE
feat(pi): prompt-stash 拡張機能を追加 (Claude Code-like stash)

### DIFF
--- a/common/pi/.pi/agent/extensions/prompt-stash.ts
+++ b/common/pi/.pi/agent/extensions/prompt-stash.ts
@@ -1,0 +1,104 @@
+// Prompt Stash Extension for pi
+//
+// Claude Code-like prompt stash: Ctrl+S saves the current editor draft,
+// handles an interruption, then auto-restores when the agent finishes.
+//
+// Flow:
+//   1. Ctrl+S  → stash current draft + clear editor
+//   2. Send a different prompt (handle interruption)
+//   3. Agent finishes → draft auto-restores into editor
+//   4. Continue where you left off
+//
+// Single-slot stash. Ctrl+S on empty editor toggles restore.
+// /stash-clear to discard without restoring. /stash to show status.
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI) {
+  let stashed: string | null = null;
+
+  // -----------------------------------------------------------------------
+  // Ctrl+S: stash or restore
+  // -----------------------------------------------------------------------
+  pi.registerShortcut("ctrl+s", {
+    description: "Stash or restore prompt draft",
+    handler: async (ctx) => {
+      const current = ctx.ui.getEditorText();
+
+      if (current.trim().length > 0) {
+        // Stash the current draft (replace any previous stash)
+        stashed = current;
+        ctx.ui.setEditorText("");
+        ctx.ui.setStatus("stash", "📝 stashed");
+        ctx.ui.notify("📝 Prompt stashed (send interruption, draft auto-restores)", "info");
+      } else if (stashed) {
+        // Toggle: restore the stash
+        ctx.ui.setEditorText(stashed);
+        ctx.ui.setStatus("stash", undefined);
+        ctx.ui.notify("📝 Stash manually restored", "info");
+        stashed = null;
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Auto-restore when agent finishes and editor is empty
+  // -----------------------------------------------------------------------
+  pi.on("agent_end", async (_event, ctx) => {
+    if (!stashed) return;
+
+    // Give the TUI a moment to settle — editor may not be immediately empty
+    // when agent_end fires if there are queued follow-up messages.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const current = ctx.ui.getEditorText();
+    if (!current || current.trim().length === 0) {
+      ctx.ui.setEditorText(stashed);
+      ctx.ui.setStatus("stash", undefined);
+      ctx.ui.notify("📝 Stashed draft auto-restored", "info");
+      stashed = null;
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Command: /stash — show stash status
+  // -----------------------------------------------------------------------
+  pi.registerCommand("stash", {
+    description: "Show stash status",
+    handler: async (_args, ctx) => {
+      if (stashed) {
+        const preview = stashed.length > 100
+          ? stashed.slice(0, 100) + "..."
+          : stashed;
+        ctx.ui.notify(`📝 Stashed (${stashed.length} chars):\n${preview}`, "info");
+      } else {
+        ctx.ui.notify("No stashed draft. Ctrl+S to stash your current input.", "info");
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Command: /stash-clear — discard stash without restoring
+  // -----------------------------------------------------------------------
+  pi.registerCommand("stash-clear", {
+    description: "Discard stashed draft without restoring",
+    handler: async (_args, ctx) => {
+      if (stashed) {
+        stashed = null;
+        ctx.ui.setStatus("stash", undefined);
+        ctx.ui.notify("📝 Stashed draft discarded", "info");
+      } else {
+        ctx.ui.notify("Nothing to clear", "info");
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Persist stash state across extension reloads
+  // -----------------------------------------------------------------------
+  pi.on("session_shutdown", (_event) => {
+    // Stash is cleared on shutdown — it's a transient UI state,
+    // not meant to survive session restarts.
+    stashed = null;
+  });
+}


### PR DESCRIPTION
## Summary

Claude Code の Prompt Stash (Ctrl+S) と同等の機能を pi 拡張として実装。
エディタの下書きを一時保存し、割り込み対応後に自動復元する。

## Changes

- `common/pi/.pi/agent/extensions/prompt-stash.ts` を新規追加 (104行)
  - **Ctrl+S**: エディタ下書きを単一スロットに保存 / 空エディタで押すと手動復元
  - **agent_end**: 割り込みプロンプト処理完了後、エディタが空なら自動復元
  - **/stash**: stash 状態表示 (内容プレビュー)
  - **/stash-clear**: stash を破棄 (復元しない)

## 動作フロー

```
下書き中 → Ctrl+S → 保存 & クリア
→ 別の質問を送信 → エージェント完了
→ 元の下書きが自動復元 → 続きから再開
```

## Test plan

- [x] `npx tsx --eval` で構文エラーなしを確認
- [ ] pi 起動後に Ctrl+S → 割り込みプロンプト送信 → 自動復元の動作確認
- [ ] `/stash`、`/stash-clear` コマンドの動作確認