### PR TITLE
fix(notify): prefix+a の現在 pane 検出修正

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -143,7 +143,9 @@ bind s choose-tree -Zs -O name
 bind Tab switch-client -l
 
 # AI Agent 横断ビュー: 停止中エージェント一覧を popup 表示し、選択でジャンプ
-bind a display-popup -E -w 70% -h 60% "TMUX_PANE=#{pane_id} ~/dotfiles/scripts/tmux-agent-status.sh popup"
+# display-popup のコマンドは #{pane_id} を展開しないため、run-shell(展開する)で現在 pane を
+# グローバルオプションに保存してから popup を開く(popup 内で現在 pane を枠線強調するのに使用)
+bind a run-shell "tmux set-option -g @agent_cur_pane '#{pane_id}'" \; display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
 # AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
 # (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
 bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -44,7 +44,8 @@ trunc() { local s="$1" n="$2"; s="${s//$'\t'/ }"; if (( ${#s} > n )); then print
 
 # ローカル(pane option)行 → sortable 6 フィールド
 build_local_rows() {
-  local now cur; now=$(date +%s); cur="${TMUX_PANE:-}"
+  # 現在 pane(prefix+a を押した pane)は bind が @agent_cur_pane に保存している
+  local now cur; now=$(date +%s); cur="$(tmux show-options -gv @agent_cur_pane 2>/dev/null || echo "")"
   while IFS="$US" read -r pid sess win status hb path cmd title stashed; do
     is_agent "$status" || continue          # 停止状態 + running を対象
     is_shell "$cmd" && continue             # シェル復帰(終了済み)は除外


### PR DESCRIPTION
## 問題
display-popup のコマンド内 #{pane_id} は展開されず(リテラル化)、現在 pane 強調が効かなかった。

## 修正
- run-shell(#{pane_id} を展開)で @agent_cur_pane に現在 pane を保存→popup が読む
- build_local_rows が一致行に枠線▎+◀今ここ

## 検証
shellcheck CLEAN。run-shell で @agent_cur_pane 設定→list で該当行強調を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)