### PR TITLE
feat(tmux): エージェント popup を swap-pane 方式の live ビューに刷新

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -143,10 +143,14 @@ bind -r n select-window -t :+
 bind s choose-tree -Zs -O name
 bind Tab switch-client -l
 
-# AI Agent 横断ビュー: 停止中エージェント一覧を popup 表示し、選択でジャンプ
-# display-popup のコマンドは #{pane_id} を展開しないため、run-shell(展開する)で現在 pane を
-# グローバルオプションに保存してから popup を開く(popup 内で現在 pane を枠線強調するのに使用)
-bind a run-shell "tmux set-option -g @agent_cur_pane '#{pane_id}'" \; display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
+# AI Agent 横断ビュー: popup 内にセレクタ + 選択エージェントの実ペインを swap-pane で表示。
+# open が scratch session(_agentpop)でセレクタを起動し、display-popup がそれを attach。
+# j/k 選択で該当エージェント実ペインを blank と swap して右に live 表示(元 window は構造保持・
+# 該当スロットが一時 blank になるだけ)、Tab で右の実ペインへフォーカスして操作、Enter で元 client
+# を該当ペインへジャンプ、q で閉じる(swap 中の実ペインは selector 終了時に元へ戻す)。
+# 末尾の run-shell jump: popup client では switch-client できないため、popup を閉じた後に
+# 元 client コンテキストで selector が記録した target へ飛ぶ。
+bind a run-shell "~/dotfiles/scripts/tmux-agent-status.sh open" \; display-popup -E -w 85% -h 75% 'sock="${TMUX%%,*}"; TMUX= exec tmux -S "$sock" attach -t _agentpop 2>/dev/null' \; run-shell "~/dotfiles/scripts/tmux-agent-status.sh jump"
 # AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
 # (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
 bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 STATUS_DIR="${AGENT_STATUS_DIR:-/tmp/claude/status}"
+JUMP_FILE="/tmp/claude/agentpop-jump"
 US=$'\x1f'
 
 C_RED=$'\e[38;5;203m'; C_AMBER=$'\e[38;5;214m'; C_DIM=$'\e[2m'; C_BOLD=$'\e[1m'; C_RST=$'\e[0m'
@@ -147,7 +148,7 @@ render_preview() {
     branch=$(branch_of "$path"); tool=$(tool_of "$cmd")
     printf '%s%s · %s · %s%s\n' "$C_DIM" "$target" "$tool" "$branch" "$C_RST"
     printf '%sタスク%s %s\n' "$C_BOLD" "$C_RST" "$title"
-    local cap needs; cap=$(tmux capture-pane -p -S -40 -t "$target" 2>/dev/null)
+    local cap needs; cap=$(tmux capture-pane -p -e -S -200 -t "$target" 2>/dev/null)
     needs=$(extract_needs "$status" "$cap")
     [[ -n "$needs" ]] && printf '%s%s%s\n' "$col" "$needs" "$C_RST"
     printf '%s%s%s\n' "$C_DIM" "────────────────────────────" "$C_RST"
@@ -157,6 +158,12 @@ render_preview() {
     printf 'jump: %s\n' "$target"
   fi
 }
+
+# --- prefix+a エージェントビュー(swap-pane 方式) ---
+# popup 右に blank placeholder を置き、選択エージェントの実ペインを swap-pane で blank と交換して
+# 表示する。swap-pane は中身だけ入替えるため元 window の構造(ペイン数/位置/サイズ)は不変で、
+# 該当スロットが一時 blank になるだけ。右は実ペインそのものなので live かつ Tab で操作可能。
+# 下記 selector / view-switch / view-focus / blankpane アクション。
 
 # source された場合(サイドバー等がヘルパー再利用)はディスパッチしない
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
@@ -190,6 +197,118 @@ case "${1:-popup}" in
     else
       tmux set-option -p -t "$p" @agent_stashed 1 2>/dev/null || true
     fi
+    ;;
+  open)
+    # prefix+a エントリ(binding の display-popup 前段)。scratch session でセレクタを起動するだけ。
+    # popup(binding 側)がこの session を attach し、中に [セレクタ | 選択エージェント実ペイン] を表示。
+    origin=$(tmux display-message -p '#{pane_id}' 2>/dev/null)
+    rows=$(build_rows)
+    if [[ -z "$rows" ]]; then tmux display-message "停止中のエージェントなし"; exit 0; fi
+    tmux kill-session -t _agentpop 2>/dev/null || true   # 残骸掃除
+    mkdir -p "$(dirname "$JUMP_FILE")" 2>/dev/null || true
+    rm -f "$JUMP_FILE" 2>/dev/null || true
+    tmux new-session -d -s _agentpop "exec '$SELF' selector '$origin'"
+    # 入れ子表示(status bar / pane 境界タイトル)を消して popup を単一画面に見せる。
+    tmux set-option -t _agentpop status off 2>/dev/null || true
+    tmux set-option -t _agentpop pane-border-status off 2>/dev/null || true
+    # detach-on-destroy on: kill-session 時に popup client を別 session へ切替えず終了させる。
+    # グローバル off のままだと popup 内に MAIN が出て閉じた後に二重化する。
+    tmux set-option -t _agentpop detach-on-destroy on 2>/dev/null || true
+    ;;
+  selector)
+    origin="${2:-}"
+    sel=$(tmux display-message -p '#{pane_id}' 2>/dev/null)
+    tmux set-option -p -t "$sel" @av_swapped "" 2>/dev/null || true
+    tmux set-option -p -t "$sel" @av_blank "" 2>/dev/null || true
+    # 単一ペインで起動。初回 focus で右に blank placeholder を遅延生成し、選択エージェントの実ペインを
+    # swap-pane で blank と交換 → 右に実ペイン(live・操作可)を表示する。swap-pane は中身だけ入替え
+    # 元 window の構造(ペイン数/位置/サイズ)を保つため、元 window は該当スロットが一時 blank に
+    # なるだけで崩れない。Tab で右(実ペイン)へフォーカスして操作、Enter でその場へジャンプ。
+    sel_out=$(build_rows | to_fzf_records \
+      | fzf --read0 --ansi --delimiter=$'\t' --with-nth=3 --no-sort --reverse --height=100% --gap --cycle \
+            --prompt 'agent> ' \
+            --header 'j/k:移動  Tab:右で操作(C-Space o で戻る)  Enter:ジャンプ  r:再走査  s:stash  /:検索  q:閉じる' \
+            --bind "focus:execute-silent(bash '$SELF' view-switch {1} '$sel')" \
+            --bind "tab:execute-silent(bash '$SELF' view-focus '$sel')" \
+            --bind 'g:first,G:last' \
+            --bind 'j:down+transform:[ {2} = divider ] && echo down' \
+            --bind 'k:up+transform:[ {2} = divider ] && echo up' \
+            --bind 'down:down+transform:[ {2} = divider ] && echo down' \
+            --bind 'up:up+transform:[ {2} = divider ] && echo up' \
+            --bind 'ctrl-d:half-page-down+transform:[ {2} = divider ] && echo down' \
+            --bind 'ctrl-u:half-page-up+transform:[ {2} = divider ] && echo up' \
+            --bind 'load:transform:[ {2} = divider ] && echo down' \
+            --bind "r:reload(bash '$SELF' rescan)" \
+            --bind 'q:abort' \
+            --bind "s:reload(bash '$SELF' stash-toggle {1}; bash '$SELF' rescan)" \
+            --bind 'change:clear-query' \
+            --bind '/:unbind(change)+unbind(j,k,g,G,r,q,s)+change-prompt(検索> )' \
+            --bind 'enter:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "rebind(j,k,g,G,r,q,s)+change-prompt(agent> )" || echo accept' \
+            --bind 'esc:transform:[ "$FZF_PROMPT" = "検索> " ] && echo "rebind(change,j,k,g,G,r,q,s)+clear-query+change-prompt(agent> )" || echo abort' \
+            --color 'pointer:203,marker:214') || true
+    # accept(Enter)された target を jump file に記録 → popup を閉じた後に binding 末尾の
+    # run-shell jump が元 client を該当ペインへ switch する(popup client では switch できない)。
+    target=$(printf '%s' "$sel_out" | head -1 | cut -f1)
+    if [[ -n "$target" && "$target" != "-" && "$target" != "divider" ]]; then
+      printf '%s' "$target" > "$JUMP_FILE" 2>/dev/null || true
+    fi
+    # 後始末(最重要): swap 中の実ペインを元 window へ戻してから session kill。戻さず kill すると
+    # 実ペインが _agentpop もろとも kill されエージェントが死ぬ。popup は selector(fzf)終了でしか
+    # 閉じない(q/esc → ここで cleanup)ので、この経路で必ず swap back される。
+    cur=$(tmux show-options -p -t "$sel" -qv @av_swapped 2>/dev/null || true)
+    blank=$(tmux show-options -p -t "$sel" -qv @av_blank 2>/dev/null || true)
+    if [[ -n "$cur" && "$cur" == %* && -n "$blank" ]] && tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$cur"; then
+      tmux swap-pane -s "$cur" -t "$blank" 2>/dev/null || true
+    fi
+    tmux kill-session -t _agentpop 2>/dev/null || true
+    ;;
+  view-switch)
+    # focus ハンドラ。$2=新ターゲット, $3=sel(fzf) pane。選択エージェント実ペインを blank と swap。
+    sel="${3:-}"; new="${2:-}"
+    [[ -z "$sel" ]] && exit 0
+    # 初回 focus で右に blank placeholder を遅延生成(popup attach 済み=正サイズ。起動時 split は
+    # detached サイズで崩れる)。
+    blank=$(tmux show-options -p -t "$sel" -qv @av_blank 2>/dev/null || true)
+    if [[ -z "$blank" ]] || ! tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$blank"; then
+      blank=$(tmux split-window -h -l 58% -d -P -F '#{pane_id}' -t "$sel" "exec '$SELF' blankpane" 2>/dev/null || true)
+      tmux set-option -p -t "$sel" @av_blank "$blank" 2>/dev/null || true
+      tmux select-pane -t "$sel" 2>/dev/null || true
+    fi
+    [[ -z "$blank" ]] && exit 0
+    cur=$(tmux show-options -p -t "$sel" -qv @av_swapped 2>/dev/null || true)
+    [[ "$cur" == "$new" ]] && exit 0
+    # 現在 swap 中の実ペインを元へ戻す(blank が popup 右へ復帰)
+    if [[ -n "$cur" && "$cur" == %* ]] && tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$cur"; then
+      tmux swap-pane -s "$cur" -t "$blank" 2>/dev/null || true
+    fi
+    # 新ターゲットがローカル実ペインなら blank と swap(実ペインが popup 右へ)。リモート/非ペインは blank のまま。
+    if [[ "$new" == %* ]] && tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$new"; then
+      tmux swap-pane -s "$new" -t "$blank" 2>/dev/null || true
+      tmux set-option -p -t "$sel" @av_swapped "$new" 2>/dev/null || true
+    else
+      tmux set-option -p -t "$sel" @av_swapped "" 2>/dev/null || true
+    fi
+    tmux select-pane -t "$sel" 2>/dev/null || true   # browse 中はフォーカスを fzf に維持
+    ;;
+  view-focus)
+    # Tab。swap 中の実ペイン(popup 右)へフォーカスして操作する。$2=sel pane。
+    v=$(tmux show-options -p -t "${2:-}" -qv @av_swapped 2>/dev/null || true)
+    [[ -n "$v" && "$v" == %* ]] && tmux select-pane -t "$v" 2>/dev/null || true
+    ;;
+  blankpane)
+    # swap 用 placeholder。swap で元 window 側へ出たときに「popup で表示中」と分かるよう表示し待機。
+    printf '\e[2J\e[H\n  %s(この pane は agent popup に表示中 — popup を閉じると復帰)%s\n' "$C_DIM" "$C_RST"
+    exec sleep 2147483647
+    ;;
+  jump)
+    # binding 末尾(display-popup の後)で元 client コンテキストから実行。selector が記録した
+    # target へ元 client を switch する。popup を閉じた後に走るのでここで初めて実 client が飛ぶ。
+    [[ -f "$JUMP_FILE" ]] || exit 0
+    target=$(cat "$JUMP_FILE" 2>/dev/null || true); rm -f "$JUMP_FILE" 2>/dev/null || true
+    [[ -z "$target" || "$target" == "-" ]] && exit 0
+    tmux switch-client -t "$target" 2>/dev/null || true
+    tmux select-window -t "$target" 2>/dev/null || true
+    tmux select-pane -t "$target" 2>/dev/null || true
     ;;
   popup)
     rows=$(build_rows)
