### PR TITLE
feat(hunk): エージェント変更レビュー用 TUI 差分ビューア hunk を導入

### DIFF
--- a/common/hunk/.config/hunk/config.toml
+++ b/common/hunk/.config/hunk/config.toml
@@ -1,0 +1,1 @@
+theme = "dark-plus"

--- a/config/packages.npm.txt
+++ b/config/packages.npm.txt
@@ -10,6 +10,9 @@ command-code
 # Claude Code token usage analytics (local JSONL parser)
 ccusage
 
+# Review-first terminal diff viewer for agent-authored changesets (hunk binary)
+hunkdiff
+
 # Claude Code token optimizer (auto-config hooks via global install)
 @ooples/token-optimizer-mcp
 


### PR DESCRIPTION
## Summary

agent が書いた変更をレビューするための review-first な TUI 差分ビューア [hunk](https://github.com/modem-dev/hunk) を導入。`hunk skill path` 経由で Claude が live セッションをナビゲートしインラインコメントを残せる (オンデマンド読み込み、ハーネスへの常時配線はなし)。

## Changes

- `config/packages.npm.txt`: `hunkdiff` を追加。既存 AI CLI 群と同じ仕組みで mac/linux 両方が冪等インストール (node は mise の lts が供給)
- `common/hunk/.config/hunk/config.toml`: `theme = "dark-plus"` (VSCode Dark+)。stow 管理

## Test plan

- [ ] `npm install -g hunkdiff` 後 `hunk --version` が解決する (確認済み: 0.16.0)
- [ ] `hunk diff` が dark-plus テーマで起動する
- [ ] `hunk diff --watch` で別ペイン編集に追従する
- [ ] `hunk skill path` のスキルを Claude に読ませ session 操作が動く