### PR TITLE
fix(tmux): 残留 window-size manual を config load 時に一掃 (画面リサイズ自動追従を回復)

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -25,6 +25,11 @@ set -g focus-events on   # Neovim autoread等に必要
 # 注: resize-window は window-size を manual に落とし自動追従を無効化するため使わない
 # (tmux(1): "automatically set window-size to manual")。
 set -g window-size latest
+# 既存 window に残った per-window window-size override (廃止した旧 resize-window -A 由来の
+# manual 等) を config load 時に一掃し、全 window をグローバル window-size (latest) へ追従させる。
+# 残留 manual があると client リサイズに自動追従せず表示領域が合わなくなる。unset 済みなら no-op。
+# `##` は run-shell のフォーマット展開をエスケープし、内側 tmux に #{window_id} を渡すため。
+run-shell 'for w in $(tmux list-windows -a -F "##{window_id}"); do tmux set-window-option -t "$w" -u window-size; done'
 set -g aggressive-resize off  # Claude Code等のTUI再描画チラつき軽減 (default offを明示)
 # 多数 pane 環境では history は pane 数だけ積算され tmux RSS を押し上げる
 # (常駐が大きいと一部が swap に出され再描画でページフォルト→ラグ)。5000 で実用と省メモリを両立。


### PR DESCRIPTION
## Summary

client (端末) のサイズが変わっても tmux の表示領域が自動追従せず、画面サイズに合わなくなる問題を修正。

## 根本原因

廃止した旧 `resize-window -A` が各 window に残した `window-size manual` の per-window override が、グローバルの `window-size latest` を上書きしたまま残留していた。`manual` は自動追従を無効化するため、端末リサイズ時に window がサイズを追従しない（実 server で 11 window が manual 残留、client 422x95 に対し window が 315x69 で固定していた）。

現行コードは `resize-window` を一切使わないので `manual` は新規発生しないが、過去に旧コードを通った既存 server には残る。

## Changes

- `set -g window-size latest` 直後に、全 window の per-window `window-size` override を解除する run-shell を追加。config load / reload の度に実行され、残留 manual を self-heal する（unset 済みなら no-op で無害）。

## Test plan

- [x] 実 server で window に `window-size manual` をセット → config reload → override が解除され window が client サイズへ追従することを確認 (422x95 → 422x94)
- [x] `##` エスケープで run-shell のフォーマット展開を回避し内側 tmux に `#{window_id}` が渡ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm