### PR TITLE
fix(notify): 開いた時に区切りが先頭でもフォーカスしない

### DIFF
--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -185,6 +185,7 @@ case "${1:-popup}" in
             --bind 'up:up+transform:[ {2} = divider ] && echo up' \
             --bind 'ctrl-d:half-page-down+transform:[ {2} = divider ] && echo down' \
             --bind 'ctrl-u:half-page-up+transform:[ {2} = divider ] && echo up' \
+            --bind 'load:transform:[ {2} = divider ] && echo down' \
             --bind "r:reload(bash '$SELF' rescan)" \
             --bind 'change:clear-query' \
             --bind '/:unbind(change)+unbind(j,k,g,G,r)+change-prompt(検索> )' \


### PR DESCRIPTION
running のみで区切りが先頭になる場合、開いた瞬間カーソルが divider に乗っていた。load イベントで先頭が divider なら下へ移動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)