### PR TITLE
feat(tools): gittype を導入

### DIFF
--- a/config/Brewfile
+++ b/config/Brewfile
@@ -82,6 +82,7 @@ brew "viddy"
 brew "doggo"
 brew "topgrade"
 brew "grex"
+brew "gittype"
 
 # --- System Monitoring ---
 brew "macmon"      # Apple Silicon GPU/CPU monitoring (tmux status bar)

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -220,6 +220,11 @@ TOOL_gitabsorb_method="cargo"
 TOOL_gitabsorb_cargo_crate="git-absorb"
 TOOL_gitabsorb_depends_on="rust"
 
+TOOL_gittype_check_cmd="gittype"
+TOOL_gittype_method="cargo"
+TOOL_gittype_cargo_crate="gittype"
+TOOL_gittype_depends_on="rust"
+
 TOOL_cargoupdate_check_cmd="cargo-install-update"
 TOOL_cargoupdate_method="cargo"
 TOOL_cargoupdate_cargo_crate="cargo-update"
@@ -407,7 +412,7 @@ LINUX_TOOL_ORDER=(
   # APT-only (skipped on Alpine)
   gh neovim eza bat postgresql
   # Cargo tools (depend on rust)
-  tokei tealdeer procs sd dust bottom rip2 lsd quay gitabsorb cargoupdate keifu
+  tokei tealdeer procs sd dust bottom rip2 lsd quay gitabsorb cargoupdate keifu gittype
   # Python tools (depend on uv)
   pgcli
 )


### PR DESCRIPTION
## Summary
ソースコードをタイピング教材に変える TUI ゲーム [gittype](https://github.com/unhappychoice/gittype) を導入。

## Changes
- `config/Brewfile`: `brew "gittype"` を追加（macOS）
- `config/tools.linux.bash`: cargo エントリ追加とツール一覧に `gittype` を追加（Linux）

設定ファイルは持たない（テーマ等はアプリ内管理）ため stow パッケージは不要。

## Test plan
- [x] macOS で `brew install gittype` 実行、`gittype 0.10.0` 動作確認
- [ ] Linux で `install.sh` 経由の cargo インストールを確認