### PR TITLE
fix(zsh): compinit ordering + 24h cache repair, defer heavy plugins

### DIFF
--- a/common/sheldon/.config/sheldon/plugins.toml
+++ b/common/sheldon/.config/sheldon/plugins.toml
@@ -1,19 +1,32 @@
 # plugins.toml
 shell = "zsh"
 
+# zsh-defer: プロンプト表示後 (アイドル時) に source する遅延ロード。
+# 体感起動時間を削る。fpath 提供プラグイン (zsh-completions) と、
+# source 直後に .zshrc.local から参照されるもの (zsh-abbr の abbr) には使えない。
+[templates]
+defer = """{% for file in files %}zsh-defer source "{{ file }}"
+{% endfor %}"""
+
+[plugins.zsh-defer]
+github = "romkatv/zsh-defer"
+
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"
 dir = "src"
 apply = ["fpath"]
 
-[plugins.forgit]
-github = "wfxr/forgit"
-
 [plugins.zsh-abbr]
 github = "olets/zsh-abbr"
 
+[plugins.forgit]
+github = "wfxr/forgit"
+apply = ["defer"]
+
 [plugins.zsh-syntax-highlighting]
 github = "zsh-users/zsh-syntax-highlighting"
+apply = ["defer"]
 
 [plugins.zsh-autosuggestions]
 github = "zsh-users/zsh-autosuggestions"
+apply = ["defer"]

