### PR TITLE
revert(mcp): tmux-mcp の bash-wrapper 固定 (#261) を撤回

### DIFF
--- a/common/claude/.config/claude/mcp.json
+++ b/common/claude/.config/claude/mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "tmux": {
       "type": "stdio",
-      "command": "bash",
-      "args": ["-c", "export PATH=\"$HOME/.local/bin:$PATH\"; exec npx -y tmux-mcp"]
+      "command": "npx",
+      "args": ["-y", "tmux-mcp"]
     },
     "notion": {
       "type": "stdio",


### PR DESCRIPTION
## Summary

#261 (tmux-mcp を bash-wrapper で ~/.local/bin/tmux 3.6a に固定) を撤回し、`npx` 直起動に戻す。

## 理由

#261 は「tmux-mcp が tmux バージョン分裂 (server 3.6a / usr 3.2a) で死んでいる」という**誤診**を発端にした対症療法だった。実際には走っていた tmux-mcp は `~/.pixi/bin/tmux` 3.6 に解決されており、server 3.6a と protocol 互換で正常動作していた (壊れていなかった)。

per-consumer の PATH ラッパは version 分裂という別問題への対症療法であり、今回の症状 (prefix-z/s の revert = window-size smallest) とも無関係。不要なため撤回する。

## Test plan

- [x] tmux-mcp が npx 起動で pixi tmux 3.6 に解決され server と会話できることは調査時に確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm