### PR TITLE
fix(tmux): window-size を latest に戻す (prefix-z/s が勝手に戻る回帰を修正)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -14,13 +14,17 @@ set -g default-command 'exec "$(command -v zsh 2>/dev/null || echo /bin/bash)"'
 set -g mouse on
 set -g set-clipboard on  # OSC52 clipboard (SSH経由でもコピー可能)
 set -g focus-events on   # Neovim autoread等に必要
-# window のサイズを「最小の attach クライアント」に合わせる。同一 session を別サイズの
-# 複数クライアント (人間の Ghostty + rcon/agent attach) で共有しても、window はサイズを
-# 1 つしか持てないため latest/largest だと小さい側が画面外まで広がる。smallest なら最小
-# 画面 (通常は人間の Ghostty) が常に全体を見られる (大きい側は余白になるだけ)。
+# window のサイズは最後にアクティブだったクライアントに合わせる。
+# 注: 以前 smallest を試したが重大な副作用があり撤回した。smallest は「最小の attach
+# クライアント」に追従するため、client のサイズ/接続が変わる度に window サイズを再計算する。
+# tmux は window サイズが再計算されると zoom を解除する仕様のため、agent が tmux-mcp 等で
+# サーバに触れて一時的な制御クライアントが瞬間 attach/detach する度に、zoom 中 (prefix-z) や
+# choose-tree 中 (prefix-s は -Z でズーム) の window が unzoom され、操作中に元の配置へ戻る
+# 問題が発生した (「claude 稼働中にランダムで戻る」の正体)。latest は一時クライアントに
+# 縮まないため unzoom しない。
 # 注: resize-window は window-size を manual に落とし自動追従を無効化するため使わない
 # (tmux(1): "automatically set window-size to manual")。
-set -g window-size smallest
+set -g window-size latest
 set -g aggressive-resize off  # Claude Code等のTUI再描画チラつき軽減 (default offを明示)
 # 多数 pane 環境では history は pane 数だけ積算され tmux RSS を押し上げる
 # (常駐が大きいと一部が swap に出され再描画でページフォルト→ラグ)。5000 で実用と省メモリを両立。


### PR DESCRIPTION
## Summary

agent window で prefix-z (zoom) / prefix-s (choose-tree) を操作している最中に、勝手にズームが解除されて元の pane 配置に戻ってしまう問題を修正。原因は今セッションで導入した `window-size smallest`。

## 根本原因

`window-size smallest` は「最小の attach クライアント」に window を追従させるため、クライアントのサイズ/接続が変わる度に window サイズを再計算する。tmux は **window サイズが再計算されると zoom を解除する**仕様。

agent が tmux-mcp 等でサーバに触れると一時的な制御クライアントが瞬間 attach/detach する。その度に「最小クライアント」が変わって window が resize され、zoom 中 (prefix-z) や choose-tree 中 (prefix-s は `-Z` でズーム) の window が unzoom されて操作が中断していた。これが以下の症状と一致する:

- 「claude が動いている時に起きる」= agent が tmux-mcp を使う時
- 「ランダム」= agent の呼び出しタイミング次第
- 「agent 自身は tmux を操作していない」= 制御クライアントの attach が引き金 (select 等ではない)

`latest` は一時クライアントに縮まないため unzoom しない。

## Changes

- `set -g window-size smallest` → `latest`（理由コメント更新）

## Test plan

- [x] 実機 (ailab) で `latest` に戻して prefix-z / prefix-s が再発しないことをユーザ確認
- [x] `smallest` では再現、`latest` では停止することを切り分け確認

## 備考

サイドバー幅補正も unzoom を起こす副次経路として PR #262 でガードを入れたが、本 PR (`window-size latest`) が主犯への修正。#262 は defense-in-depth として併存可。`smallest` 導入の狙い (異サイズ複数クライアント共有) はこの副作用の方が実害が大きいため撤回する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm