### PR TITLE
fix(mcp): tmux-mcp を server と同一の tmux 3.6a で起動 (バージョン不整合回避)

### DIFF
--- a/common/claude/.config/claude/mcp.json
+++ b/common/claude/.config/claude/mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "tmux": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "tmux-mcp"]
+      "command": "bash",
+      "args": ["-c", "export PATH=\"$HOME/.local/bin:$PATH\"; exec npx -y tmux-mcp"]
     },
     "notion": {
       "type": "stdio",


### PR DESCRIPTION
## Summary

tmux-mcp が tmux server とバージョン不整合を起こしうる問題を、launcher を login PATH でラップして根本回避する。

## 背景

no-sudo ホストではホスト上に複数の tmux が同居する:
- `/usr/bin/tmux` 3.2a (apt)
- `~/.pixi/bin/tmux` 3.6 (pixi/conda-forge、install スクリプトが attach crash を警告)
- `~/.local/bin/tmux` 3.6a (dotfiles が source build。**tmux server はこれ**)

tmux-mcp は `npx → node → /bin/sh -c tmux` で tmux を起動するが、非対話 shell は `~/.local/bin` を PATH に載せない (`.zshenv` は zsh 専用、`.profile`/`.bashrc` は login/interactive 限定)。このため解決順次第で 3.2a を掴むと protocol mismatch で `server exited unexpectedly` になる。現状は pixi 3.6 に解決されて偶然動いているが、pixi 版は install スクリプト自身が非推奨としている。

## Changes

- `common/claude/.config/claude/mcp.json` の tmux エントリを `npx` 直起動から `bash -c 'export PATH="$HOME/.local/bin:$PATH"; exec npx -y tmux-mcp'` に変更。server と同一の `~/.local/bin/tmux` 3.6a を確定的に使わせる。
- `install.sh` が mcp.json を読んで `claude mcp add-json` で登録するため、この repo 変更で再現可能。

## Test plan

- [x] `bash -c 'export PATH=$HOME/.local/bin:$PATH; tmux -V'` → 3.6a に解決、server と会話成功を実機確認
- [x] pixi 3.6 / usr 3.2a との解決差を実機確認 (3.2a のみ mismatch)
- [x] mcp.json JSON 妥当性チェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm