### PR TITLE
fix: audit priorities 1-3 — adopt safety, Claude harness integrity, setup failure detection

### DIFF
--- a/common/claude/.config/claude/mcp.json
+++ b/common/claude/.config/claude/mcp.json
@@ -1,1 +1,34 @@
-../../../../agent/.config/agent/mcp.json
+{
+  "mcpServers": {
+    "tmux": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "tmux-mcp"]
+    },
+    "notion": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@notionhq/notion-mcp-server"],
+      "env": {
+        "NOTION_TOKEN": "${NOTION_TOKEN}"
+      }
+    },
+    "syntopic": {
+      "type": "http",
+      "url": "https://mcp.sandbox.syntopic.io/mcp"
+    },
+    "serena": {
+      "type": "stdio",
+      "command": "serena",
+      "args": ["start-mcp-server", "--context", "claude-code", "--project-from-cwd"]
+    },
+    "token-optimizer": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "token-optimizer-mcp"],
+      "env": {
+        "TOKEN_OPTIMIZER_CACHE_DIR": "${HOME}/.cache/token-optimizer-mcp"
+      }
+    }
+  }
+}

--- a/docs/ai-agents/pi/mcp-layer.md
+++ b/docs/ai-agents/pi/mcp-layer.md
@@ -18,7 +18,9 @@ MCP Server (stdio JSON-RPC)
 
 ## Config
 
-共有 MCP 設定は `~/.config/agent/mcp.json` で一元管理。Claude/pi 両方が参照する。
+pi の MCP 設定は `~/.config/agent/mcp.json` で管理（pi 起動パフォーマンスのため必要最小限に絞る）。
+Claude は `common/claude/.config/claude/mcp.json` を正本とし、install.sh が
+`claude mcp add-json --scope user` で登録する（秘密情報は `${NOTION_TOKEN}` を 1Password から解決）。
 詳細は [agent-layer.md](agent-layer.md) を参照。
 
 ### Format

--- a/docs/specs/agent-infrastructure.md
+++ b/docs/specs/agent-infrastructure.md
@@ -105,7 +105,7 @@ MCP サーバーへの安全な接続レイヤー。
 | **Audit** | `~/.pi/research/mcp-audit.jsonl` |
 | **Stats** | `~/.pi/research/mcp-stats.json` |
 | **Pi impl** | `extensions/mcp-gateway.ts` — JSON-RPC stdio client + tool registration. allow/ask/deny enforced via `tool_call` gate; protocol version negotiated (advertises latest). stdio only (HTTP deferred) |
-| **Claude impl** | ネイティブ MCP 対応 + symlink で共有 config 参照 |
+| **Claude impl** | ネイティブ MCP 対応。`common/claude/.config/claude/mcp.json` を正本に install.sh が `claude mcp add-json --scope user` で登録 |
 
 ## Shared Configuration
 

