### PR TITLE
fix(zsh): hunk default diff の VCS 判定を repo root の .jj 有無に変更

### DIFF
--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -130,9 +130,18 @@ if command -v hunk &>/dev/null; then
   alias hd='hunk diff'                      # 作業ツリーをインタラクティブレビュー
   alias hs='hunk show'                      # コミットをレビュー
   alias hdw='hunk diff --watch'             # 編集に追従して自動リロード
-  # default branch との3点diff (jj: trunk()..@ / git: <default>...)
-  alias hdd='hunk diff "$(jj root >/dev/null 2>&1 && echo "trunk()..@" || echo "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)...")"'
-  alias hddw='hunk diff "$(jj root >/dev/null 2>&1 && echo "trunk()..@" || echo "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)...")" --watch'
+  # default branch との3点diff target を返す (hunk の VCS 判定に合わせる:
+  # repo root に .jj があれば jj、なければ git。jj root は祖先まで遡り誤判定するため使わない)
+  _hunk_default_ref() {
+    local root
+    if root=$(git rev-parse --show-toplevel 2>/dev/null) && [[ ! -d $root/.jj ]]; then
+      printf '%s...' "$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | cut -d/ -f2-)"
+    else
+      printf 'trunk()..@'
+    fi
+  }
+  alias hdd='hunk diff "$(_hunk_default_ref)"'          # default branch と3点diff
+  alias hddw='hunk diff "$(_hunk_default_ref)" --watch' # それに --watch
   alias jhd='jj diff --git | hunk patch -'  # jj の変更を hunk でレビュー
 fi
 


### PR DESCRIPTION
## Summary
#255 で入れた `hdd`/`hddw` の VCS 判定 (`jj root` ベース) を是正する。`jj root` は祖先ディレクトリまで遡るため、jj workspace 配下にネストした git リポジトリで誤って jj 扱いし、hunk(git 判定) と食い違って `could not resolve Git revision trunk()..@` で失敗していた。

## Root cause
- alias 側: `jj root` 成功 → `trunk()..@`
- hunk 側: そのリポジトリ root の `.jj` 有無で判定 → git
- 両者が別基準のため、git repo が jj workspace に内包されるレイアウトで不一致。

## Fix
`_hunk_default_ref` を追加し、hunk と同じ基準（リポジトリ root の `.jj` 有無）で判定する。

| レイアウト | target |
|---|---|
| plain git | `<default>...` (origin/HEAD から導出) |
| colocated jj+git | `trunk()..@` |
| jj workspace 配下の git | `<default>...` (git 扱い) |

## Test plan
- [x] plain git → `main...`
- [x] colocated jj+git → `trunk()..@`
- [x] nested git-under-jj → `develop...`（旧 `jj root` の誤判定を回避）

🤖 Generated with [Claude Code](https://claude.com/claude-code)