### PR TITLE
fix(notify): nav 中の入力を検索バーに溜めない

### DIFF
--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -177,9 +177,10 @@ case "${1:-popup}" in
             --header 'j/k:移動  C-u/d:ページ  g/G:上下端  r:再走査  /:検索  Enter:ジャンプ' \
             --bind 'j:down,k:up,g:first,G:last,ctrl-d:half-page-down,ctrl-u:half-page-up' \
             --bind "r:reload(bash '$SELF' rescan)" \
-            --bind '/:enable-search+unbind(j,k,g,G,r)+change-prompt(検索> )' \
+            --bind 'change:clear-query' \
+            --bind '/:enable-search+unbind(change)+unbind(j,k,g,G,r)+change-prompt(検索> )' \
             --bind 'enter:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "rebind(j,k,g,G,r)+change-prompt(agent> )" || echo accept' \
-            --bind 'esc:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "disable-search+rebind(j,k,g,G,r)+clear-query+change-prompt(agent> )" || echo abort' \
+            --bind 'esc:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "disable-search+rebind(change,j,k,g,G,r)+clear-query+change-prompt(agent> )" || echo abort' \
             --color 'pointer:203,marker:214') || exit 0
     [[ -z "$sel" ]] && exit 0
     target=$(printf '%s' "$sel" | head -1 | cut -f1)


### PR DESCRIPTION
## 問題
--disabled はフィルタを止めるだけで、打った文字は query バーに入る。

## 修正
- nav 中: change:clear-query で入力を即クリア(バーに残らない)
- / で unbind(change)+enable-search して初めて入力・検索可
- esc 取消で rebind(change) して入力無視に戻す

## 検証
shellcheck CLEAN。fzf がバインド受理(exit 0)。次回 prefix+a から有効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)