### PR TITLE
fix(notify): cursor の total を included 枠消化率に修正

### DIFF
--- a/scripts/tmux-cursor-usage.sh
+++ b/scripts/tmux-cursor-usage.sh
@@ -122,7 +122,14 @@ try:
   d = json.load(sys.stdin)
   pu = d.get('planUsage') or {}
   if pu:
-    s = int(round(float(pu.get('totalPercentUsed') or 0)))
+    # total = included 枠の消化率(Cursor UI の 'X% of your included usage' と一致)。
+    # includedSpend/limit を優先し、無ければ totalPercentUsed にフォールバック。
+    limit = float(pu.get('limit') or 0)
+    spend = float(pu.get('includedSpend') or pu.get('totalSpend') or 0)
+    if limit > 0:
+      s = int(round(spend * 100 / limit))
+    else:
+      s = int(round(float(pu.get('totalPercentUsed') or 0)))
     w = int(round(float(pu.get('autoPercentUsed') or pu.get('apiPercentUsed') or 0)))
     s = max(0, min(100, s))
     w = max(0, min(100, w))


### PR DESCRIPTION
cursor USAGE の `total` が `totalPercentUsed`(枠消化と無関係な低い値、例 4%)を表示していた。Cursor 自身の UI は「You've used 41% of your included usage」と表示しており、これは `includedSpend/limit`(820/2000=41%)。`total` をこの included 枠消化率に修正。

- `includedSpend`(無ければ `totalSpend`)/`limit` で算出
- `limit` 不在時は従来の `totalPercentUsed` にフォールバック
- `auto` は `autoPercentUsed`(5%)のまま

## 確認
- shellcheck CLEAN
- 出力 `◆ total 41% / auto 5%` を確認(API の 41% included usage と一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)