### PR TITLE
fix(tmux): stop set-hook accumulation on reload, target windows by id

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -264,9 +264,15 @@ bind y display-menu -T "Theme" -x C -y C \
 source-file ~/.config/tmux/claude-hooks.tmux
 
 # Per-session accent color hooks (claude-hooks.tmux の後に追加、-ga で append)
+# -gu でリセットしてから append しないと prefix+r のリロードごとに同じ
+# run-shell が蓄積する。client-session-changed のみ claude-hooks.tmux が
+# -g (上書き) で先に登録するため -gu 不要 (-gu すると claude-hooks 側が消える)。
+set-hook -gu session-created
 set-hook -ga session-created 'run-shell "~/dotfiles/scripts/tmux-session-color.sh apply #{session_name} 2>/dev/null || true"'
 set-hook -ga client-session-changed 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -gu client-attached
 set-hook -ga client-attached 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -gu after-new-window
 set-hook -ga after-new-window 'run-shell "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
 
 # Pane-sticky zoom: register after-select-pane hook once (reload-safe via @zoom-hooks-loaded)
@@ -364,6 +370,9 @@ set -g status-style bg=default
 # On every client-resized event, reset all windows in the session back to
 # "latest" so they track the client's terminal size.
 # Must come AFTER the opensessions plugin (loaded via TPM above).
+# window-size latest の対象指定は #{window_id} (@N): ウィンドウ名 (#W) は
+# 空白で単語分割され、重複名では曖昧解決になるため使わない。
 set-hook -gu client-resized
-set-hook -ga client-resized  'run-shell "for w in $(tmux list-windows -F \"##W\"); do tmux setw -t \"\$w\" window-size latest 2>/dev/null; done"'
+set-hook -ga client-resized  'run-shell "for w in $(tmux list-windows -F \"##{window_id}\"); do tmux setw -t \"\$w\" window-size latest 2>/dev/null; done"'
+# after-new-window は session color ブロック (上方) で -gu 済み。これは 2 つ目の append。
 set-hook -ga after-new-window 'run-shell "tmux setw window-size latest 2>/dev/null"'


### PR DESCRIPTION
## Summary

総合監査の優先度 5 (tmux hook) を修正する。

1. `prefix+r` リロードごとの `set-hook -ga` 蓄積を `-gu` リセットで停止
2. client-resized フックのウィンドウ対象指定を `#W` (名前) から `#{window_id}` に変更

## Changes

### 1. hook 蓄積の停止 (`tmux.conf`)
- session-created / client-attached / after-new-window に `-gu` リセットを追加（既存の client-resized と同じパターン）
- after-new-window は 2 箇所 (session color + window-size latest) で append されるため、リロードごとに +2 で増殖していた。tmux-popup-manager の session-created append も同様に蓄積していた
- client-session-changed は claude-hooks.tmux が `-g` (上書き) で先に登録するため `-gu` を置かない（置くと claude-focus hook が消える）

### 2. `#W` → `#{window_id}` (`tmux.conf`)
- ウィンドウ名はスペースで単語分割され、重複名では `-t` 解決が曖昧になる。`@N` 形式の window_id は一意かつ空白なし

## Test plan

- [x] 隔離 socket (`tmux -L audit-test`) で起動 → `source-file` 2 回 → 全 hook 数が不変であることを確認 (修正前は after-new-window が +2/リロード)
- [x] プラグイン登録エントリ (claude-hooks, tmux-popup-manager) がリロード後も保持されることを確認
- [x] client-resized の格納値が `##{window_id}` (実行時 `#{window_id}` に展開) であることを確認
- [ ] 実セッションで prefix+r 後にウィンドウリサイズ・セッション色が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)