@@ -242,5 +361,5 @@ case "${1:-popup}" in
     tmux display-message "agent-notify reloaded (watcher 再起動 + 状態スキャン)"
     ;;
   *)
-    echo "Usage: $0 {list|popup|reload|rescan|preview <target> <status>}" >&2; exit 1 ;;
+    echo "Usage: $0 {open|selector|list|popup|reload|rescan|preview <t> <s>|view-switch <t> <sel>|view-focus <sel>|blankpane|jump}" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

prefix+a のエージェント横断ビューを、選択中エージェントの実ペインを `swap-pane` で popup 右に表示する方式へ刷新。`join-pane` ベースの旧方式が元 window のレイアウトを壊していた問題を、構造を保持する `swap-pane` で根本解決する。

## Changes

- `scripts/tmux-agent-status.sh`
  - 選択エージェント実ペインを blank placeholder と `swap-pane` で交換し popup 右へ live 表示（`view-switch` / `view-focus` / `blankpane`）。focus 中の1つだけを swap-in/out、他は home に存在
  - `swap-pane` は中身のみ入替えるため元 window の構造（ペイン数/位置/サイズ）は不変。該当スロットが一時 blank になるだけ
  - Tab で右の実ペインへフォーカスして操作。Enter で元 client を該当ペインへジャンプ（target を jump file に記録 → popup を閉じた後に binding 末尾の `run-shell jump` が元 client で `switch-client`）
  - `open` で `_agentpop` に `status off` / `pane-border-status off` / `detach-on-destroy on` を設定し、popup 内の入れ子 status bar と閉じた後の二重化を解消
  - selector(fzf) 終了時に必ず swap back してから `kill-session`。実ペインが popup もろとも kill されエージェントが死ぬのを防止
- `common/tmux/.config/tmux/tmux.conf`
  - `bind a` を新フロー（`open` → `display-popup` で `_agentpop` を attach → 末尾 `run-shell jump`）へ更新

## Test plan

- [ ] prefix+a で一覧表示、j/k で選択エージェントが右に live 表示される
- [ ] 選択中、元 window 側は該当スロットが一時 blank になるだけで構造が崩れない
- [ ] Tab で右の実ペインにフォーカスして操作でき、C-Space o で一覧へ戻れる
- [ ] Enter で該当ペインへジャンプ
- [ ] q で閉じた後、実ペインが元 window へ復帰し崩れ/二重化がない
- [ ] リモート/コンテナ行を選択時は swap せず右が blank のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)