### PR TITLE
fix(notify): サイドバートグルを window 単位化(誤クローズ解消)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -148,7 +148,7 @@ bind a display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh p
 # (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
 bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
 # AI Agent サイドバー: 全エージェントを常時表示する pane を開閉(opensessions 代替)
-bind b run-shell "~/dotfiles/scripts/tmux-agent-sidebar.sh toggle"
+bind b run-shell "TMUX_PANE=#{pane_id} ~/dotfiles/scripts/tmux-agent-sidebar.sh toggle"
 bind -r ( switch-client -p
 bind -r ) switch-client -n
 

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -148,15 +148,22 @@ case "${1:-toggle}" in
     done
     ;;
   toggle)
-    existing=$(tmux show-options -gqv @agent_sidebar_pane 2>/dev/null || echo "")
-    if [[ -n "$existing" ]] && tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$existing"; then
+    # サイドバーは window 内の pane。追跡は window 単位にし、別 window/session の
+    # サイドバーを誤って kill しない(グローバル追跡だとセッション移動で閉じてしまう)。
+    # prefix+b を押した pane($TMUX_PANE)の window に -t で固定して操作する。
+    src="${TMUX_PANE:-$(tmux display-message -p '#{pane_id}' 2>/dev/null)}"
+    win=$(tmux display-message -t "$src" -p '#{window_id}' 2>/dev/null)
+    [[ -z "$win" ]] && exit 0
+    existing=$(tmux show-options -w -t "$win" -qv @agent_sidebar_pane 2>/dev/null || echo "")
+    if [[ -n "$existing" ]] && tmux list-panes -t "$win" -F '#{pane_id}' 2>/dev/null | grep -qxF "$existing"; then
       tmux kill-pane -t "$existing" 2>/dev/null || true
-      tmux set-option -gu @agent_sidebar_pane 2>/dev/null || true
+      tmux set-option -w -t "$win" -u @agent_sidebar_pane 2>/dev/null || true
     else
-      pane=$(tmux split-window -fh -b -l "$WIDTH" -P -F '#{pane_id}' \
+      pane=$(tmux split-window -t "$src" -fh -b -l "$WIDTH" -P -F '#{pane_id}' \
         "bash '$SCRIPT_DIR/tmux-agent-sidebar.sh' run")
       tmux set-option -p -t "$pane" @agent_status "" 2>/dev/null || true
-      tmux set-option -g @agent_sidebar_pane "$pane" 2>/dev/null || true
+      tmux set-option -w -t "$win" @agent_sidebar_pane "$pane" 2>/dev/null || true
+      tmux select-pane -t "$src" 2>/dev/null || true   # 作業 pane にフォーカスを残す
     fi
     ;;
   once)


### PR DESCRIPTION
## 問題
@agent_sidebar_pane がグローバルで、別 session/window で prefix+b すると別 window のサイドバーを kill →「セッション移動で閉じる/二度押しで開く」。

## 修正
- 追跡を window 単位(set-option -w)に。各 window 独立トグル、他を kill しない
- prefix+b を押した pane を TMUX_PANE=#{pane_id} で渡し、その window に -t 固定で操作
- 開後は作業 pane にフォーカスを残す

## 検証
shellcheck CLEAN。2窓で独立トグル(A開→B開でA生存→A再toggleでAのみ閉)を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)