### PR TITLE
fix(notify): s(stash)を単一 reload に統合

### DIFF
--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -207,7 +207,7 @@ case "${1:-popup}" in
             --bind 'load:transform:[ {2} = divider ] && echo down' \
             --bind "r:reload(bash '$SELF' rescan)" \
             --bind 'q:abort' \
-            --bind "s:execute-silent(bash '$SELF' stash-toggle {1})+reload(bash '$SELF' rescan)" \
+            --bind "s:reload(bash '$SELF' stash-toggle {1}; bash '$SELF' rescan)" \
             --bind 'change:clear-query' \
             --bind '/:unbind(change)+unbind(j,k,g,G,r,q,s)+change-prompt(検索> )' \
             --bind 'enter:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "rebind(j,k,g,G,r,q,s)+change-prompt(agent> )" || echo accept' \


### PR DESCRIPTION
## 問題
s が execute-silent+reload の2段で、display-popup 文脈で stash が反映されずセクション移動しないことがあった。

## 修正
- s を reload(stash-toggle {1}; rescan) の単一 reload に統合(トグル→再生成を原子的に)

## 検証
shellcheck CLEAN。実 socket で stash-toggle→rescan が @agent_stashed=1 + あとで見る区切り出力を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)