### PR TITLE
feat(notify): サイドバー USAGE に AI ごとの色分け

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -128,18 +128,26 @@ usage_section() {
   # curl --max-time + キャッシュ + fail backoff により自己制限する)
   local TO; TO="$(command -v timeout || command -v gtimeout || true)"
   {
-    local sc out icon gauge pct rem
+    local sc out icon gauge pct rem col
     for sc in tmux-claude-usage tmux-codex-usage tmux-gemini-usage tmux-cursor-usage; do
+      # AI ごとの色分け(ステータスバーと同じ): claude=橙 codex=水色 gemini=青 cursor=紫
+      case "$sc" in
+        *claude*) col=$'\033[38;2;255;102;0m' ;;
+        *codex*)  col=$'\033[38;2;125;211;252m' ;;
+        *gemini*) col=$'\033[38;2;66;133;244m' ;;
+        *cursor*) col=$'\033[38;2;153;102;255m' ;;
+        *)        col="" ;;
+      esac
       out=$(${TO:+$TO 6} bash "$SCRIPT_DIR/$sc.sh" 2>/dev/null)
       [[ -z "$out" ]] && continue
       # 形式 "ICON GAUGE(2字) PCT/PCT REMAINING"。ゲージは低%だと空白になり read の空白圧縮で
       # ずれるため正規表現で抽出する。マッチしなければデータなし(ICON --)扱い。
       if [[ "$out" =~ ^([^[:space:]]+)\ (..)\ ([0-9]+%/[0-9]+%)\ ?(.*)$ ]]; then
         icon="${BASH_REMATCH[1]}"; gauge="${BASH_REMATCH[2]}"; pct="${BASH_REMATCH[3]}"; rem="${BASH_REMATCH[4]}"
-        printf '%s %s\n  %s%s %s%s\n' "$icon" "$rem" "$C_DIM" "$gauge" "$pct" "$C_RST"
+        printf '%s%s%s %s\n  %s%s %s%s\n' "$col" "$icon" "$C_RST" "$rem" "$col" "$gauge" "$pct" "$C_RST"
       else
         read -r icon _ <<< "$out"
-        printf '%s %s--%s\n' "$icon" "$C_DIM" "$C_RST"
+        printf '%s%s%s %s--%s\n' "$col" "$icon" "$C_RST" "$C_DIM" "$C_RST"
       fi
     done
   } | tee "$USAGE_CACHE"


### PR DESCRIPTION
ステータスバーと同じ色分けを USAGE に適用(claude=橙/codex=水/gemini=青/cursor=紫)。アイコン+ゲージ+%を truecolor で着色。

shellcheck CLEAN。各ツール色コード適用を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)