--- a/common/zsh/.zshrc
+++ b/common/zsh/.zshrc
@@ -4,4 +4,24 @@
 # Load OS-specific settings
 [[ -f "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
 
+# --- Completion Init (cached: full rebuild once per 24h) ---
+# 全 fpath 追加 (.zshrc.common の ~/.zsh/completions, sheldon の zsh-completions) の
+# 後に 1 回だけ実行する。compinit 後の fpath 追加は補完登録されない。
+# (#qN.mh+24) glob 修飾子は extended_glob 必須のため無名関数内で局所有効化する
+# (無効だと条件が常に真になり、毎起動フル compinit + compaudit が走る)。
+if [[ -o interactive ]]; then
+  autoload -Uz compinit
+  () {
+    setopt local_options extended_glob
+    local dump="${ZDOTDIR:-$HOME}/.zcompdump"
+    local -a stale
+    stale=( $dump(#qN.mh+24) )
+    if [[ ! -f "$dump" || -n "$stale" ]]; then
+      compinit
+    else
+      compinit -C
+    fi
+  }
+fi
+
 command -v fzf &>/dev/null && source <(fzf --zsh)

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -87,13 +87,9 @@ command -v mise &>/dev/null && eval "$(mise activate zsh)"
 # --- Direnv (interactive shell hooks) ---
 command -v direnv &>/dev/null && eval "$(direnv hook zsh)"
 
-# --- Completion Init (cached: full rebuild once per 24h) ---
-autoload -Uz compinit
-if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
-  compinit
-else
-  compinit -C
-fi
+# compinit は common/zsh/.zshrc の最後 (全 fpath 追加 + sheldon source 後) で実行する。
+# ここで実行すると後続の fpath 追加 (~/.zsh/completions, sheldon zsh-completions) が
+# 補完登録されない。
 
 # --- Conditional Aliases (runtime checks) ---
 # ls -> lsd (fallback: eza)

--- a/linux/zsh/.zshrc.local
+++ b/linux/zsh/.zshrc.local
@@ -27,8 +27,12 @@ bindkey -M emacs '^p' atuin-up-search
 
 # --- zsh-abbr syntax highlighting integration ---
 # Show abbreviations in green instead of red
+# zsh-syntax-highlighting は zsh-defer で遅延ロードされるため、ここでは
+# += でなく完全な値を設定する (+= だと plugin デフォルトの main が失われる)。
+# ZSH_HIGHLIGHT_REGEXP は plugin より先に連想配列として宣言しておく。
 if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS} )); then
-  ZSH_HIGHLIGHT_HIGHLIGHTERS+=(regexp)
+  ZSH_HIGHLIGHT_HIGHLIGHTERS=(main regexp)
+  typeset -gA ZSH_HIGHLIGHT_REGEXP
   local -a abbr_keys=()
   for k in ${(k)ABBR_REGULAR_USER_ABBREVIATIONS}; do
     abbr_keys+="${k//\"/}"

--- a/mac/zsh/.zshrc.local
+++ b/mac/zsh/.zshrc.local
@@ -26,8 +26,12 @@ bindkey -M emacs '^p' atuin-up-search
 
 # --- zsh-abbr syntax highlighting integration ---
 # Show abbreviations in green instead of red
+# zsh-syntax-highlighting は zsh-defer で遅延ロードされるため、ここでは
+# += でなく完全な値を設定する (+= だと plugin デフォルトの main が失われる)。
+# ZSH_HIGHLIGHT_REGEXP は plugin より先に連想配列として宣言しておく。
 if (( ${+ABBR_REGULAR_USER_ABBREVIATIONS} )); then
-  ZSH_HIGHLIGHT_HIGHLIGHTERS+=(regexp)
+  ZSH_HIGHLIGHT_HIGHLIGHTERS=(main regexp)
+  typeset -gA ZSH_HIGHLIGHT_REGEXP
   # Remove quotes from keys and join with |
   local -a abbr_keys=()
   for k in ${(k)ABBR_REGULAR_USER_ABBREVIATIONS}; do


### PR DESCRIPTION
## Summary

総合監査の優先度 6 (zsh 起動) を修正する。

1. compinit を全 fpath 追加後に移動 + 壊れていた 24h キャッシュ分岐を修復
2. zsh-defer 導入で重いプラグイン 3 本をプロンプト表示後に遅延ロード

## Changes

### 1. compinit 順序 + キャッシュ修復 (`common/zsh/.zshrc.common`, `common/zsh/.zshrc`)
- compinit が `~/.zsh/completions` (gh) と sheldon の zsh-completions の fpath 追加より前に実行されていたため、クリーン環境では両者の補完が未登録だった（親シェルから FPATH 継承時のみ偶然動作）。compinit を .zshrc の最後 (.zshrc.local source 後) に移動
- `(#qN.mh+24)` glob 修飾子は extended_glob 必須（無効）のため条件が常に真 → 毎起動フル compinit + compaudit が走り `compinit -C` がデッドコードだった。無名関数内で extended_glob を局所有効化して修復

### 2. zsh-defer 遅延ロード (`plugins.toml`, `mac/zsh/.zshrc.local`, `linux/zsh/.zshrc.local`)
- zsh-syntax-highlighting / zsh-autosuggestions / forgit を sheldon の defer template で遅延。zsh-completions (compinit 前に fpath 必須) と zsh-abbr (source 直後に `abbr import` 参照) は即時のまま
- 遅延に伴う順序逆転対応: `ZSH_HIGHLIGHT_HIGHLIGHTERS+=` がプラグインデフォルト (main) を失い、`ZSH_HIGHLIGHT_REGEXP+=` が通常配列化してプラグインの `typeset -gA` に消される問題 → 明示値 `(main regexp)` 設定 + 事前の連想配列宣言で解決 (両 OS)

## Test plan

- [x] クリーン環境 (`env -i`) で gh/cmake 補完登録を確認（修正前: 未登録 → 修正後: 登録、`compinit -C` 経路でも維持）
- [x] 実 PTY (隔離 tmux) で遅延プラグイン 3 本のロード、`HL=main,regexp` + abbr regexp ルールの維持を確認
- [x] `zsh -n` 全編集ファイル構文 OK、起動エラーなし（`fzf --zsh` 由来の既存 zle warning は変更前から存在）
- [x] warm 起動 0.20s → 0.17s
- [ ] Linux 環境での起動確認

## Notes

- 補完追加 (新ツール install 等) は次回 24h フル rebuild まで反映されない（`rm ~/.zcompdump` で即時反映可）— 24h キャッシュ方式の標準トレードオフ
- 適用には `sheldon lock` の再実行が必要（次回シェル起動時に自動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)