### PR TITLE
fix(tmux): フック多重登録の累積を防ぐ (-gu リセット追加)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -379,14 +379,20 @@ set -g status-style bg=default
 
 # サイドバー幅の即時補正: window-size latest 再適用後の比例リサイズ丸めで幅がドリフトするため、
 # resize/session 切替の都度サイドバー pane を固定幅へ戻す (run ループの 3 秒補正の即時版)。
+# -gu でリセットしてから append しないと prefix+r リロードの度に同じ run-shell が蓄積する
+# (278-281 の client-attached 等と同じ理由)。client-session-changed のみ claude-hooks.tmux が
+# -g で先に上書きするため -gu 不要。
+set-hook -gu client-resized
 set-hook -ga client-resized          'run-shell "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all 2>/dev/null || true"'
 set-hook -ga client-session-changed  'run-shell "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all 2>/dev/null || true"'
 # window-layout-changed: prefix+a の swap-pane 等でレイアウトが変わるとサイドバーが比例配分で
 # 広がるため、変更のあった window のみ固定幅へ snap し直す (resize-all 側に再発火ループ防止ガードあり)。
+set-hook -gu window-layout-changed
 set-hook -ga window-layout-changed   'run-shell "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all #{window_id} 2>/dev/null || true"'
 
 # Layout auto-apply: window/session 切替で、その window に記憶された @layout-preset
 # (tmux-layout apply 時に付与) があれば保存済み構成へ自動リサイズ。
 # プリセット未設定の window は autoapply 内で即 return = ゼロコスト・非フリッカー。
+set-hook -gu pane-focus-in
 set-hook -ga pane-focus-in           'run-shell "~/dotfiles/scripts/tmux-layout autoapply 2>/dev/null || true"'
 set-hook -ga client-session-changed  'run-shell "~/dotfiles/scripts/tmux-layout autoapply 2>/dev/null || true"'


### PR DESCRIPTION
## Summary

`client-resized` / `window-layout-changed` / `pane-focus-in` の tmux hook が prefix+r リロードの度に多重登録される問題を修正。

## 原因

これら3つは `set-hook -ga` (append) で登録されるが、対応する `set-hook -gu` (reset) が無い。`source-file` によるリロード (prefix+r) の度に同じ run-shell が追加され、際限なく累積する。実サーバで `client-resized` が16エントリまで累積し、1回の client-resize イベントで `resize-all` が16連発する状態を観測した。

`client-session-changed` が累積しないのは、`claude-hooks.tmux` が `-g` (上書き) で先に登録してリロード毎にリセットしているため。同じ理由で上記3つも append 前に `-gu` リセットが必要。

## Changes

- `client-resized` / `window-layout-changed` / `pane-focus-in` の `-ga` の前に `set-hook -gu` を追加。既存の `session-created` / `client-attached` / `after-new-window` と同じ reload-safe パターンに揃える。

## Test plan

- [x] throwaway tmux server で -gu+-ga パターンを2回リロード → hook が1エントリのまま (累積しない) を確認
- [x] 実サーバで累積 (16エントリ) を観測済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm