### PR TITLE
fix: tmux pane リサイズ時の表示崩れ対策 (Claude alt-screen 化 + zsh transient prompt)

### DIFF
--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -140,6 +140,33 @@ alias -s {png,jpg,jpeg,gif,webp}=open
 command -v starship &>/dev/null && eval "$(starship init zsh)"
 command -v zoxide &>/dev/null && eval "$(zoxide init zsh --cmd cd)"
 
+# --- Transient prompt (starship): 確定済みプロンプトを ❯ のみへ縮小 ---
+# starship の $fill 全幅罫線・右寄せは描画時の幅に固定された hard line で、tmux pane
+# リサイズ時に reflow されず崩れる。プロンプトは全コマンドの前に出る → scrollback 全域が
+# 崩れて見える主因。行確定直前に PROMPT/RPROMPT を最小化し reset-prompt で再描画すると、
+# scrollback には幅非依存の ❯ だけが残り、リサイズしても崩れない。zsh は starship transient
+# 非対応のため手動実装。starship は PROMPT='$(starship prompt …)' を prompt_subst で 1 回
+# だけ設定し毎回再評価する(precmd で再代入しない) → リテラル上書きすると永久破壊される。
+# よってフル文字列を退避し、line-finish で transient 化 → 次の precmd で復元する。
+# zle -N の上書きでなく add-zle-hook-widget を使い、sheldon 管理の autosuggestions /
+# syntax-highlighting が握る line-finish フックに非破壊で相乗りする。
+if command -v starship &>/dev/null; then
+  autoload -Uz add-zle-hook-widget add-zsh-hook
+  _STARSHIP_PROMPT_FULL="$PROMPT"      # starship init 直後の prompt_subst 文字列を退避
+  _STARSHIP_RPROMPT_FULL="$RPROMPT"
+  _starship_transient_set() {          # 行確定時: 過去プロンプトを ❯ に縮小
+    PROMPT='%B%F{green}❯%f%b '
+    RPROMPT=''
+    zle && zle .reset-prompt
+  }
+  _starship_transient_restore() {      # 次プロンプト直前: フル starship を復元
+    PROMPT="$_STARSHIP_PROMPT_FULL"
+    RPROMPT="$_STARSHIP_RPROMPT_FULL"
+  }
+  add-zle-hook-widget line-finish _starship_transient_set
+  add-zsh-hook precmd _starship_transient_restore
+fi
+
 # --- Auto ls on cd (chpwd hook) ---
 chpwd() {
   ls

--- a/templates/claude-settings.json
+++ b/templates/claude-settings.json
@@ -1,4 +1,5 @@
 {
+  "tui": "fullscreen",
   "statusLine": {
     "type": "command",
     "command": "__HOME__/.claude/statusline-command.sh"


### PR DESCRIPTION
## Summary

tmux pane の幅を変えると過去の表示が旧幅で固定されて崩れる問題を、2系統で対処する。根本原因は、tmux の history reflow は端末がオートラップした行(wrap フラグ付き)しか再ラップできず、プログラムが自前レイアウトした hard line は凍結するため。

## Changes

### Claude (alt-screen 化) — `templates/claude-settings.json`
- Claude Code は main-screen に会話を流すため、過去出力が tmux scrollback に残り pane リサイズで崩れる。`tui: "fullscreen"` で alternate screen に切り替え、reflow を Claude 自身に委ねる(nvim と同じ挙動)。
- PgUp/PgDn 等のネイティブスクロールも届き、tmux copy-mode 不要になる。
- install.sh が各環境の `~/.claude/settings.json` にマージするため mac/linux 全環境で再現。

### shell (starship transient prompt) — `common/zsh/.zshrc.common`
- starship の `$fill` 全幅罫線・右寄せは固定幅 hard line で reflow されず、全コマンドの前に出るため scrollback 全域が崩れて見える主因。
- 行確定時に PROMPT/RPROMPT を `❯` のみへ縮小、次の precmd でフル復元。starship は PROMPT を prompt_subst で1回設定し precmd で再代入しないため、フル文字列を退避して復元する2フック構成。
- `add-zle-hook-widget` で sheldon 管理の autosuggestions/syntax-highlighting と非破壊共存。

## Test plan

- [x] 隔離 tmux で starship 実設定を読み込み、autowrap 行は reflow 健全・transient で過去プロンプトが `❯` に縮小・55幅へ狭めても罫線フレーム0・ライブプロンプトはフル復元を確認
- [x] install.sh のマージロジック dry-run で `tui: fullscreen` 注入・既存 permissions/hooks 保持を確認
- [x] 実機で `/tui fullscreen` により Claude pane が alt-screen 化(alt=0→1)し崩れ解消を確認
- [ ] 新しい zsh セッションで transient prompt が実機動作することを最終確認

## Note

pi-coding-agent でも同様の調査を行ったが、画面モード切替設定(alt-screen 化)が存在せず同等の対処は不可。upstream 対応待ち。

🤖 Generated with [Claude Code](https://claude.com/claude-code)