### PR TITLE
fix(notify): サイドバー content を実 pane 幅に追従

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -166,6 +166,9 @@ render() {
   W=$(tmux display-message -p -t "${TMUX_PANE}" '#{pane_width}' 2>/dev/null)
   [[ -z "$H" ]] && H=40
   [[ -z "$W" || "$W" -lt 1 ]] && W="$WIDTH"
+  # 以降の幅計算(trunc_w / per / divider)は静的 WIDTH ではなく実 pane 幅に揃える。
+  # _sb_flush は動的スコープで WIDTH を参照するため、ここで上書きすれば波及する。
+  local WIDTH="$W"
   # divider は pane 幅ちょうどの罫線(リサイズに追従、折返し防止)
   local div; div=$(printf '─%.0s' $(seq 1 "$W"))
 


### PR DESCRIPTION
セッション名の切り詰め(trunc_w)とアイコン折返し(per)が静的 WIDTH=40 のままで、リサイズで狭くなった pane(例 27 列)からはみ出し・折返ししていた。render 内で WIDTH を実 `pane_width` に上書きし、divider を含め全体が表示幅に追従するよう修正。

## 確認
- shellcheck CLEAN
- pane 幅27 で全行が幅内に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)