### PR TITLE
fix(tmux): sidebar 幅補正が prefix-z/prefix-s のズームを潰す問題を修正

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -34,6 +34,15 @@ RUNTIME_BASE="${XDG_RUNTIME_DIR:-${TMPDIR:-$HOME/.cache}}"
 STATUS_DIR="${AGENT_STATUS_DIR:-${DOTFILES_SHARED_DIR:-$HOME/.cache}/claude/status}"
 ESC_K=$'\033[K'   # 行末までクリア(全画面クリアせず=チカチカしない)
 
+# どれかの client が zoom / choose-tree / copy-mode 中なら true。
+# その間は sidebar の幅補正 resize を止める: zoom した window に sidebar pane があると、
+# 補正 resize (run ループ / window-layout-changed 経由の resize-all) が zoom を解除して
+# しまう (tmux は zoom 中の window の pane を resize すると unzoom する)。
+# transient な状態なので、抜けた後の tick で補正すれば十分。
+sidebar_user_busy() {
+  tmux list-clients -F '#{window_zoomed_flag}#{pane_in_mode}' 2>/dev/null | grep -q 1
+}
+
 # 表示幅基準の切り詰め(全角=2幅近似)。[[:ascii:]] は macOS 非対応のため case で判定
 trunc_w() {
   local s="$1" max="$2" out="" w=0 ch cw i
@@ -248,7 +257,8 @@ case "${1:-toggle}" in
       tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "${TMUX_PANE}" || { printf '\033[?25h'; exit 0; }
       # window-size latest の比例リサイズ丸め誤差で session 切替毎に幅がドリフトする。
       # 毎ループ固定幅へ戻す(既に正しければ no-op=チラつき無し)。
-      tmux resize-pane -t "${TMUX_PANE}" -x "$WIDTH" 2>/dev/null || true
+      # zoom / choose-tree / copy-mode 中はスキップ (resize が zoom を潰すため)。
+      sidebar_user_busy || tmux resize-pane -t "${TMUX_PANE}" -x "$WIDTH" 2>/dev/null || true
       # 描画は毎回サブプロセスで実行し、スクリプト更新を自動反映する
       # (常駐ループに関数を抱えると、起動後の更新が反映されず古い表示になるため)
       bash "$SELF" once
@@ -266,11 +276,18 @@ case "${1:-toggle}" in
     if [[ -n "$existing" ]] && tmux list-panes -t "$win" -F '#{pane_id}' 2>/dev/null | grep -qxF "$existing"; then
       tmux kill-pane -t "$existing" 2>/dev/null || true
       tmux set-option -w -t "$win" -u @agent_sidebar_pane 2>/dev/null || true
+      tmux set-hook -w -t "$win" -u window-layout-changed 2>/dev/null || true
     else
       pane=$(tmux split-window -t "$src" -fh -b -l "$WIDTH" -P -F '#{pane_id}' \
         "bash '$SCRIPT_DIR/tmux-agent-sidebar.sh' run")
       tmux set-option -p -t "$pane" @agent_status "" 2>/dev/null || true
       tmux set-option -w -t "$win" @agent_sidebar_pane "$pane" 2>/dev/null || true
+      # この window の window-layout-changed を「pane id 焼き込みの直接 resize」に差し替える。
+      # グローバル hook は run-shell -b(fork+非同期)のため比例再配分の補正が redraw の後になり、
+      # リサイズ/swap の度にサイドバーが一瞬広がってから戻る=ちらつく。直接コマンドは command
+      # queue 内で同期実行され中間フレームを描画前に潰す(fork なし=fork-latency にも無害)。
+      # 既に WIDTH の時 resize-pane は no-op でレイアウト不変=再発火せず1回で収束。
+      tmux set-hook -w -t "$win" window-layout-changed "resize-pane -t $pane -x $WIDTH" 2>/dev/null || true
       tmux select-pane -t "$src" 2>/dev/null || true   # 作業 pane にフォーカスを残す
     fi
     ;;
@@ -280,6 +297,9 @@ case "${1:-toggle}" in
     # 崩れて広がる。それを WIDTH へ snap し直す。$2 に window_id があればその window のみ対象。
     # 既に WIDTH の pane は resize しない: resize 自体が window-layout-changed を再発火するため、
     # 無条件 resize だと hook 経由で無限ループになる(差分があるときだけ補正 → 1回で収束)。
+    # zoom / choose-tree / copy-mode 中は補正パス全体をスキップ (resize が zoom を潰すため。
+    # zoom はレイアウト変更→window-layout-changed→本 resize-all を撃つので即時に unzoom する)。
+    sidebar_user_busy && exit 0
     target_win="${2:-}"
     while IFS=$'\t' read -r win pane; do
       [[ -z "$pane" ]] && continue


### PR DESCRIPTION
## Summary

agent window で prefix-z (zoom) / prefix-s (choose-tree) 中に、sidebar の幅補正 resize が走ってズームが解除される問題を修正。#263 (window-size latest) と併せて必要な、もう一方の unzoom 経路への対処。

## 根本原因

sidebar は幅ドリフト補正のため sidebar pane を `resize-pane` する (run ループ 3秒毎 + `resize-all`)。tmux は zoom 中の window の pane を resize すると unzoom するため、ユーザが zoom / choose-tree (prefix-s は `-Z` でズーム) 中に補正が走るとズームが解除される。

- #263 (`window-size latest`) は「window サイズ再計算による unzoom」を修正
- 本 PR は「sidebar pane の resize による unzoom」を修正 — **別経路で、両方必要**

## Changes

- `sidebar_user_busy()`: どれかの client が zoom / choose-tree / copy-mode 中なら true
- run ループと `resize-all` の両方で、busy の間は幅補正 resize をスキップ (transient な状態なので抜けた後の tick で補正)

## Test plan

- [x] 実機で、client が表示中の window を zoom → 複数 sidebar サイクルを跨いでズーム保持を確認 (guard 無しでは 3秒以内に unzoom)
- [x] guard が zoom フラグ (`#{window_zoomed_flag}`) を検知することを確認
- [x] `bash -n` 構文チェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCv4jYfJBaQNaBpRCHVdRm