### PR TITLE
perf(notify): file store 蓄積解消・サイドバー高速化・heartbeat 半減

### DIFF
--- a/docs/specs/agent-stop-notification.md
+++ b/docs/specs/agent-stop-notification.md
@@ -139,6 +139,19 @@
 - 低オーバーヘッド: シェル起動・status 更新サイクルに影響を与えない。watcher は軽量・遅延ロード。
 - ヒューリスティック廃止: `scan` のペーン文字列 grep は hook 駆動 + heartbeat に置換（ツール起動時の取りこぼし救済が必要なら最小限の初期スキャンのみ）。
 
+### 6.1 パフォーマンス設計メモ（実測ベース）
+
+| 箇所 | コスト | 対策 |
+|------|--------|------|
+| heartbeat hook | 1回 ~27ms(fork+tmux)。tool 毎に発火 | `PostToolUse` のみに限定(`PreToolUse` 廃止)。長 tool の生存は watcher の出力ハッシュ差分で担保し heartbeat 冗長分を削減 |
+| file store | `set_status` が timestamp 付きファイルを書き続け無限蓄積 → scan が全件 jq | workspace ごと旧ファイルを削除し1ファイルに(get は最新のみ参照) |
+| サイドバー render | 128ms/3s → ファイル数分 jq spawn + agent毎 subshell | 全ファイルを単一 `jq -s` で処理、rank+glyph を1関数化。実測 128ms→34ms |
+| 横断ビュー popup | ~130ms/回 | on-demand(prefix+a / ^R)なので許容 |
+| hang watcher | 15s 周期、running ペーンのみ capture-pane | 低頻度・対象限定で軽量 |
+| window バッジ | status 更新(~5s)毎、3s キャッシュ + pane option 優先 | file store 1ファイル化で fallback も軽量 |
+
+原則: 常駐ループ(サイドバー/watcher)は jq/subprocess を最小化し、無制限に増える状態(file store)は書き込み側で必ず上限を設ける。
+
 ## 7. 現行コンポーネントの扱い
 
 | 現行 | 変更方針 |

--- a/scripts/claude-status.sh
+++ b/scripts/claude-status.sh
@@ -41,6 +41,10 @@ set_status() {
     fi
   done
 
+  # 同一 workspace の旧ファイルを削除(get_status は最新のみ参照するため蓄積は無駄。
+  # 残すと sidebar/badge の jq スキャンが毎回全ファイルを舐めて重くなる)。
+  rm -f "$STATUS_DIR"/workspace_"${workspace}"_*.json 2>/dev/null || true
+
   # workspace_${workspace}_${timestamp}.json 形式でユニークに
   local timestamp
   timestamp=$(date +%s%N)

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -31,8 +31,6 @@ WIDTH="${AGENT_SIDEBAR_WIDTH:-40}"
 STATUS_DIR="${AGENT_STATUS_DIR:-/tmp/claude/status}"
 ESC_K=$'\033[K'   # 行末までクリア(全画面クリアせず=チカチカしない)
 
-sb_rank() { case "$1" in permission) echo 0;; hang) echo 1;; error) echo 2;; idle) echo 3;; complete) echo 4;; running) echo 8;; *) echo 9;; esac; }
-
 # 表示幅基準の切り詰め(全角=2幅近似)。[[:ascii:]] は macOS 非対応のため case で判定
 trunc_w() {
   local s="$1" max="$2" out="" w=0 ch cw i
@@ -45,19 +43,18 @@ trunc_w() {
   printf '%s' "$out"
 }
 
-# AI 1体のアイコン(色=状態)。色で状態が分かるのが主、グリフで種別も補助
-sb_glyph() {
-  local c g
+# AI 1体の rank と色付きアイコン(色=状態)を "rank<TAB>glyph" で返す
+# (rank と glyph を1回の呼び出しで返し subshell を減らす)
+sb_rank_glyph() {
   case "$1" in
-    permission) c=203; g="󰌆" ;;   # 承認待ち(赤)
-    hang)       c=196; g="" ;;   # 無応答(明るい赤)
-    error)      c=160; g="" ;;   # エラー(暗い赤)
-    idle)       c=214; g="󰔟" ;;   # 入力待ち(amber)
-    complete)   c=114; g="" ;;   # 完了(緑)
-    running)    c=39;  g="●" ;;   # 実行中(青)
-    *)          c=240; g="●" ;;
+    permission) printf '0\t\033[38;5;203m󰌆\033[0m' ;;
+    hang)       printf '1\t\033[38;5;196m\033[0m' ;;
+    error)      printf '2\t\033[38;5;160m\033[0m' ;;
+    idle)       printf '3\t\033[38;5;214m󰔟\033[0m' ;;
+    complete)   printf '4\t\033[38;5;114m\033[0m' ;;
+    running)    printf '8\t\033[38;5;39m●\033[0m' ;;
+    *)          printf '9\t\033[38;5;240m●\033[0m' ;;
   esac
-  printf '\033[38;5;%sm%s\033[0m' "$c" "$g"
 }
 
 # (session, rank, glyph) を収集: local pane option + file store
@@ -66,7 +63,7 @@ collect_agents() {
   while IFS=$'\x1f' read -r sess status cmd; do
     [[ -z "$status" ]] && continue
     is_shell "$cmd" && continue
-    printf '%s\t%s\t%s\n' "$sess" "$(sb_rank "$status")" "$(sb_glyph "$status")"
+    printf '%s\t%s\n' "$sess" "$(sb_rank_glyph "$status")"
   done < <(tmux list-panes -a -F "#{session_name}$(printf '\x1f')#{@agent_status}$(printf '\x1f')#{pane_current_command}")
 
   # file store (リモート/コンテナ)。workspace ごと最新のみ採用。
@@ -74,24 +71,24 @@ collect_agents() {
   # 真のリモート/コンテナ(tmux_session 空 or 非ローカル)のみ採用する。
   [[ -d "$STATUS_DIR" ]] || return 0
   command -v jq >/dev/null 2>&1 || return 0
-  local local_sessions
+  local local_sessions ws_seen="" status ws tsess project _u
   local_sessions="|$(tmux list-sessions -F '#{session_name}' 2>/dev/null | tr '\n' '|')"
-  local rows="" f ws_seen=""
-  for f in "$STATUS_DIR"/*.json; do
-    [[ -f "$f" ]] || continue
-    rows+=$(jq -r --arg us $'\x1f' '[(.updated // .timestamp // 0),(.status // ""),(.workspace // ""),(.tmux_session // ""),(.project // "")]|map(tostring)|join($us)' "$f" 2>/dev/null)$'\n'
-  done
-  printf '%s' "$rows" | sort -rn -t$'\x1f' -k1,1 | while IFS=$'\x1f' read -r _u status ws tsess project; do
+  # 全ファイルを1回の jq で処理(ファイル数分 jq を spawn しない)
+  local files=("$STATUS_DIR"/*.json)
+  [[ -e "${files[0]}" ]] || return 0
+  while IFS=$'\x1f' read -r _u status ws tsess project; do
     [[ -z "$status" ]] && continue
     case "$status" in idle|permission|complete|hang|error) ;; *) continue;; esac
-    # ローカルセッションに属する行はローカル pane で既出 → 除外
     if [[ -n "$tsess" ]]; then case "$local_sessions" in *"|${tsess}|"*) continue;; esac; fi
     if [[ -n "$ws" ]]; then case "$ws_seen" in *"|${ws}|"*) continue;; *) ws_seen="${ws_seen}|${ws}|";; esac; fi
     local key="$tsess"
-    [[ -z "$key" ]] && key="${project%%:*}"   # session 不明なら host/project(リモート)
+    [[ -z "$key" ]] && key="${project%%:*}"
     [[ -z "$key" ]] && key="remote"
-    printf '%s\t%s\t%s\n' "$key" "$(sb_rank "$status")" "$(sb_glyph "$status")"
-  done
+    printf '%s\t%s\n' "$key" "$(sb_rank_glyph "$status")"
+  done < <(jq -rs --arg us $'\x1f' '
+      sort_by(-(.updated // .timestamp // 0))[]
+      | [((.updated // .timestamp // 0)|tostring),(.status // ""),(.workspace // ""),(.tmux_session // ""),(.project // "")]|join($us)
+    ' "${files[@]}" 2>/dev/null)
 }
 
 # セッションブロックを出力(セッション名を独立行、アイコンは折返してインデント表示)。

--- a/templates/claude-settings.json
+++ b/templates/claude-settings.json
@@ -53,16 +53,6 @@
         ]
       }
     ],
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "hooks": [

--- a/templates/commandcode-settings.json
+++ b/templates/commandcode-settings.json
@@ -14,16 +14,6 @@
         ]
       }
     ],
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "hooks": [


### PR DESCRIPTION
## 概要
CPU/性能の怪しい箇所を実測し是正。

## 実測と対策
- file store 無限蓄積: set_status が timestamp 付きファイルを書き続け全件 jq スキャン → workspace ごと1ファイルに(24→1)
- サイドバー render: ファイル数分 jq spawn + agent毎 subshell → 単一 jq -s + rank/glyph 1関数化。**128ms→34ms/回**(3秒ループ)
- heartbeat: PreToolUse 廃止し PostToolUse のみ(tool毎 2→1回, 各~27ms)。長toolは出力ハッシュ差分で生存判定
- 仕様 §6.1 にメモ

## 反映
スクリプト(file store/sidebar)は即時。heartbeat 削減は settings 再生成+エージェント再起動で有効。

## 検証
shellcheck/JSON OK。file store 24→1、render 128→34ms をライブ実測。

🤖 Generated with [Claude Code](https://claude.com/claude-code)