### PR TITLE
feat: Make tmux RAM widget swap-aware and surface top consumer

### DIFF
--- a/scripts/tmux-ram.sh
+++ b/scripts/tmux-ram.sh
@@ -31,18 +31,24 @@ if [[ -f "$CACHE_FILE" ]]; then
 fi
 
 ram_pct=""
+swap_pct=""  # used swap as percent of total; "" when unknown (e.g. macOS)
 
 case "$(uname -s)" in
   Linux)
-    # /proc/meminfo: MemTotal and MemAvailable (kernel 3.14+)
+    # /proc/meminfo: MemTotal/MemAvailable (kernel 3.14+) and swap
     while IFS=': ' read -r key val _; do
       case "$key" in
         MemTotal) mem_total=$val ;;
         MemAvailable) mem_avail=$val ;;
+        SwapTotal) swap_total=$val ;;
+        SwapFree) swap_free=$val ;;
       esac
     done < /proc/meminfo
     if [[ -n "$mem_total" && -n "$mem_avail" && "$mem_total" -gt 0 ]]; then
       ram_pct=$(( (mem_total - mem_avail) * 100 / mem_total ))
+    fi
+    if [[ -n "${swap_total:-}" && "$swap_total" -gt 0 && -n "${swap_free:-}" ]]; then
+      swap_pct=$(( (swap_total - swap_free) * 100 / swap_total ))
     fi
     ;;
   Darwin)
@@ -71,14 +77,30 @@ case "$(uname -s)" in
 esac
 
 if [[ -n "$ram_pct" && "$ram_pct" =~ ^[0-9]+$ ]]; then
-  if [[ $ram_pct -ge 90 ]]; then
-    color="#f7768e"  # red - high
+  swap_pct=${swap_pct:-0}
+  # Critical when RAM is nearly full OR swap is under real pressure. The swap
+  # term matters: a thrashing host can sit at ~88% RAM (sub-90) while swap is
+  # exhausted -- RAM% alone would stay yellow and hide the problem.
+  critical=0
+  if [[ $ram_pct -ge 90 || $swap_pct -ge 50 ]]; then
+    color="#f7768e"; critical=1  # red - critical
   elif [[ $ram_pct -ge 70 ]]; then
-    color="#e0af68"  # yellow - medium
+    color="#e0af68"              # yellow - medium
   else
-    color="#9ece6a"  # green - low
+    color="#9ece6a"              # green - low
   fi
   result="#[fg=#a9b1d6,bg=$BG]$RAM_ICON #[fg=$color,bg=$BG]$(printf '%2d%%' "$ram_pct")"
+  if [[ $critical -eq 1 ]]; then
+    # Surface what to act on: show swap when it is the trigger, and name the
+    # single largest RSS process. ps/sort run only on this rare critical path.
+    extra=""
+    [[ $swap_pct -ge 50 ]] && extra="sw$(printf '%d%%' "$swap_pct") "
+    read -r top_kb top_comm < <(ps axo rss=,comm= 2>/dev/null | sort -rn | head -1)
+    if [[ -n "${top_kb:-}" && "$top_kb" =~ ^[0-9]+$ ]]; then
+      extra="${extra}${top_comm##*/} $(( top_kb / 1048576 )).$(( (top_kb % 1048576) * 10 / 1048576 ))G"
+    fi
+    [[ -n "$extra" ]] && result="$result #[fg=#545c7e,bg=$BG]$extra"
+  fi
 else
   result="#[fg=#a9b1d6,bg=$BG]$RAM_ICON #[fg=#545c7e,bg=$BG]--"
 fi


### PR DESCRIPTION
## 実装内容

tmux ステータスバーの RAM ウィジェット (`scripts/tmux-ram.sh`) を swap 考慮にし、メモリ逼迫が深刻なときだけ原因プロセスを表示する。

従来は RAM 使用率 >= 90% でのみ pill を赤くし、swap を一切見ていなかった。swap が枯渇してスラッシングしているホストでも RAM 使用率が 90% 未満 (例 88%) だと黄色のままで逼迫を見逃す。実際にホストが重くなった際、RAM 88% / swap 100% の状態が黄色どまりだった。

変更後の挙動:

- 深刻度判定に swap を追加。RAM >= 90% または swap 使用率 >= 50% で赤 (critical)
- critical 時のみ、swap が誘因なら swap 使用率を、さらに最大 RSS プロセス名とサイズを pill に併記 (例: `sw90% nvim 49.0G`)
- 平常時のレンダリングは従来どおり

## 技術詳細

- `ps`/`sort` は critical の稀なパスでのみ実行。平常時の負荷増および 3 秒キャッシュは変更なし
- 最大消費プロセスは `ps axo rss=,comm= | sort -rn | head -1` でポータブルに取得 (GNU 依存の `--sort` を避け macOS でも動作)。プロセス名は `${comm##*/}` で basename 化
- `%` はリテラル 1 個 (`printf '%%'`) で従来どおり tmux status 上で正しく表示される (既存 widget と同じ扱い)
- 生成物であるテーマファイル (`tokyonight.tmux` 等) は `tmux-ram.sh` を呼ぶだけなので再生成不要。全テーマに反映される

動作確認:

- `bash -n` 構文チェック OK
- 実機ライブ実行: 平常時 (RAM 39%) は緑 pill、原因プロセス非表示で従来どおり
- critical シミュレーション (RAM 88% / swap 90%): 赤 pill + `sw90% <proc> N.NG` を確認

## 画像・動画

該当なし (ステータスバー文字列の変更。critical 時の表示例は技術詳細に記載)

---

## PR チェックリスト

### PR の内容

- [ ] 適切な PR の説明が記載されている
- [ ] UI に関する変更がある場合は、スクリーンショットや動画を添付した
- [ ] 変更した全てのコードについて、なぜその実装にしたのか説明できる

### production データベースへの影響

- [ ] 本番データに影響する変更がある場合はそれを処理する migration を実装した
- [ ] 本番データに影響する変更の場合、本番相当データでの動作を確認した（`pnpm db:preflight`）

### 最終確認

- [ ] 上記の該当する箇所全てにチェックをつけた。チェックがついていない部分については該当しないか意図的にチェックを外している
