### PR TITLE
feat(zsh): hunk で default branch との3点diff alias (hdd/hddw) を追加

### DIFF
--- a/common/zsh-abbr/.config/zsh-abbr/user-abbreviations
+++ b/common/zsh-abbr/.config/zsh-abbr/user-abbreviations
@@ -16,10 +16,6 @@ abbr grh="git reset --hard HEAD"
 abbr grs="git reset --soft HEAD^"
 abbr gpf="git push --force"
 
-# hunk (default branch との3点diff。jj は trunk()..@、git は <default>...)
-abbr hd='hunk diff $(jj root >/dev/null 2>&1 && echo "trunk()..@" || echo "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)...")'
-abbr hdw='hunk diff $(jj root >/dev/null 2>&1 && echo "trunk()..@" || echo "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)...") --watch'
-
 # ghq
 abbr gq="ghq get"
 abbr gql="ghq list"

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -130,6 +130,9 @@ if command -v hunk &>/dev/null; then
   alias hd='hunk diff'                      # 作業ツリーをインタラクティブレビュー
   alias hs='hunk show'                      # コミットをレビュー
   alias hdw='hunk diff --watch'             # 編集に追従して自動リロード
+  # default branch との3点diff (jj: trunk()..@ / git: <default>...)
+  alias hdd='hunk diff "$(jj root >/dev/null 2>&1 && echo "trunk()..@" || echo "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)...")"'
+  alias hddw='hunk diff "$(jj root >/dev/null 2>&1 && echo "trunk()..@" || echo "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)...")" --watch'
   alias jhd='jj diff --git | hunk patch -'  # jj の変更を hunk でレビュー
 fi
 


### PR DESCRIPTION
## Summary
hunk で現在ブランチを default branch と3点diff するための alias `hdd` / `hddw` を追加。VCS を判定し jj では `trunk()..@`、git では `<default>...`（origin/HEAD から導出）を渡す。

## Changes
- `common/zsh/.zshrc.common`: 既存 hunk alias 群（`hd`/`hs`/`hdw`/`jhd`）に揃えて追加
  - `hdd` — hunk diff で default branch と3点比較
  - `hddw` — `hdd` に `--watch` 付与（編集追従）
- `common/zsh-abbr/.config/zsh-abbr/user-abbreviations`: 誤って混入していた abbr `hd`/`hdw` を削除（既存 `alias hd`/`alias hdw` と衝突するため）

## Notes
- 別ターミナルでの main push 時に working copy が一緒に snapshot され、不具合版の abbr が main(`22c8df1e`) に混入していた。本 PR でそれを是正する。
- `d-hunk-review` skill も同コミットで main に入っているが内容は正常なため据え置き。

## Test plan
- [ ] jj repo で `hdd` 実行 → `hunk diff trunk()..@` が開く
- [ ] git repo で `hdd` 実行 → `hunk diff <default>...` が開く
- [ ] `hddw` で `--watch` が付く
- [ ] `hd`/`hdw` が既存 alias どおり動作する（abbr 衝突解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)