### PR TITLE
fix: Exclude file-op and git commands from rtk digest

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -778,6 +778,7 @@ main() {
 
   # 4.5. Configure rtk Claude Code hook (token compression)
   configure_rtk_claude_hook
+  configure_rtk_passthrough
 
   # 4.6. Disable Serena MCP dashboard auto-open
   configure_serena_dashboard
@@ -863,6 +864,43 @@ configure_rtk_claude_hook() {
   else
     log_warn "rtk init -g --auto-patch failed (non-fatal)"
   fi
+}
+
+# rtk's heuristic digest corrupts machine-readable output: it truncates long
+# file reads, caps grep/ls results, mangles git porcelain, and has even
+# fabricated content. List the file-op and git commands in
+# [hooks].exclude_commands of ~/.config/rtk/config.toml so they pass through
+# raw, while test/lint/typecheck/build commands stay digested (where the token
+# savings actually are). Idempotent: rewrites only the exclude_commands array,
+# preserving rtk's other (machine-local) keys such as telemetry consent.
+configure_rtk_passthrough() {
+  command_exists rtk || return 0
+  local cfg="${XDG_CONFIG_HOME:-$HOME/.config}/rtk/config.toml"
+  [[ -f "$cfg" ]] || rtk config --create >/dev/null 2>&1 || true
+  [[ -f "$cfg" ]] || { log_warn "rtk config.toml absent, skipping passthrough setup"; return 0; }
+
+  python3 - "$cfg" <<'PYEOF'
+import re, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    text = f.read()
+
+excluded = ["cat", "head", "tail", "sed", "awk", "ls", "grep", "rg", "find", "wc", "git"]
+array = "exclude_commands = [\n" + "".join(f'    "{c}",\n' for c in excluded) + "]"
+
+pattern = re.compile(r'exclude_commands\s*=\s*\[[^\]]*\]')
+if pattern.search(text):
+    text = pattern.sub(array, text, count=1)
+elif re.search(r'^\[hooks\]\s*$', text, re.M):
+    text = re.sub(r'(^\[hooks\][^\n]*\n)', r'\1' + array + "\n", text, count=1, flags=re.M)
+else:
+    text = text.rstrip() + "\n\n[hooks]\n" + array + "\n"
+
+with open(path, "w") as f:
+    f.write(text)
+PYEOF
+  log_success "  rtk: file-op/git commands pass through raw (savings kept for test/lint/build)"
 }
 
 # --- 4.6. Disable Serena MCP dashboard auto-open ---


### PR DESCRIPTION
## 実装内容

install.sh に `configure_rtk_passthrough` を追加し、rtk の digest が出力を破壊するコマンド (file ops と git) を `~/.config/rtk/config.toml` の `[hooks].exclude_commands` に登録して raw 素通しにする。

rtk のヒューリスティック digest は機械可読出力を壊す: 長いファイル読みを `passthrough_max_chars` で truncate し、grep/ls の結果を上限で打ち切り、git porcelain を変形し、さらにファイル内容を捏造することすらある。実作業中にこれらで読み取り・編集の前提が崩れた。

test/lint/typecheck/build は引き続き digest され、token 節約はそこで維持される。

## 技術詳細

- 対象除外コマンド: cat, head, tail, sed, awk, ls, grep, rg, find, wc, git
- パッチは冪等。`exclude_commands` 配列のみを書き換え、rtk が所有する他の machine-local キー (telemetry consent_date 等) は保持する
- `[hooks]` テーブルや `exclude_commands` キーが無い場合も挿入/追記で対応
- `configure_rtk_claude_hook` は「設定済み」で早期 return するため、除外設定は独立関数として無条件に実行する
- config が無ければ `rtk config --create` で生成してからパッチ

動作確認:

- `bash -n install.sh` 構文 OK
- 冪等性: 同パッチを2回実行しても安定。tomllib で妥当な TOML としてパースでき、telemetry consent_date が保持されることを確認
- 実証: 除外後、素の `grep`/`cat` が大きいファイル (1017 行) を truncate なし・上限なしで全件返すことを確認

## 画像・動画

該当なし (CLI 設定スクリプトの変更)

---

## PR チェックリスト

### PR の内容

- [ ] 適切な PR の説明が記載されている
- [ ] UI に関する変更がある場合は、スクリーンショットや動画を添付した
- [ ] 変更した全てのコードについて、なぜその実装にしたのか説明できる

### production データベースへの影響

- [ ] 本番データに影響する変更がある場合はそれを処理する migration を実装した
- [ ] 本番データに影響する変更の場合、本番相当データでの動作を確認した（`pnpm db:preflight`）

### 最終確認

- [ ] 上記の該当する箇所全てにチェックをつけた。チェックがついていない部分については該当しないか意図的にチェックを外している
