### PR TITLE
fix(notify): pi 実行中検出 + prefix+a 現在 pane 強調

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -143,7 +143,7 @@ bind s choose-tree -Zs -O name
 bind Tab switch-client -l
 
 # AI Agent 横断ビュー: 停止中エージェント一覧を popup 表示し、選択でジャンプ
-bind a display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
+bind a display-popup -E -w 70% -h 60% "TMUX_PANE=#{pane_id} ~/dotfiles/scripts/tmux-agent-status.sh popup"
 # AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
 # (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
 bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -28,6 +28,7 @@ STATUS_DIR="${AGENT_STATUS_DIR:-/tmp/claude/status}"
 US=$'\x1f'
 
 C_RED=$'\e[38;5;203m'; C_AMBER=$'\e[38;5;214m'; C_DIM=$'\e[2m'; C_BOLD=$'\e[1m'; C_RST=$'\e[0m'
+C_CUR=$'\e[38;5;45m'   # 現在の pane 強調(シアン)。prefix+a を押した pane を枠線で示す
 
 status_rank() { case "$1" in permission) echo 0;; hang) echo 1;; error) echo 2;; idle) echo 3;; complete) echo 4;; running) echo 8;; *) echo 9;; esac; }
 status_icon() { case "$1" in idle) echo "󰔟";; permission) echo "󰌆";; complete) echo "";; hang) echo "";; error) echo "";; running) echo "●";; *) echo " ";; esac; }
@@ -43,19 +44,25 @@ trunc() { local s="$1" n="$2"; s="${s//$'\t'/ }"; if (( ${#s} > n )); then print
 
 # ローカル(pane option)行 → sortable 6 フィールド
 build_local_rows() {
-  local now; now=$(date +%s)
+  local now cur; now=$(date +%s); cur="${TMUX_PANE:-}"
   while IFS="$US" read -r pid sess win status hb path cmd title stashed; do
     is_agent "$status" || continue          # 停止状態 + running を対象
     is_shell "$cmd" && continue             # シェル復帰(終了済み)は除外
-    local rank icon col task branch elapsed loc tool line1 line2
+    local rank icon col task branch elapsed loc tool line1 line2 g1 g2 mk
     # stash 済みは status に関わらず stash セクション(rank 6: stopped と running の間)へ
     if [[ -n "$stashed" ]]; then rank=6; else rank=$(status_rank "$status"); fi
     icon=$(status_icon "$status"); col=$(status_color "$status")
     task=$(trunc "${title:-$(basename "${path:-?}")}" 52)
     branch=$(branch_of "$path"); tool=$(tool_of "$cmd"); loc="${sess}:${win}"
     if [[ "$hb" =~ ^[0-9]+$ ]]; then elapsed=$(humanize "$(( now - hb ))"); else elapsed="-"; fi
-    line1=$(printf '%s%s %-10s%s %s' "$col" "$icon" "$status" "$C_RST" "$task")
-    line2=$(printf '   %s%s · %s · %s · %s · %s%s' "$C_DIM" "$sess" "$branch" "$loc" "$tool" "${elapsed}前" "$C_RST")
+    # 現在の pane(prefix+a を押した pane)は左に枠線バー + マーカーで強調
+    if [[ -n "$cur" && "$pid" == "$cur" ]]; then
+      g1="${C_CUR}▎${C_RST} "; g2="${C_CUR}▎${C_RST}  "; mk=" ${C_CUR}◀ 今ここ${C_RST}"
+    else
+      g1="  "; g2="   "; mk=""
+    fi
+    line1=$(printf '%s%s%s %-10s%s %s%s' "$g1" "$col" "$icon" "$status" "$C_RST" "$task" "$mk")
+    line2=$(printf '%s%s%s · %s · %s · %s · %s%s' "$g2" "$C_DIM" "$sess" "$branch" "$loc" "$tool" "${elapsed}前" "$C_RST")
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$rank" "$pid" "$loc" "$status" "$line1" "$line2"
   done < <(tmux list-panes -a -F \
     "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}")

--- a/scripts/tmux-claude-pane.sh
+++ b/scripts/tmux-claude-pane.sh
@@ -111,18 +111,17 @@ case "${1:-}" in
     ;;
 
   heartbeat)
-    # 生存信号更新。停止状態(idle/permission/complete/error)は触らない。
-    # running/hang/未設定 のみ running へ(hang からの自動復帰)。
+    # 生存信号更新。heartbeat はツール実行中にのみ呼ばれる=エージェントは稼働中なので、
+    # idle/complete/hang/error/未設定 いずれからも running へ戻す(turn_start イベントが
+    # 無い pi 等で、前ターンの idle が残って実行中に見えない問題を防ぐ)。
     PANE_ID=$(resolve_pane)
     tmux set-option -p -t "$PANE_ID" @agent_heartbeat "$(date +%s)" 2>/dev/null || true
     current=$(tmux show-options -pv -t "$PANE_ID" @agent_status 2>/dev/null || echo "")
-    case "$current" in
-      ""|running|hang)
-        tmux set-option -p -t "$PANE_ID" @agent_status running 2>/dev/null || true
-        tmux set-option -p -t "$PANE_ID" -u @agent_icon 2>/dev/null || true
-        [[ "$current" == "hang" ]] && tmux refresh-client -S 2>/dev/null || true
-        ;;
-    esac
+    if [[ "$current" != "running" ]]; then
+      tmux set-option -p -t "$PANE_ID" @agent_status running 2>/dev/null || true
+      tmux set-option -p -t "$PANE_ID" -u @agent_icon 2>/dev/null || true
+      tmux refresh-client -S 2>/dev/null || true
+    fi
     ;;
 
   clear)


### PR DESCRIPTION
## 変更
- pi running 未検出: heartbeat を「ツール活動=稼働中」として idle 等からも running へ復帰。pi は turn_start が無く tool_call→heartbeat が唯一の実行中シグナルのため idle 固定だった
- prefix+a 現在 pane 強調: bind で TMUX_PANE=#{pane_id} を渡し、該当行に枠線バー▎+◀今ここ

## 検証
shellcheck CLEAN。heartbeat idle→running、TMUX_PANE 一致行の強調表示を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)