### PR TITLE
fix(tmux): agent popup の current pane 強調を修正

### DIFF
--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -203,6 +203,8 @@ case "${1:-popup}" in
     # prefix+a エントリ(binding の display-popup 前段)。scratch session でセレクタを起動するだけ。
     # popup(binding 側)がこの session を attach し、中に [セレクタ | 選択エージェント実ペイン] を表示。
     origin=$(tmux display-message -p '#{pane_id}' 2>/dev/null)
+    # 現在 pane(prefix+a を押した pane)を保存。build_local_rows がこれを読んで「◀ current」強調する。
+    tmux set-option -g @agent_cur_pane "$origin" 2>/dev/null || true
     rows=$(build_rows)
     if [[ -z "$rows" ]]; then tmux display-message "停止中のエージェントなし"; exit 0; fi
     tmux kill-session -t _agentpop 2>/dev/null || true   # 残骸掃除


### PR DESCRIPTION
swap-pane 改修(#242)で `bind a` が旧来の `@agent_cur_pane` 設定を落としており、`build_local_rows` の `◀ current` 強調が付かない/古い pane を指す退行があった。`open` で現在 pane を `@agent_cur_pane` に保存して復旧。

## 確認
- 隔離 tmux で `open` 後 `@agent_cur_pane`=origin、`list` 出力で origin 行に `◀ current` が付くことを確認
- 実機で current 強調が正しい pane に付くことをユーザー確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)