### PR TITLE
fix(notify): サイドバー SELF 上書きの Usage エラー修正

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -22,10 +22,11 @@ set -uo pipefail
 [[ -z "${TMUX:-}" ]] && exit 0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SELF="$SCRIPT_DIR/tmux-agent-sidebar.sh"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/tmux-agent-status.sh"   # ヘルパー(is_shell, trunc_w 由来の helpers, C_*)
 set +e +o pipefail
+# SELF は source の後に定義する(status.sh も冒頭で SELF を設定するため上書きを避ける)
+SELF="$SCRIPT_DIR/tmux-agent-sidebar.sh"
 
 REFRESH="${AGENT_SIDEBAR_REFRESH:-3}"
 WIDTH="${AGENT_SIDEBAR_WIDTH:-40}"


### PR DESCRIPTION
#228 の退行。SELF を source 前に定義→status.sh に上書きされ bash status.sh once→Usage。SELF 定義を source 後へ移動。

shellcheck CLEAN。once が正常描画することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)