### PR TITLE
feat(hunk): レビュー用 alias 追加と背景透過の撤回

### DIFF
--- a/common/git/.gitconfig
+++ b/common/git/.gitconfig
@@ -90,6 +90,8 @@
 [alias]
     secrets = !gitleaks detect --verbose
     absorb = !git-absorb --and-rebase
+	hdiff = -c core.pager=hunk pager diff
+	hshow = -c core.pager=hunk pager show
 
 # === ghq (Repository Management) ===
 [ghq]

--- a/common/hunk/.config/hunk/config.toml
+++ b/common/hunk/.config/hunk/config.toml
@@ -1,2 +1,1 @@
 theme = "dark-plus"
-transparent_background = true

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -124,6 +124,15 @@ command -v viddy &>/dev/null && alias watch="viddy"
 command -v doggo &>/dev/null && alias dig="doggo"
 command -v xh &>/dev/null && alias http="xh"
 
+# --- hunk (review-first diff viewer / agent レビュー) ---
+# delta は通常の git pager として温存。hunk はここの alias で限定的に使う。
+if command -v hunk &>/dev/null; then
+  alias hd='hunk diff'                      # 作業ツリーをインタラクティブレビュー
+  alias hs='hunk show'                      # コミットをレビュー
+  alias hdw='hunk diff --watch'             # 編集に追従して自動リロード
+  alias jhd='jj diff --git | hunk patch -'  # jj の変更を hunk でレビュー
+fi
+
 # --- Global Aliases (pipe modifiers) ---
 # Usage: git log L → git log | bat
 alias -g L='| bat'


### PR DESCRIPTION
## Summary

hunk 導入(#251)のフォローアップ。レビュー用の shell/git alias を追加し、背景透過設定を撤回。delta は通常の git pager として温存(A 方針: delta 温存・hunk 限定)。

## Changes

- `common/git/.gitconfig`: `git hdiff` / `git hshow` alias を追加(`-c core.pager="hunk pager"` で hunk 表示。global pager は delta のまま)
- `common/zsh/.zshrc.common`: `command -v hunk` ガード付きで alias 追加
  - `hd` = `hunk diff`(作業ツリーをインタラクティブレビュー)
  - `hs` = `hunk show`(コミットをレビュー)
  - `hdw` = `hunk diff --watch`(編集に追従して自動リロード)
  - `jhd` = `jj diff --git | hunk patch -`(jj の変更を hunk でレビュー)
- `common/hunk/.config/hunk/config.toml`: `transparent_background` を削除
  - インタラクティブ TUI 側は透過にすると差分の帯ハイライト(addedBg/removedBg)も消えるため

## 設計メモ

- jj はグローバル pager にすると毎回 Node 起動で重くなるため、global 設定は変えず `jhd` のオンデマンド alias に留めた
- lazygit は delta(side-by-side)を温存し変更なし

## Test plan

- [ ] `hd` / `hs` / `hdw` / `jhd` が新しいシェルで解決する(確認済み)
- [ ] `git hdiff` / `git hshow` が hunk 表示になり、通常の `git diff` は delta のまま
- [ ] `hunk diff` が dark-plus テーマで帯ハイライト付きで表示される