### PR TITLE
fix(tmux): sidebar 幅補正が prefix-z/prefix-s のズームを潰す問題を修正

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -34,6 +34,14 @@ RUNTIME_BASE="${XDG_RUNTIME_DIR:-${TMPDIR:-$HOME/.cache}}"
 STATUS_DIR="${AGENT_STATUS_DIR:-${DOTFILES_SHARED_DIR:-$HOME/.cache}/claude/status}"
 ESC_K=$'\033[K'   # 行末までクリア(全画面クリアせず=チカチカしない)
 
+# どれかの client が zoom / choose-tree / copy-mode 中なら true。
+# その間は sidebar の幅補正 resize を止める: 補正 resize が window-size(smallest) の
+# window 再計算を誘発し、zoom 中 window の pane まで resize して unzoom してしまう
+# (= ユーザの prefix-z / prefix-s(choose-tree -Z) が操作中に潰れる)。
+sidebar_user_busy() {
+  tmux list-clients -F '#{window_zoomed_flag}#{pane_in_mode}' 2>/dev/null | grep -q 1
+}
+
 # 表示幅基準の切り詰め(全角=2幅近似)。[[:ascii:]] は macOS 非対応のため case で判定
 trunc_w() {
   local s="$1" max="$2" out="" w=0 ch cw i
@@ -248,7 +256,11 @@ case "${1:-toggle}" in
       tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "${TMUX_PANE}" || { printf '\033[?25h'; exit 0; }
       # window-size latest の比例リサイズ丸め誤差で session 切替毎に幅がドリフトする。
       # 毎ループ固定幅へ戻す(既に正しければ no-op=チラつき無し)。
-      tmux resize-pane -t "${TMUX_PANE}" -x "$WIDTH" 2>/dev/null || true
+      # ただし、どれかの client が zoom / choose-tree / copy-mode 中は幅補正を一切行わない。
+      # 幅補正の resize は window-size(smallest) の window 再計算を誘発し、zoom 中 window の
+      # pane まで resize されて unzoom する(= prefix-z / prefix-s が操作中に潰れる)。transient
+      # な状態なので、抜けた後の tick で補正すれば十分。
+      sidebar_user_busy || tmux resize-pane -t "${TMUX_PANE}" -x "$WIDTH" 2>/dev/null || true
       # 描画は毎回サブプロセスで実行し、スクリプト更新を自動反映する
       # (常駐ループに関数を抱えると、起動後の更新が反映されず古い表示になるため)
       bash "$SELF" once
@@ -280,6 +292,10 @@ case "${1:-toggle}" in
     # 崩れて広がる。それを WIDTH へ snap し直す。$2 に window_id があればその window のみ対象。
     # 既に WIDTH の pane は resize しない: resize 自体が window-layout-changed を再発火するため、
     # 無条件 resize だと hook 経由で無限ループになる(差分があるときだけ補正 → 1回で収束)。
+    # ユーザが zoom / choose-tree / copy-mode 中は補正パス全体をスキップ。
+    # 他 window の sidebar を resize するだけでも window-size 再計算の連鎖で zoom が
+    # 潰れるため、対象 window 単位ではなくパス全体を止める必要がある。
+    sidebar_user_busy && exit 0
     target_win="${2:-}"
     while IFS=$'\t' read -r win pane; do
       [[ -z "$pane" ]] && continue


### PR DESCRIPTION
## Summary

agent window で prefix-z (zoom) や prefix-s (choose-tree) を操作している最中に、勝手にズームが解除されて元の pane 配置に戻ってしまう問題を修正。

## 根本原因

AI サイドバー (`tmux-agent-sidebar.sh`) は、`window-size` の比例リサイズによる幅ドリフトを補正するため sidebar pane を常時 `resize-pane` する（run ループ 3秒毎 + `client-resized` / `client-session-changed` / `window-layout-changed` hook）。

この幅補正 resize が `window-size smallest` の window 再計算を誘発し、ユーザが zoom した window（prefix-z）や choose-tree（prefix-s は `-Z` で全画面ズーム）中の window の active pane まで resize されて **unzoom** する。sidebar のある agent window で、navigation の度にランダムに発生していた（「claude が動いている時」＝sidebar のある window、と一致）。

対象 window の sidebar pane だけスキップしても不十分だった。他 window の補正 resize が window-size 再計算の連鎖を起こし、zoom 中の window を巻き込むため。

## Changes

- `sidebar_user_busy()` を追加: どれかの client が zoom / choose-tree / copy-mode 中なら true。
- run ループと `resize-all` の両方で、`sidebar_user_busy` が true の間は幅補正 resize を一切行わないようガード。transient な状態なので、抜けた後の tick で補正すれば十分。
- `window-size smallest`（マルチクライアント用）はそのまま維持。

## Test plan

- [x] zoom 中に `resize-all` を25秒間連続実行してもズームが保持されることを実機確認（従来は unzoom）
- [x] `window-size smallest` のまま成立することを確認
- [x] `bash -n` 構文チェック
- [ ] ユーザによる prefix-z / prefix-s の実操作確認（sidebar 稼働 + navigation）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm