### PR TITLE
feat(notify): prefix+a 検索モードのモーダル化

### DIFF
--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -176,6 +176,8 @@ case "${1:-popup}" in
             --bind 'j:down,k:up,g:first,G:last,ctrl-d:half-page-down,ctrl-u:half-page-up' \
             --bind "r:reload(bash '$SELF' rescan)" \
             --bind '/:unbind(j,k,g,G,r)+change-prompt(検索> )' \
+            --bind 'enter:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "rebind(j,k,g,G,r)+change-prompt(agent> )" || echo accept' \
+            --bind 'esc:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "rebind(j,k,g,G,r)+change-prompt(agent> )+clear-query" || echo abort' \
             --color 'pointer:203,marker:214') || exit 0
     [[ -z "$sel" ]] && exit 0
     target=$(printf '%s' "$sel" | head -1 | cut -f1)


### PR DESCRIPTION
## 変更
fzf transform + $FZF_PROMPT で enter/esc を文脈依存に:
- 検索中: enter/esc とも検索を抜けてナビに戻るだけ(遷移/クローズしない、esc は query クリア)
- ナビ中: enter=ジャンプ / esc=閉じる

## 検証
shellcheck CLEAN。fzf がバインド受理、モーダル判定ロジックを sh で確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)