### PR TITLE
fix(tmux): 背景ループの孤児化と多重起動を防ぐ

### DIFF
--- a/scripts/tmux-agent-hang-watch.sh
+++ b/scripts/tmux-agent-hang-watch.sh
@@ -24,13 +24,19 @@ fi
 echo $$ > "$LOCK_FILE"
 # INT/TERM は cleanup 後に必ず exit する。exit しないと TERM を握り潰してループ継続し、
 # pkill で死なず多重起動の原因になる。
-cleanup() { rm -f "$LOCK_FILE"; }
+# cleanup は自分が所有する lock のみ削除する。別インスタンスが lock を奪った後に自分が
+# exit するとき、無条件 rm だと勝者の lock を消してしまうため。
+cleanup() { [[ "$(cat "$LOCK_FILE" 2>/dev/null)" == "$$" ]] && rm -f "$LOCK_FILE"; }
 trap cleanup EXIT
 trap 'cleanup; exit 0' INT TERM
 
 while true; do
   # tmux サーバが消えたら終了
   tmux info &>/dev/null || exit 0
+  # 起動時ロックすり抜け (旧インスタンス生存中に lock が消えて新規が起動) で多重化した場合、
+  # lock を新インスタンスに奪われた旧インスタンスはここで畳む → 単一インスタンスへ収束。
+  owner="$(cat "$LOCK_FILE" 2>/dev/null || true)"
+  [[ -n "$owner" && "$owner" != "$$" ]] && exit 0
   "$SCRIPT_DIR/tmux-claude-pane.sh" hang-scan 2>/dev/null || true
   # sleep を背景+wait にすることで INT/TERM を sleep 中でも即座に trap できる
   # (前景 sleep だと bash が trap を sleep 終了まで保留し、pkill が最大 INTERVAL 遅延する)

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -242,6 +242,10 @@ case "${1:-toggle}" in
     printf '\033[?25l'   # カーソル非表示(ちらつき低減)
     while true; do
       tmux info &>/dev/null || { printf '\033[?25h'; exit 0; }
+      # 自分の pane が消えたらループを畳む。kill-pane / window・session 破棄で pane だけ
+      # 消えてもサーバは生存するため、tmux info チェックだけでは孤児ループがリークする。
+      # display-message -t deadpane は default pane にフォールバックして成功するため使えない。
+      tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "${TMUX_PANE}" || { printf '\033[?25h'; exit 0; }
       # window-size latest の比例リサイズ丸め誤差で session 切替毎に幅がドリフトする。
       # 毎ループ固定幅へ戻す(既に正しければ no-op=チラつき無し)。
       tmux resize-pane -t "${TMUX_PANE}" -x "$WIDTH" 2>/dev/null || true


### PR DESCRIPTION
## Summary

エージェント監視系の常駐ループが孤児化・多重起動する2つの問題を修正。

## 原因と修正

### sidebar run ループ (tmux-agent-sidebar.sh)
`while` ループの生存判定が `tmux info` (サーバ生存) のみで、自分の pane が消えたことを検知しない。pane だけ kill されてもサーバは生きているため、孤児ループが残り続ける (実サーバで `TMUX_PANE` 空の孤児プロセスを1件確認)。

- 毎ループ `list-panes -a` で自 pane の生存を確認し、無ければ畳む。
- `display-message -t deadpane` は default pane にフォールバックして成功してしまうため使えず、`list-panes -a | grep -qxF` で確実に判定する。

### hang-watch (tmux-agent-hang-watch.sh)
PID ロックによる単一インスタンス保証があるが、旧インスタンス生存中にロックファイルが消える (例: XDG_RUNTIME クリア) と、起動時ガードをすり抜けて新規が起動し多重化する (実サーバで2重起動を確認)。さらに `cleanup` が無条件 `rm` のため、奪われた側の exit が勝者のロックを消す二次障害もある。

- `cleanup` を「自分が所有するロックのみ削除」に変更。
- ループ先頭でロック所有権を確認し、別インスタンスに奪われていたら畳む → 単一インスタンスへ収束。

## Test plan

- [x] `list-panes -a \| grep -qxF` が dead pane / 空 TMUX_PANE を確実に検知することを確認
- [x] hang-watch の所有権ロジック (superseded→exit / own→continue) を確認
- [x] 両スクリプト `bash -n` 構文チェック
- [x] 実サーバで孤児1件・hang-watch 2重起動を観測

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm