### PR TITLE
feat(jj): jj/jjui 開発環境の整備（config分離・starship表示・tmux popup・install）

### DIFF
--- a/common/claude/.claude/rules/version-control.md
+++ b/common/claude/.claude/rules/version-control.md
@@ -2,6 +2,7 @@
 
 `.jj/` が存在するリポジトリでは Jujutsu (`jj`) を version-control write の標準にする。
 
+- colocated 前提（`jj git init --colocate`、jj v0.39+ は `jj git init` で既定）。Git read-only と jj write の両立はこれが条件
 - 作業前に `jj status` を実行し、snapshot と状態確認を行う
 - 変更確認は `jj status` / `jj diff` / `jj log` を使う
 - ローカル作業の参照は Git hash より jj change ID を優先する

--- a/common/jj/.config/jj/config.toml
+++ b/common/jj/.config/jj/config.toml
@@ -1,0 +1,11 @@
+#:schema https://docs.jj-vcs.dev/latest/config-schema.json
+
+# user identity (name/email) は machine 固有のため追跡しない。
+# ~/.config/jj/conf.d/user.toml に分離 (install.sh が git config から scaffold)。
+# git の ~/.gitconfig.local と同じ規約。
+
+[ui]
+# 引数なし `jj` で log を表示する
+default-command = "log"
+
+# ponytail: log default のみ。alias / delta pager / revset は必要になってから追加する。

--- a/common/starship/.config/starship.toml
+++ b/common/starship/.config/starship.toml
@@ -5,6 +5,7 @@ $os\
 $directory\
 $git_branch\
 $git_status\
+${custom.jj}\
 ${custom.git_diff}\
 $fill\
 $cmd_duration\
@@ -69,6 +70,15 @@ format = '[─](fg:current_line)[](fg:cyan)[󰊤 ](fg:primary bg:cyan)[](f
 command = "~/dotfiles/scripts/starship-git-diff.sh"
 when = true
 detect_folders = [".git"]
+shell = ["bash", "--noprofile", "--norc"]
+
+# jj working-copy change-id + bookmark (.jj が存在する repo でのみ表示)
+# colocated repo では git_branch は detached でほぼ空になるため衝突しない
+[custom.jj]
+format = '[─](fg:current_line)[](fg:purple)[󰁨 ](fg:primary bg:purple)[](fg:purple bg:box)[ $output ](fg:foreground bg:box)[](fg:box)'
+command = "~/dotfiles/scripts/starship-jj.sh"
+when = true
+detect_folders = [".jj"]
 shell = ["bash", "--noprofile", "--norc"]
 
 [fill]

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -212,11 +212,12 @@ bind S run-shell '\
 # inside the backing docker container for rcon-managed sessions (falls through
 # to host execution for non-docker sessions, preserving in-docker tmux compat).
 set -g @popup-lazygit   "g|80|80|~/dotfiles/scripts/tmux-popup-in-container lazygit"
+set -g @popup-jjui      "j|80|80|~/dotfiles/scripts/tmux-popup-in-container jjui|jjui"
 set -g @popup-keifu     "k|80|80|~/dotfiles/scripts/tmux-popup-in-container zsh -lc keifu"
 set -g @popup-pgcli     "P|80|80|~/dotfiles/scripts/tmux-popup-in-container pgcli \${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres}"
 set -g @popup-quay      "Q|80|80|~/dotfiles/scripts/tmux-popup-in-container quay"
 set -g @popup-gh-dash   "G|85|85|~/dotfiles/scripts/tmux-popup-in-container gh dash|gh-dash"
-set -g @popup-scratch   "j|80|80|SCRATCH|Scratchpad"
+set -g @popup-scratch   "l|80|80|SCRATCH|Scratchpad"
 set -g @popup-sessions  "f|60|60|~/dotfiles/scripts/tmux-session-color.sh fzf-sessions"
 set -g @popup-projects  "F|60|60|~/dotfiles/scripts/tmux-popup-ghq.sh"
 set -g @popup-layout    "A|60|40|~/dotfiles/scripts/tmux-layout menu"

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -397,6 +397,14 @@ TOOL_jj_archive_pattern='jj-${VERSION}-${ARCH}-unknown-linux-musl.tar.gz'
 TOOL_jj_binary_path='jj'
 TOOL_jj_arch_map='x86_64:x86_64 aarch64:aarch64'
 
+# jjui: jj 用 TUI (lazygit ライク)。zip 内バイナリは version+arch 名なので install_cmd で jjui へ rename
+TOOL_jjui_check_cmd="jjui"
+TOOL_jjui_method="github_release"
+TOOL_jjui_github_repo="idursun/jjui"
+TOOL_jjui_archive_pattern='jjui-${VERSION_NOTAG}-linux-${ARCH}.zip'
+TOOL_jjui_arch_map='x86_64:amd64 aarch64:arm64'
+TOOL_jjui_install_cmd='unzip -o "$archive" -d "$_td" >/dev/null; if [[ "$NO_SUDO" == "true" ]]; then mkdir -p "$HOME/.local/bin"; install -m755 "$_td/jjui-${VERSION_NOTAG}-linux-${ARCH}" "$HOME/.local/bin/jjui"; else $SUDO install -m755 "$_td/jjui-${VERSION_NOTAG}-linux-${ARCH}" /usr/local/bin/jjui; fi'
+
 # ════════════════════════════════════════
 # Install order (dependencies must come before dependents)
 # ════════════════════════════════════════
@@ -406,7 +414,7 @@ LINUX_TOOL_ORDER=(
   bun starship mise sheldon zoxide atuin dotenvx uv rust lazydocker direnv
   # GitHub releases (no deps)
   fzf fzftmux fastfetch delta lazygit ghq smug dops yazi rainfrog typst
-  just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex sesh lemonade jj
+  just watchexec hyperfine gitleaks xh ouch glow viddy doggo topgrade grex sesh lemonade jj jjui
   # Cursor CLI (headless AI coding agent)
   cursor
   # APT-only (skipped on Alpine)

--- a/install.sh
+++ b/install.sh
@@ -405,6 +405,16 @@ link_dotfiles() {
     log_info "Run 'setup_git_from_op' to configure git user from 1Password"
   fi
 
+  # jj user identity is machine-specific (not tracked). Scaffold conf.d/user.toml
+  # from git config so jj reuses the same name/email as git (~/.gitconfig.local).
+  if [[ ! -f "$HOME/.config/jj/conf.d/user.toml" ]]; then
+    mkdir -p "$HOME/.config/jj/conf.d"
+    printf '[user]\nname = "%s"\nemail = "%s"\n' \
+      "$(git config user.name)" "$(git config user.email)" \
+      > "$HOME/.config/jj/conf.d/user.toml"
+    log_info "Created ~/.config/jj/conf.d/user.toml from git config"
+  fi
+
   # Verify critical symlinks were created
   verify_stow
 

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -33,6 +33,17 @@ install_jj_cli() {
   log_success "jj installed"
 }
 
+install_jjui() {
+  if command_exists jjui; then
+    log_success "jjui already installed"
+    return
+  fi
+
+  log_info "Installing jjui..."
+  brew install jjui
+  log_success "jjui installed"
+}
+
 install_npm_packages() {
   if ! command_exists npm; then
     log_warn "npm not found, skipping npm packages"
@@ -333,6 +344,7 @@ install_cursor_cli() {
 # --- Main Execution ---
 run_step install_brew_bundle
 run_step install_jj_cli
+run_step install_jjui
 run_step install_mise_tools
 run_step install_npm_packages
 run_step install_claude_mem

--- a/scripts/starship-jj.sh
+++ b/scripts/starship-jj.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# starship custom module: jj working-copy change-id + bookmarks
+# Output: "qpvu main" (change-id short prefix, optional bookmark names)
+# --ignore-working-copy: snapshot/lock を取らない (prompt 毎の read-only 表示用)
+
+command -v jj >/dev/null 2>&1 || exit 0
+
+jj log --ignore-working-copy --no-graph --color never -r @ \
+  -T 'change_id.shortest(4) ++ if(bookmarks, " " ++ bookmarks.join(" "))' 2>/dev/null


### PR DESCRIPTION
## 概要

jj (Jujutsu) を使った開発環境を整備する。jj/jjui の導入、設定、シェル/エディタ統合をまとめて追加。

## 変更内容

- jj config (`common/jj/.config/jj/config.toml`): machine 非依存の設定のみ追跡（schema, `ui.default-command = log`）。user identity は machine 固有のため追跡せず、`~/.config/jj/conf.d/user.toml` に分離（git の `~/.gitconfig.local` と同じ規約）
- `install.sh`: `conf.d/user.toml` を `git config` から scaffold するステップを追加（再現性確保）
- version-control rule: colocated 前提（`jj git init --colocate`）を明記
- starship: `.jj` がある repo で change-id + bookmark を表示する custom module を追加（`scripts/starship-jj.sh`、`--ignore-working-copy` で prompt 毎の snapshot を回避）
- jjui (jj 用 lazygit ライク TUI) の install: mac は `brew install jjui`、linux は `config/tools.linux.bash` に github_release エントリ追加（zip 内バイナリを install_cmd で `jjui` に rename）
- tmux: prefix+j を jjui popup に割当、既存の scratchpad を prefix+l へ移動

## 動作確認

- jj config 反映（`jj config get`）、starship 設定パース、`starship-jj.sh` を実 jj repo で出力確認
- jjui: mac 導入（0.10.6）、linux の install_cmd ロジックを実 zip で検証し `jjui` バイナリ生成を確認
- tmux: reload 後の prefix+j / prefix+l バインドを確認