### PR TITLE
perf(tmux): history-limit を 5000 に下げる (メモリ削減)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -22,7 +22,9 @@ set -g focus-events on   # Neovim autoread等に必要
 # (tmux(1): "automatically set window-size to manual")。
 set -g window-size smallest
 set -g aggressive-resize off  # Claude Code等のTUI再描画チラつき軽減 (default offを明示)
-set -g history-limit 10000
+# 多数 pane 環境では history は pane 数だけ積算され tmux RSS を押し上げる
+# (常駐が大きいと一部が swap に出され再描画でページフォルト→ラグ)。5000 で実用と省メモリを両立。
+set -g history-limit 5000
 set -g allow-passthrough on  # Kitty graphics protocol (image.nvim等で必要)
 set -g extended-keys on      # CSI u: C-S-u等の修飾キーをNeovimに正しく送信
 set -ga update-environment TERM


### PR DESCRIPTION
## Summary

tmux の `history-limit` を 10000 → 5000 に変更し、多数 pane 環境での常駐メモリを削減する。

## 背景

history buffer は pane 単位に確保されるため、多数の pane を抱える環境では tmux server の RSS が pane 数 × history 行数で積算される。常駐が大きいと一部が swap に追い出され、再描画時のページフォルトでラグが出る。5000 行あれば実用上のスクロールバック要件を満たしつつメモリを半減できる。

## Changes

- `set -g history-limit 10000` → `5000`（理由コメント付き）

## Test plan

- [x] 設定値のみの変更（新規 pane から適用、既存 pane は据え置き）
- [x] reload 済み実機で 5000 が有効

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm