### PR TITLE
feat(notify): USAGE を current/週間 別ブロック表示に

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -128,7 +128,7 @@ usage_section() {
   # curl --max-time + キャッシュ + fail backoff により自己制限する)
   local TO; TO="$(command -v timeout || command -v gtimeout || true)"
   {
-    local sc out icon gauge pct rem col
+    local sc out col icon label gauge pct rem
     for sc in tmux-claude-usage tmux-codex-usage tmux-gemini-usage tmux-cursor-usage; do
       # AI ごとの色分け(ステータスバーと同じ): claude=橙 codex=水色 gemini=青 cursor=紫
       case "$sc" in
@@ -140,15 +140,19 @@ usage_section() {
       esac
       out=$(${TO:+$TO 6} bash "$SCRIPT_DIR/$sc.sh" 2>/dev/null)
       [[ -z "$out" ]] && continue
-      # 形式 "ICON GAUGE(2字) PCT/PCT REMAINING"。ゲージは低%だと空白になり read の空白圧縮で
-      # ずれるため正規表現で抽出する。マッチしなければデータなし(ICON --)扱い。
-      if [[ "$out" =~ ^([^[:space:]]+)\ (..)\ ([0-9]+%/[0-9]+%)\ ?(.*)$ ]]; then
-        icon="${BASH_REMATCH[1]}"; gauge="${BASH_REMATCH[2]}"; pct="${BASH_REMATCH[3]}"; rem="${BASH_REMATCH[4]}"
-        printf '%s%s%s %s\n  %s%s %s%s\n' "$col" "$icon" "$C_RST" "$rem" "$col" "$gauge" "$pct" "$C_RST"
-      else
-        read -r icon _ <<< "$out"
-        printf '%s%s%s %s--%s\n' "$col" "$icon" "$C_RST" "$C_DIM" "$C_RST"
-      fi
+      # 各ウィンドウ1レコード "ICON\x1fLABEL\x1fGAUGE\x1fPCT\x1fREMAINING"。
+      # データ無しは "ICON\x1f--"。current/weekly を別ブロックで縦に並べる:
+      #   {icon} {label}
+      #     {gauge} {pct}  {remaining}
+      while IFS=$'\x1f' read -r icon label gauge pct rem; do
+        [[ -z "$icon" ]] && continue
+        if [[ "$label" == "--" ]]; then
+          printf '%s%s%s %s--%s\n' "$col" "$icon" "$C_RST" "$C_DIM" "$C_RST"
+        else
+          printf '%s%s%s %s%s%s\n' "$col" "$icon" "$C_RST" "$C_DIM" "$label" "$C_RST"
+          printf '  %s%s %s%s%s  %s%s\n' "$col" "$gauge" "$pct" "$C_RST" "$C_DIM" "$rem" "$C_RST"
+        fi
+      done <<< "$out"
     done
   } | tee "$USAGE_CACHE"
 }

--- a/scripts/tmux-claude-usage.sh
+++ b/scripts/tmux-claude-usage.sh
@@ -2,16 +2,21 @@
 # Claude Code 使用量表示 (tmux status-right 用)
 # OAuth トークンで使用量を取得しキャッシュ
 # macOS: Keychain, Linux: ~/.claude/.credentials.json
-# 出力: "󰛄 ▃▅ 42%/67% 2h15m" 形式のプレーンテキスト
-#   最後のフィールドは five_hour セッションが切れるまでの残り時間
+# 出力: サイドバー用の構造化レコード(1行=1ウィンドウ、区切りは US 0x1f)
+#   "<icon>\x1f<label>\x1f<gauge>\x1f<pct>\x1f<remaining>"  (current=five_hour / weekly=seven_day)
+#   データ無しは "<icon>\x1f--"
 #
-# キャッシュ形式: "<five_hour_pct>|<seven_day_pct>|<five_hour_resets_at_iso>"
+# キャッシュ形式: "<five_hour_pct>|<seven_day_pct>|<five_hour_resets_iso>|<seven_day_resets_iso>"
 # 残り時間はキャッシュ読み出し時に現在時刻から都度計算する
 
 CACHE_FILE="/tmp/tmux_claude_usage"
 CACHE_TTL=300  # 5分
 FAIL_FILE="${CACHE_FILE}.fail"
 FAIL_TTL=60    # API 失敗時のバックオフ秒数（tmux 再描画ごとの再試行を防ぐ）
+ICON="󰛄"
+
+# データ無しレコードを出力
+na() { printf '%s\x1f--\n' "$ICON"; }
 
 # クロスプラットフォーム mtime 取得
 get_mtime() {
@@ -21,35 +26,38 @@ get_mtime() {
   esac
 }
 
-# "<s>|<w>|<resets_at>" を受け取り表示文字列を出力
+# "<s>|<w>|<five_resets_iso>|<seven_resets_iso>" を受け取り2レコード出力
 render() {
-  python3 - "$1" "$2" "$3" <<'PY'
+  python3 - "$ICON" "$1" "$2" "$3" "$4" <<'PY'
 import sys
 from datetime import datetime, timezone
+US = '\x1f'
+icon = sys.argv[1]
+bars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
+def bar(v):
+  if v <= 0: return bars[0]
+  if v >= 100: return bars[8]
+  return bars[max(1, v * 8 // 100)]
+def remain(iso):
+  if not iso: return ''
+  try:
+    delta = int((datetime.fromisoformat(iso) - datetime.now(timezone.utc)).total_seconds())
+    if delta <= 0: return '0m'
+    total_min = delta // 60
+    h, m = divmod(total_min, 60)
+    if h >= 24:
+      d, h = divmod(h, 24)
+      return f'{d}d'
+    return f'{h}h{m:02d}m' if h > 0 else f'{m}m'
+  except Exception:
+    return ''
 try:
-  s = int(sys.argv[1])
-  w = int(sys.argv[2])
-  resets_at = sys.argv[3]
-  bars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
-  sb = bars[s * 8 // 100] if s < 100 else bars[8]
-  wb = bars[w * 8 // 100] if w < 100 else bars[8]
-  remaining = ''
-  if resets_at:
-    try:
-      reset_dt = datetime.fromisoformat(resets_at)
-      now = datetime.now(timezone.utc)
-      delta = int((reset_dt - now).total_seconds())
-      if delta <= 0:
-        remaining = ' 0m'
-      else:
-        total_min = delta // 60
-        h, m = divmod(total_min, 60)
-        remaining = f' {h}h{m:02d}m' if h > 0 else f' {m}m'
-    except Exception:
-      pass
-  print(f'󰛄 {sb}{wb} {s}%/{w}%{remaining}')
+  s = int(sys.argv[2]); w = int(sys.argv[3])
+  r5 = sys.argv[4]; r7 = sys.argv[5]
+  print(US.join([icon, 'current', bar(s), f'{s}%', remain(r5)]))
+  print(US.join([icon, 'weekly',  bar(w), f'{w}%', remain(r7)]))
 except Exception:
-  print('󰛄 --')
+  print(f'{icon}{US}--')
 PY
 }
 
@@ -57,9 +65,9 @@ PY
 if [[ -f "$CACHE_FILE" ]]; then
   age=$(( $(date +%s) - $(get_mtime "$CACHE_FILE") ))
   if (( age < CACHE_TTL )); then
-    IFS='|' read -r cs cw cresets < "$CACHE_FILE" 2>/dev/null
+    IFS='|' read -r cs cw cr5 cr7 < "$CACHE_FILE" 2>/dev/null
     if [[ -n "$cs" && -n "$cw" ]]; then
-      render "$cs" "$cw" "${cresets:-}"
+      render "$cs" "$cw" "${cr5:-}" "${cr7:-}"
       exit 0
     fi
   fi
@@ -69,7 +77,7 @@ fi
 if [[ -f "$FAIL_FILE" ]]; then
   fail_age=$(( $(date +%s) - $(get_mtime "$FAIL_FILE") ))
   if (( fail_age < FAIL_TTL )); then
-    echo "󰛄 --"
+    na
     exit 0
   fi
 fi
@@ -105,7 +113,7 @@ print(d['claudeAiOauth']['accessToken'])
 token=$(get_token)
 if [[ -z "$token" ]]; then
   touch "$FAIL_FILE"
-  echo "󰛄 --"
+  na
   exit 0
 fi
 
@@ -117,7 +125,7 @@ raw=$(curl -sf --max-time 5 \
 
 if [[ -z "$raw" ]]; then
   touch "$FAIL_FILE"
-  echo "󰛄 --"
+  na
   exit 0
 fi
 
@@ -127,19 +135,20 @@ try:
   d = json.load(sys.stdin)
   s = max(0, min(100, round(d['five_hour']['utilization'])))
   w = max(0, min(100, round(d['seven_day']['utilization'])))
-  r = d['five_hour'].get('resets_at') or ''
-  print(f'{s}|{w}|{r}')
+  r5 = d['five_hour'].get('resets_at') or ''
+  r7 = d['seven_day'].get('resets_at') or ''
+  print(f'{s}|{w}|{r5}|{r7}')
 except Exception:
   print('')
 " 2>/dev/null)
 
 if [[ -z "$parsed" ]]; then
   touch "$FAIL_FILE"
-  echo "󰛄 --"
+  na
   exit 0
 fi
 
 echo "$parsed" > "$CACHE_FILE"
 rm -f "$FAIL_FILE"
-IFS='|' read -r s w resets_at <<< "$parsed"
-render "$s" "$w" "$resets_at"
+IFS='|' read -r s w r5 r7 <<< "$parsed"
+render "$s" "$w" "$r5" "$r7"

--- a/scripts/tmux-codex-usage.sh
+++ b/scripts/tmux-codex-usage.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Codex (OpenAI) 使用量表示 (tmux status-right 用)
 # ~/.codex/auth.json の OAuth トークンで使用量を取得しキャッシュ
-# 出力: "OAI ▃▅ 42%/67% 2h15m" 形式のプレーンテキスト
-#   最後のフィールドは primary_window がリセットされるまでの残り時間
+# 出力: サイドバー用の構造化レコード(1行=1ウィンドウ、区切りは US 0x1f)
+#   "<icon>\x1f<label>\x1f<gauge>\x1f<pct>\x1f<remaining>" (current=primary / weekly=secondary)
+#   データ無しは "<icon>\x1f--"
 #
-# キャッシュ形式: "<primary_pct>|<secondary_pct>|<primary_resets_at_unix>"
+# キャッシュ形式: "<primary_pct>|<secondary_pct>|<primary_resets_unix>|<secondary_resets_unix>"
 # 残り時間はキャッシュ読み出し時に現在時刻から都度計算する
 
 CACHE_FILE="/tmp/tmux_codex_usage"
@@ -15,6 +16,9 @@ FAIL_TTL=60    # API 失敗時のバックオフ秒数
 AUTH_FILE="$HOME/.codex/auth.json"
 LABEL="󰝨"
 
+# データ無しレコードを出力
+na() { printf '%s\x1f--\n' "$LABEL"; }
+
 # クロスプラットフォーム mtime 取得
 get_mtime() {
   case "$(uname -s)" in
@@ -23,36 +27,38 @@ get_mtime() {
   esac
 }
 
-# "<s>|<w>|<resets_at_unix>" を受け取り表示文字列を出力
+# "<s>|<w>|<primary_resets_unix>|<secondary_resets_unix>" を受け取り2レコード出力
 render() {
-  python3 - "$1" "$2" "$3" "$LABEL" <<'PY'
+  python3 - "$LABEL" "$1" "$2" "$3" "$4" <<'PY'
 import sys
 from datetime import datetime, timezone
-label = sys.argv[4] if len(sys.argv) > 4 else 'OAI'
+US = '\x1f'
+icon = sys.argv[1]
+bars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
+def bar(v):
+  if v <= 0: return bars[0]
+  if v >= 100: return bars[8]
+  return bars[max(1, v * 8 // 100)]
+def remain(ts):
+  if not ts: return ''
+  try:
+    delta = int(ts) - int(datetime.now(timezone.utc).timestamp())
+    if delta <= 0: return '0m'
+    total_min = delta // 60
+    h, m = divmod(total_min, 60)
+    if h >= 24:
+      d, h = divmod(h, 24)
+      return f'{d}d'
+    return f'{h}h{m:02d}m' if h > 0 else f'{m}m'
+  except Exception:
+    return ''
 try:
-  s = int(sys.argv[1])
-  w = int(sys.argv[2])
-  resets_at = sys.argv[3]
-  bars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
-  sb = bars[s * 8 // 100] if s < 100 else bars[8]
-  wb = bars[w * 8 // 100] if w < 100 else bars[8]
-  remaining = ''
-  if resets_at:
-    try:
-      reset_ts = int(resets_at)
-      now_ts = int(datetime.now(timezone.utc).timestamp())
-      delta = reset_ts - now_ts
-      if delta <= 0:
-        remaining = ' 0m'
-      else:
-        total_min = delta // 60
-        h, m = divmod(total_min, 60)
-        remaining = f' {h}h{m:02d}m' if h > 0 else f' {m}m'
-    except Exception:
-      pass
-  print(f'{label} {sb}{wb} {s}%/{w}%{remaining}')
+  s = int(sys.argv[2]); w = int(sys.argv[3])
+  rp = sys.argv[4]; rsec = sys.argv[5]
+  print(US.join([icon, 'current', bar(s), f'{s}%', remain(rp)]))
+  print(US.join([icon, 'weekly',  bar(w), f'{w}%', remain(rsec)]))
 except Exception:
-  print(f'{label} --')
+  print(f'{icon}{US}--')
 PY
 }
 
@@ -60,9 +66,9 @@ PY
 if [[ -f "$CACHE_FILE" ]]; then
   age=$(( $(date +%s) - $(get_mtime "$CACHE_FILE") ))
   if (( age < CACHE_TTL )); then
-    IFS='|' read -r cs cw cresets < "$CACHE_FILE" 2>/dev/null
+    IFS='|' read -r cs cw crp crsec < "$CACHE_FILE" 2>/dev/null
     if [[ -n "$cs" && -n "$cw" ]]; then
-      render "$cs" "$cw" "${cresets:-}"
+      render "$cs" "$cw" "${crp:-}" "${crsec:-}"
       exit 0
     fi
   fi
@@ -72,7 +78,7 @@ fi
 if [[ -f "$FAIL_FILE" ]]; then
   fail_age=$(( $(date +%s) - $(get_mtime "$FAIL_FILE") ))
   if (( fail_age < FAIL_TTL )); then
-    echo "$LABEL --"
+    na
     exit 0
   fi
 fi
@@ -80,7 +86,7 @@ fi
 # auth.json は Mac/Linux 共通でプレーンテキスト保存（macOS Keychain は使わない）
 if [[ ! -f "$AUTH_FILE" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
@@ -113,7 +119,7 @@ PY
 
 if [[ -z "$token" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
@@ -131,12 +137,14 @@ raw=$(curl "${curl_args[@]}" "https://chatgpt.com/backend-api/wham/usage" 2>/dev
 
 if [[ -z "$raw" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
 parsed=$(echo "$raw" | python3 -c "
 import sys, json
+def ts(v):
+  return str(int(v)) if v is not None else ''
 try:
   d = json.load(sys.stdin)
   rl = d.get('rate_limit') or {}
@@ -146,20 +154,20 @@ try:
   w = int(round(sw.get('used_percent') or 0))
   s = max(0, min(100, s))
   w = max(0, min(100, w))
-  r = pw.get('reset_at')
-  r_str = str(int(r)) if r is not None else ''
-  print(f'{s}|{w}|{r_str}')
+  rp = ts(pw.get('reset_at'))
+  rsec = ts(sw.get('reset_at'))
+  print(f'{s}|{w}|{rp}|{rsec}')
 except Exception:
   print('')
 " 2>/dev/null)
 
 if [[ -z "$parsed" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
 echo "$parsed" > "$CACHE_FILE"
 rm -f "$FAIL_FILE"
-IFS='|' read -r s w resets_at <<< "$parsed"
-render "$s" "$w" "$resets_at"
+IFS='|' read -r s w rp rsec <<< "$parsed"
+render "$s" "$w" "$rp" "$rsec"

--- a/scripts/tmux-cursor-usage.sh
+++ b/scripts/tmux-cursor-usage.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Cursor Agent 使用量表示 (tmux status-right 用)
 # cursor-agent OAuth トークンで api2.cursor.sh から取得しキャッシュ
-# 出力: "◆ ▃▅ 20%/3% 12d" 形式 (total% / auto% + 請求周期終了まで)
+# 出力: サイドバー用の構造化レコード(1行=1ウィンドウ、区切りは US 0x1f)
+#   "<icon>\x1f<label>\x1f<gauge>\x1f<pct>\x1f<remaining>" (total / auto、いずれも請求周期末まで)
+#   データ無しは "<icon>\x1f--"
 #
 # キャッシュ形式: "<total_pct>|<auto_pct>|<billing_cycle_end_ms>"
 
@@ -14,6 +16,9 @@ FAIL_TTL=60
 LABEL="◆"
 API_BASE="${CURSOR_API_BASE:-https://api2.cursor.sh}"
 
+# データ無しレコードを出力
+na() { printf '%s\x1f--\n' "$LABEL"; }
+
 get_mtime() {
   case "$(uname -s)" in
     Darwin) stat -f %m "$1" 2>/dev/null || echo 0 ;;
@@ -21,51 +26,46 @@ get_mtime() {
   esac
 }
 
+# "<total>|<auto>|<billing_end_ms>" を受け取り2レコード出力(total / auto)
 render() {
-  python3 - "$1" "$2" "$3" "$LABEL" <<'PY'
+  python3 - "$LABEL" "$1" "$2" "$3" <<'PY'
 import sys
 from datetime import datetime, timezone
-
-label = sys.argv[4] if len(sys.argv) > 4 else "◆"
+US = "\x1f"
+icon = sys.argv[1]
+bars = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
+# 0%は空白、それ以外は最低でも▁を表示(低%でゲージが不可視になるのを防ぐ)
+def bar(v):
+    if v <= 0:
+        return bars[0]
+    if v >= 100:
+        return bars[8]
+    return bars[max(1, v * 8 // 100)]
+def remain(ts):
+    if not ts:
+        return ""
+    try:
+        reset_ts = int(ts)
+        if reset_ts > 10_000_000_000:
+            reset_ts //= 1000
+        delta = reset_ts - int(datetime.now(timezone.utc).timestamp())
+        if delta <= 0:
+            return "0m"
+        total_min = delta // 60
+        h, m = divmod(total_min, 60)
+        if h >= 24:
+            d, h = divmod(h, 24)
+            return f"{d}d" if d > 0 else f"{h}h{m:02d}m"
+        return f"{h}h{m:02d}m" if h > 0 else f"{m}m"
+    except Exception:
+        return ""
 try:
-    s = int(sys.argv[1])
-    w = int(sys.argv[2])
-    resets_at = sys.argv[3]
-    bars = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
-    # 0%は空白、それ以外は最低でも▁を表示(低%でゲージが不可視になるのを防ぐ)
-    def bar(v):
-        if v <= 0:
-            return bars[0]
-        if v >= 100:
-            return bars[8]
-        return bars[max(1, v * 8 // 100)]
-    sb = bar(s)
-    wb = bar(w)
-    remaining = ""
-    if resets_at:
-        try:
-            reset_ts = int(resets_at)
-            if reset_ts > 10_000_000_000:
-                reset_ts //= 1000
-            now_ts = int(datetime.now(timezone.utc).timestamp())
-            delta = reset_ts - now_ts
-            if delta <= 0:
-                remaining = " 0m"
-            else:
-                total_min = delta // 60
-                h, m = divmod(total_min, 60)
-                if h >= 24:
-                    d, h = divmod(h, 24)
-                    remaining = f" {d}d" if d > 0 else f" {h}h{m:02d}m"
-                elif h > 0:
-                    remaining = f" {h}h{m:02d}m"
-                else:
-                    remaining = f" {m}m"
-        except Exception:
-            pass
-    print(f"{label} {sb}{wb} {s}%/{w}%{remaining}")
+    s = int(sys.argv[2]); w = int(sys.argv[3])
+    rem = remain(sys.argv[4])
+    print(US.join([icon, "total", bar(s), f"{s}%", rem]))
+    print(US.join([icon, "auto",  bar(w), f"{w}%", rem]))
 except Exception:
-    print(f"{label} --")
+    print(f"{icon}{US}--")
 PY
 }
 
@@ -83,14 +83,14 @@ fi
 if [[ -f "$FAIL_FILE" ]]; then
   fail_age=$(( $(date +%s) - $(get_mtime "$FAIL_FILE") ))
   if (( fail_age < FAIL_TTL )); then
-    echo "$LABEL --"
+    na
     exit 0
   fi
 fi
 
 token=$("$SCRIPT_DIR/cursor-auth-token.sh" 2>/dev/null) || {
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 }
 
@@ -112,7 +112,7 @@ fi
 
 if [[ -z "$raw" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
@@ -152,7 +152,7 @@ except Exception:
 
 if [[ -z "$parsed" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 

--- a/scripts/tmux-gemini-usage.sh
+++ b/scripts/tmux-gemini-usage.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # Gemini CLI 使用量表示 (tmux status-right 用)
 # ~/.gemini/oauth_creds.json の Google OAuth トークンで Code Assist quota を取得
-# 出力例: "󰫢 ▄▆ 50%/75% 18h22m" (top2 most-used buckets / 最も早いリセット残り時間)
+# 出力: サイドバー用の構造化レコード(1行=1ウィンドウ、区切りは US 0x1f)
+#   "<icon>\x1f<label>\x1f<gauge>\x1f<pct>\x1f<remaining>" (top2 most-used buckets を current/weekly)
+#   データ無しは "<icon>\x1f--"
 #
-# キャッシュ形式: "<used1_pct>|<used2_pct>|<reset_time_iso>"
+# キャッシュ形式: "<used1_pct>|<used2_pct>|<reset1_iso>|<reset2_iso>"
 
 CACHE_FILE="/tmp/tmux_gemini_usage"
 CACHE_TTL=300
@@ -14,6 +16,9 @@ CREDS_FILE="$HOME/.gemini/oauth_creds.json"
 PROJECTS_FILE="$HOME/.gemini/projects.json"
 LABEL="󰫢"
 
+# データ無しレコードを出力
+na() { printf '%s\x1f--\n' "$LABEL"; }
+
 get_mtime() {
   case "$(uname -s)" in
     Darwin) stat -f %m "$1" 2>/dev/null || echo 0 ;;
@@ -21,35 +26,39 @@ get_mtime() {
   esac
 }
 
+# "<s>|<w>|<reset1_iso>|<reset2_iso>" を受け取り2レコード出力
 render() {
-  python3 - "$1" "$2" "$3" "$LABEL" <<'PY'
+  python3 - "$LABEL" "$1" "$2" "$3" "$4" <<'PY'
 import sys
 from datetime import datetime, timezone
-label = sys.argv[4] if len(sys.argv) > 4 else ''
+US = '\x1f'
+icon = sys.argv[1]
+bars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
+def bar(v):
+  if v <= 0: return bars[0]
+  if v >= 100: return bars[8]
+  return bars[max(1, v * 8 // 100)]
+def remain(iso):
+  if not iso: return ''
+  try:
+    reset_dt = datetime.fromisoformat(iso.replace('Z', '+00:00'))
+    delta = int((reset_dt - datetime.now(timezone.utc)).total_seconds())
+    if delta <= 0: return '0m'
+    total_min = delta // 60
+    h, m = divmod(total_min, 60)
+    if h >= 24:
+      d, h = divmod(h, 24)
+      return f'{d}d'
+    return f'{h}h{m:02d}m' if h > 0 else f'{m}m'
+  except Exception:
+    return ''
 try:
-  s = int(sys.argv[1])
-  w = int(sys.argv[2])
-  resets_at = sys.argv[3]
-  bars = [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
-  sb = bars[s * 8 // 100] if s < 100 else bars[8]
-  wb = bars[w * 8 // 100] if w < 100 else bars[8]
-  remaining = ''
-  if resets_at:
-    try:
-      reset_dt = datetime.fromisoformat(resets_at.replace('Z', '+00:00'))
-      now = datetime.now(timezone.utc)
-      delta = int((reset_dt - now).total_seconds())
-      if delta <= 0:
-        remaining = ' 0m'
-      else:
-        total_min = delta // 60
-        h, m = divmod(total_min, 60)
-        remaining = f' {h}h{m:02d}m' if h > 0 else f' {m}m'
-    except Exception:
-      pass
-  print(f'{label} {sb}{wb} {s}%/{w}%{remaining}')
+  s = int(sys.argv[2]); w = int(sys.argv[3])
+  r1 = sys.argv[4]; r2 = sys.argv[5]
+  print(US.join([icon, 'current', bar(s), f'{s}%', remain(r1)]))
+  print(US.join([icon, 'weekly',  bar(w), f'{w}%', remain(r2)]))
 except Exception:
-  print(f'{label} --')
+  print(f'{icon}{US}--')
 PY
 }
 
@@ -57,9 +66,9 @@ PY
 if [[ -f "$CACHE_FILE" ]]; then
   age=$(( $(date +%s) - $(get_mtime "$CACHE_FILE") ))
   if (( age < CACHE_TTL )); then
-    IFS='|' read -r cs cw cresets < "$CACHE_FILE" 2>/dev/null
+    IFS='|' read -r cs cw cr1 cr2 < "$CACHE_FILE" 2>/dev/null
     if [[ -n "$cs" && -n "$cw" ]]; then
-      render "$cs" "$cw" "${cresets:-}"
+      render "$cs" "$cw" "${cr1:-}" "${cr2:-}"
       exit 0
     fi
   fi
@@ -69,12 +78,12 @@ fi
 if [[ -f "$FAIL_FILE" ]]; then
   fail_age=$(( $(date +%s) - $(get_mtime "$FAIL_FILE") ))
   if (( fail_age < FAIL_TTL )); then
-    echo "$LABEL --"
+    na
     exit 0
   fi
 fi
 
-[[ -f "$CREDS_FILE" ]] || { touch "$FAIL_FILE"; echo "$LABEL --"; exit 0; }
+[[ -f "$CREDS_FILE" ]] || { touch "$FAIL_FILE"; na; exit 0; }
 
 # access_token / expiry_date を読む。
 # 期限切れトークンは gemini CLI を一度起動すれば自動リフレッシュされる。
@@ -94,7 +103,7 @@ PY
 
 if [[ -z "$access_token" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
@@ -102,7 +111,7 @@ fi
 now_ms=$(( $(date +%s) * 1000 ))
 if [[ -n "$expiry_date" && "$expiry_date" =~ ^[0-9]+$ ]] && (( expiry_date < now_ms )); then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
@@ -137,7 +146,7 @@ raw=$(curl -sf --max-time 5 \
 
 if [[ -z "$raw" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
@@ -158,22 +167,23 @@ try:
     print(''); raise SystemExit(0)
   scored.sort(key=lambda x: x[0], reverse=True)
   s = int(round(scored[0][0] * 100))
-  w = int(round(scored[1][0] * 100)) if len(scored) > 1 else s
-  # 最も早いリセット時刻
-  reset_candidates = [r for _, r, _ in scored if r]
-  r = min(reset_candidates) if reset_candidates else ''
-  print(f'{s}|{w}|{r}')
+  r1 = scored[0][1] or ''
+  if len(scored) > 1:
+    w = int(round(scored[1][0] * 100)); r2 = scored[1][1] or ''
+  else:
+    w = s; r2 = r1
+  print(f'{s}|{w}|{r1}|{r2}')
 except Exception:
   print('')
 " 2>/dev/null)
 
 if [[ -z "$parsed" ]]; then
   touch "$FAIL_FILE"
-  echo "$LABEL --"
+  na
   exit 0
 fi
 
 echo "$parsed" > "$CACHE_FILE"
 rm -f "$FAIL_FILE"
-IFS='|' read -r s w resets_at <<< "$parsed"
-render "$s" "$w" "$resets_at"
+IFS='|' read -r s w r1 r2 <<< "$parsed"
+render "$s" "$w" "$r1" "$r2"


### PR DESCRIPTION
## 変更

サイドバー USAGE を current/週間 の別ブロック表示にし、各ウィンドウごとの残り時間を表示する。

```
󰛄 current
  ▁ 16%  3h41m
󰛄 weekly
  ▃ 43%  6d
󰝨 --
󰫢 --
◆ total
  ▁ 4%  20d
◆ auto
  ▁ 5%  20d
```

- 各 usage スクリプトの出力を構造化レコード化(`ICON\x1fLABEL\x1fGAUGE\x1fPCT\x1fREMAINING`、1行=1ウィンドウ、データ無しは `ICON\x1f--`)。
- 2ウィンドウ分の reset 時刻を取得: claude=five_hour/seven_day, codex=primary/secondary, gemini=top2 buckets, cursor=total/auto(請求周期末)。
- 低%でゲージが不可視になる問題を全スクリプトで `▁` 最低表示に統一。

## 確認
- shellcheck CLEAN (5ファイル)
- 各スクリプトのレコード出力を確認(claude は weekly 残り 6d も表示)
- サイドバー render でブロックレイアウトを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)