--- a/install.sh
+++ b/install.sh
@@ -497,12 +497,42 @@ generate_ai_cli_configs() {
 
   local templates_dir="$DOTFILES_DIR/templates"
 
-  # Claude CLI
+  # Claude CLI — merge the template into the existing settings instead of
+  # regenerating from scratch. Template keys win (single source of truth),
+  # but keys only present locally (model, hooks registered by other steps
+  # like rtk, feedbackSurveyState, ...) are preserved.
   if [[ -f "$templates_dir/claude-settings.json" ]]; then
     mkdir -p "$HOME/.claude"
-    rm -f "$HOME/.claude/settings.json" 2>/dev/null || true
-    sed "s|__HOME__|$HOME|g" "$templates_dir/claude-settings.json" > "$HOME/.claude/settings.json"
-    log_success "  Generated ~/.claude/settings.json"
+    local rendered_template
+    rendered_template=$(mktemp)
+    sed "s|__HOME__|$HOME|g" "$templates_dir/claude-settings.json" > "$rendered_template"
+    python3 - "$rendered_template" "$HOME/.claude/settings.json" <<'PYEOF'
+import json, sys
+
+template_path, settings_path = sys.argv[1], sys.argv[2]
+with open(template_path) as f:
+    template = json.load(f)
+try:
+    with open(settings_path) as f:
+        current = json.load(f)
+except (OSError, ValueError):
+    current = {}
+
+def merge(base, override):
+    out = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+with open(settings_path, "w") as f:
+    json.dump(merge(current, template), f, indent=2, ensure_ascii=False)
+    f.write("\n")
+PYEOF
+    rm -f "$rendered_template"
+    log_success "  Merged ~/.claude/settings.json (template keys win, local-only keys kept)"
   fi
 
   # Claude MCP servers (from mcp.json, secrets resolved via 1Password)

--- a/install.sh
+++ b/install.sh
@@ -337,6 +337,22 @@ link_dotfiles() {
     return 1
   fi
 
+  local os
+  os=$(detect_os)
+
+  # Abort if the repo has uncommitted changes under the stow source dirs.
+  # stow --adopt overwrites repo files with the $HOME versions, and the
+  # later `git checkout -- common/ <os>/` rolls everything back to HEAD,
+  # so any uncommitted edits would be silently destroyed.
+  local dirty
+  dirty=$(git -C "$DOTFILES_DIR" status --porcelain -- common/ "$os/" 2>/dev/null || true)
+  if [[ -n "$dirty" ]]; then
+    log_error "Uncommitted changes in dotfiles repo would be lost by stow --adopt:"
+    echo "$dirty"
+    log_error "Commit or stash these changes, then re-run install.sh"
+    return 1
+  fi
+
   # Create .config if not exists
   mkdir -p "$HOME/.config"
 
@@ -351,8 +367,6 @@ link_dotfiles() {
   fi
 
   # Stow OS-specific packages
-  local os
-  os=$(detect_os)
   if [[ -d "$DOTFILES_DIR/$os" ]]; then
     log_info "Linking $os-specific dotfiles..."
     for pkg in "$DOTFILES_DIR/$os"/*/; do

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ source "$DOTFILES_DIR/scripts/utils.sh"
 SKIP_PROMPT=false
 NO_SUDO=false
 SKIP_1P=false
+SETUP_FAILED=false
 for arg in "$@"; do
   case "$arg" in
     -y|--skip-prompt) SKIP_PROMPT=true ;;
@@ -163,7 +164,10 @@ setup_environment() {
     mac)
       if [[ -f "$DOTFILES_DIR/scripts/mac.sh" ]]; then
         log_info "Running macOS setup script..."
-        bash "$DOTFILES_DIR/scripts/mac.sh"
+        if ! bash "$DOTFILES_DIR/scripts/mac.sh"; then
+          SETUP_FAILED=true
+          log_warn "Some macOS setup steps failed (see above); continuing"
+        fi
       else
         log_warn "scripts/mac.sh not found. Skipping package installation."
       fi
@@ -171,7 +175,10 @@ setup_environment() {
     linux)
       if [[ -f "$DOTFILES_DIR/scripts/linux.sh" ]]; then
         log_info "Running Linux setup script..."
-        bash "$DOTFILES_DIR/scripts/linux.sh"
+        if ! bash "$DOTFILES_DIR/scripts/linux.sh"; then
+          SETUP_FAILED=true
+          log_warn "Some Linux setup steps failed (see above); continuing"
+        fi
       else
         log_warn "scripts/linux.sh not found. Skipping package installation."
       fi
@@ -776,11 +783,18 @@ main() {
   configure_serena_dashboard
 
   echo
-  log_success "=== Installation Complete! ==="
+  if [[ "$SETUP_FAILED" == "true" ]]; then
+    log_error "=== Installation finished with package setup failures (see above) ==="
+  else
+    log_success "=== Installation Complete! ==="
+  fi
   log_info "Please restart your shell or run: source ~/.zshrc"
 
   # Unified summary (all config-driven)
   print_install_summary
+
+  [[ "$SETUP_FAILED" == "true" ]] && exit 1
+  return 0
 }
 
 # --- 3.9. Install pi packages from stowed settings.json ---

--- a/install.sh
+++ b/install.sh
@@ -826,7 +826,11 @@ with open('$settings_file') as f:
 # --- 4.5. Configure rtk Claude Code hook ---
 # rtk init -g registers a Bash hook in ~/.claude/settings.json that transparently
 # rewrites commands like `git status` -> `rtk git status` for 60-90% token reduction.
-# Idempotent: skips if hook already configured.
+# --auto-patch is required: without it rtk prompts before patching settings.json,
+# and in non-interactive installs the prompt fails, leaving RTK.md claiming a
+# hook that was never installed.
+# Idempotent: skips if hook already configured. Must run after
+# generate_ai_cli_configs, whose template merge resets the hook arrays.
 configure_rtk_claude_hook() {
   if ! command_exists rtk; then
     log_warn "rtk not installed, skipping rtk Claude hook setup"
@@ -840,10 +844,10 @@ configure_rtk_claude_hook() {
   fi
 
   log_info "Configuring rtk Claude Code hook (token compression)..."
-  if rtk init -g; then
+  if rtk init -g --auto-patch; then
     log_success "rtk Claude hook configured"
   else
-    log_warn "rtk init -g failed (non-fatal)"
+    log_warn "rtk init -g --auto-patch failed (non-fatal)"
   fi
 }
 

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 # Linux (Debian/Ubuntu/Alpine) Setup Script
+# No -e: individual steps may fail without aborting the rest; failures are
+# collected via run_step and reported through finish_steps (non-zero exit).
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"
@@ -171,9 +174,10 @@ install_nerd_font() {
 # --- Tool Installation Helpers ---
 
 # Get a tool's config field value via indirect expansion
+# (:- keeps unset optional fields safe under `set -u`)
 _tool_field() {
   local var="TOOL_${1}_${2}"
-  echo "${!var}"
+  echo "${!var:-}"
 }
 
 # Resolve architecture from arch_map
@@ -857,26 +861,26 @@ install_tmux_source() {
 
 # --- Main Execution ---
 
-check_requirements
-install_system_packages
-install_tmux_source
-install_modern_tools
-install_bun
-install_npm_packages
-install_claude_mem
-install_genshijin
-install_rtk
-install_serena
-install_context_mode
-install_code_review_graph
-install_auto_mode
-configure_claude_remote_control_autostart
-link_ai_scripts
-install_gh_extensions
-install_ghostty_terminfo
-install_fancy_cat
-install_1password_cli
-check_1password
-set_default_shell
+run_step check_requirements
+run_step install_system_packages
+run_step install_tmux_source
+run_step install_modern_tools
+run_step install_bun
+run_step install_npm_packages
+run_step install_claude_mem
+run_step install_genshijin
+run_step install_rtk
+run_step install_serena
+run_step install_context_mode
+run_step install_code_review_graph
+run_step install_auto_mode
+run_step configure_claude_remote_control_autostart
+run_step link_ai_scripts
+run_step install_gh_extensions
+run_step install_ghostty_terminfo
+run_step install_fancy_cat
+run_step install_1password_cli
+run_step check_1password
+run_step set_default_shell
 
-log_success "Linux setup complete!"
+finish_steps "Linux setup complete!"

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 # macOS Setup Script (Homebrew packages)
+# No -e: individual steps may fail without aborting the rest; failures are
+# collected via run_step and reported through finish_steps (non-zero exit).
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"
@@ -359,23 +362,23 @@ install_cursor_cli() {
 }
 
 # --- Main Execution ---
-install_brew_bundle
-install_mise_tools
-install_npm_packages
-install_claude_mem
-install_genshijin
-install_serena
-install_context_mode
-install_code_review_graph
-install_auto_mode
-install_cursor_cli
-configure_claude_remote_control_autostart
-install_dops
-install_quay
-install_cargo_update
-install_lemonade
-install_gh_extensions
-link_ai_scripts
-set_default_shell
+run_step install_brew_bundle
+run_step install_mise_tools
+run_step install_npm_packages
+run_step install_claude_mem
+run_step install_genshijin
+run_step install_serena
+run_step install_context_mode
+run_step install_code_review_graph
+run_step install_auto_mode
+run_step install_cursor_cli
+run_step configure_claude_remote_control_autostart
+run_step install_dops
+run_step install_quay
+run_step install_cargo_update
+run_step install_lemonade
+run_step install_gh_extensions
+run_step link_ai_scripts
+run_step set_default_shell
 
-log_success "macOS packages installed!"
+finish_steps "macOS packages installed!"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -16,6 +16,32 @@ command_exists() {
   command -v "$1" &>/dev/null
 }
 
+# --- Install step failure tracking ---
+# run_step records failures instead of aborting, so one broken step doesn't
+# stop the rest of the setup but the script can still exit non-zero.
+# Usage:
+#   run_step install_foo
+#   run_step install_bar
+#   finish_steps "All packages installed!"   # exits 1 if any step failed
+# (string accumulation instead of an array: empty arrays break under
+#  `set -u` on macOS bash 3.2)
+FAILED_STEPS=""
+run_step() {
+  if ! "$1"; then
+    FAILED_STEPS="${FAILED_STEPS} $1"
+    log_error "Step failed: $1"
+  fi
+}
+
+finish_steps() {
+  local success_msg="$1"
+  if [[ -n "$FAILED_STEPS" ]]; then
+    log_error "Setup finished with failed steps:${FAILED_STEPS}"
+    return 1
+  fi
+  log_success "$success_msg"
+}
+
 detect_os() {
   case "$(uname -s)" in
     Darwin) echo "mac" ;;

--- a/templates/claude-settings.json
+++ b/templates/claude-settings.json
@@ -39,6 +39,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/common/claude/.claude/hooks/genshijin-session-start.sh"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [
@@ -49,6 +59,16 @@
           {
             "type": "command",
             "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh start"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat"
           }
         ]
       }


### PR DESCRIPTION
## Summary

総合監査 (8次元レビュー + 検証) で確定した指摘のうち、優先度 1〜3 を修正する。

1. データ消失防止: `stow --adopt` 前の dirty チェック
2. Claude ハーネス整合性回復: settings.json の merge 化 / rtk hook の実態合わせ / mcp.json の versioned 復元
3. 失敗検知: mac.sh / linux.sh の失敗集計と非ゼロ exit

## Changes

### 1. stow --adopt の dirty チェック (`install.sh`)
- `link_dotfiles` 冒頭で `git status --porcelain -- common/ <os>/` を確認し、未コミット変更があれば中断
- adopt → `git checkout` の流れで未コミット編集が黙って消失する事故を防止

### 2. settings.json の冪等 merge 化 (`install.sh`, `templates/claude-settings.json`)
- `rm -f` + テンプレート再生成を廃止し、python3 による deep merge に変更 (テンプレートのキーが勝ち、ローカル限定キー — model, rtk hook 等 — は保持)
- mac.sh/linux.sh が登録する genshijin SessionStart hook と live 限定だった PreToolUse heartbeat をテンプレートに昇格し、新規マシンでも再現可能に

### 3. rtk hook の実態合わせ (`install.sh`)
- `rtk init -g` → `rtk init -g --auto-patch` に変更。プレーン実行は settings.json パッチ前にプロンプトを出すため、非対話 install では hook が未登録のまま RTK.md だけが「自動書き換えあり」と主張する状態だった
- fake HOME での E2E で、auto-patch が既存 PreToolUse エントリを保持したまま rtk hook を追加することを確認済み

### 4. Claude MCP 設定の versioned 復元 (`common/claude/.config/claude/mcp.json`, docs)
- agent 統合層への symlink を実ファイルに置換。symlink 先は c294526 で pi 用に縮小され (3サーバ・全 disabled)、Claude の登録経路が実質壊れていた
- live で使用中の 5 サーバ (tmux, notion, syntopic, serena, token-optimizer) を登録。シークレットは `${NOTION_TOKEN}` プレースホルダで install 時に 1Password から解決
- symlink 共有を記述していた docs 2 箇所を更新

### 5. セットアップ失敗検知 (`scripts/utils.sh`, `scripts/mac.sh`, `scripts/linux.sh`, `install.sh`)
- 両スクリプトに `set -uo pipefail` を追加 (-e なし: 1 ステップの失敗で全体を止めない)
- `run_step`/`finish_steps` ヘルパーを utils.sh に追加し、失敗ステップを集計して非ゼロ exit + サマリ表示
- `_tool_field` の間接展開を `${!var:-}` 化し `set -u` 対応
- install.sh は失敗を記録しつつ後続 (stow 等) を継続、最後に失敗バナー + exit 1

## Test plan

- [x] `bash -n` + shellcheck (修正ファイル全部、新規指摘なし)
- [x] merge ロジック: ローカルキー保持 / テンプレート優先 / 新規生成の 3 パターンを assert で検証
- [x] `rtk init -g --auto-patch` を fake HOME で E2E (hook 登録 + 既存 PreToolUse 保持)
- [x] dirty チェック: 汚れ検出 + クリーン時通過を実コマンドで確認
- [x] MCP 登録ループ: 復元 mcp.json で 5 サーバの抽出・プレースホルダ解決を dry-run
- [x] `run_step`/`finish_steps`: macOS bash 3.2 + `set -u` で失敗集計と exit code を確認
- [ ] Linux 環境 (container) での install.sh フル実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)