### PR TITLE
fix(tmux): autoapply の layout 再適用が zoom/choose-tree を潰す問題を修正

### DIFF
--- a/scripts/tmux-layout
+++ b/scripts/tmux-layout
@@ -314,6 +314,13 @@ def cmd_autoapply(args: argparse.Namespace) -> int:
     name = tmux_get("#{@layout-preset}", win)
     if not name:
         return 0
+    # Yield to the user's active zoom / pane mode. apply_preset runs `select-layout`,
+    # which force-unzooms and cancels choose-tree/copy-mode — so a background
+    # focus/session event (agent churn while Claude works) would snap a manually
+    # zoomed pane back to the preset. Skip here; the next window switch re-snaps
+    # once the user has left the zoom/mode.
+    if tmux_get("#{window_zoomed_flag}", win) == "1" or tmux_get("#{pane_in_mode}", win) == "1":
+        return 0
     apply_preset(name, win, quiet=True)
     return 0
 


### PR DESCRIPTION
## Summary

prefix-z (zoom) や prefix-s (choose-tree) が、背景の focus/session イベントで勝手に解除され元の pane 配置に戻る問題を修正。

## 原因

`tmux-layout autoapply` は `pane-focus-in` / `client-session-changed` フックにバインドされ、`apply_preset` 経由で `tmux select-layout` を実行する。select-layout は window の zoom を強制解除し、pane を保存済み preset 配置へスナップバックさせる。

`@layout-preset` を持つ window (tmux-layout で組んだ agent/multi-pane window) では、Claude 稼働中の focus/session churn がこれらフックを撃つ度に、ユーザが能動的に入れた prefix-z (zoom) / prefix-s (choose-tree) が問答無用で潰されていた。「元の pane に戻る」の正体はフォーカス奪取ではなく layout preset の再適用。

## Changes

- `cmd_autoapply` に zoom/mode ガードを追加。対象 window が zoom 中 (`#{window_zoomed_flag}`) または active pane が mode 中 (`#{pane_in_mode}`) の場合は再適用をスキップ。autoapply 本来の役割 (window 切替時の layout 復元) は維持しつつ、ユーザの一時的な view 状態には介入しない。

## Test plan

- [x] `select-layout` が zoom を解除することを実機確認 (zoom=1 → select-layout → zoom=0)
- [x] preset 一致 window での A/B 検証: ガード有り=zoom 生存 (flag=1) / ガード無し=zoom 解除 (flag=0)
- [x] python 構文チェック (ast.parse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm