### PR TITLE
feat(tmux): session group (@group) とグループ対応ナビゲーションを追加

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -154,10 +154,25 @@ bind -r p select-window -t :-
 bind -r n select-window -t :+
 
 # Session navigation
-# choose-tree を名前順 (アルファベット) 固定にして命名規約 (rcon-*, proj-*, pers-*, ops-*)
-# による擬似グルーピングを成立させる。switch-client -p/-n も内部的に名前順で走査するため、
-# choose-tree の表示順と ( / ) の巡回順が一致する。
-bind s choose-tree -Zs -O name
+# Session groups: 各 session の @group user option でグループ化 (名前規約に非依存)。
+# state file 永続化・再適用は tmux-session-group.sh が担当。
+#   prefix+s   : 二段 picker (グループ一覧 menu → グループ内 choose-tree)。
+#                グループ未使用なら従来のフラットな choose-tree にフォールバック。
+#   prefix+C-g : 現 session のグループ設定/解除 (fzf popup。prefix+G は gh-dash が使用済み)
+#   M-h / M-l  : 同グループ内の前/次 session へ (名前順・循環)
+#   M-j / M-k  : 次/前のグループの先頭 session へ (ungrouped は末尾の 1 バケツ扱い)
+# run-shell は -b 必須: display-menu は menu が閉じるまで CLI を返さないため、
+# フォアグラウンド run-shell だと client のコマンドキューを保持してしまう。
+# nav 系も -b でキュー保持を避ける (cb98ccd の fork レイテンシ対策と同方針)。
+# '#{client_name}' 等の引数渡しも必須: run-shell -b の子プロセスは key を押した
+# client/pane の文脈を持たない (tmux が任意の session/pane へ解決し誤動作する) ため、
+# bind 時の format 展開で明示的に渡す。
+bind s run-shell -b "~/dotfiles/scripts/tmux-session-group.sh picker '#{client_name}' '#{pane_id}'"
+bind C-g run-shell -b "~/dotfiles/scripts/tmux-session-group.sh menu-popup '#{client_name}' '#{client_session}'"
+bind -n M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{client_name}' '#{client_session}'"
+bind -n M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
+bind -n M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
+bind -n M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
 bind Tab switch-client -l
 
 # AI Agent 横断ビュー: popup 内にセレクタ + 選択エージェントの実ペインを swap-pane で表示。
@@ -292,6 +307,11 @@ source-file ~/.config/tmux/claude-hooks.tmux
 # -g (上書き) で先に登録するため -gu 不要 (-gu すると claude-hooks 側が消える)。
 set-hook -gu session-created
 set-hook -ga session-created 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh apply #{session_name} 2>/dev/null || true"'
+# Session group 再適用: 同名 session の再作成 (resurrect 復元含む) 時に state file から
+# @group を復元する。rename 時は state file を live 状態に同期。
+set-hook -ga session-created 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh apply #{session_name} 2>/dev/null || true"'
+set-hook -gu session-renamed
+set-hook -ga session-renamed 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh sync 2>/dev/null || true"'
 set-hook -ga client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
 set-hook -gu client-attached
 set-hook -ga client-attached 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
@@ -303,6 +323,9 @@ run-shell "~/dotfiles/scripts/tmux-zoom-hooks.sh"
 
 # 現セッションに即時適用 (config reload & 既存セッション対応)
 run-shell "~/dotfiles/scripts/tmux-session-color.sh apply '#{session_name}' 2>/dev/null || true"
+
+# Session group 復元: server 起動 (config load) 時に state file から全 session へ @group を再適用
+run-shell -b "~/dotfiles/scripts/tmux-session-group.sh restore 2>/dev/null || true"
 
 # --- Plugins (TPM) ---
 set -g @plugin 'tmux-plugins/tpm'

--- a/docs/tools/tmux.md
+++ b/docs/tools/tmux.md
@@ -61,7 +61,8 @@ TokyoNight Night テーマ + 透過背景。Ghostty / Neovim 統合対応。
 
 | キー | 動作 |
 |------|------|
-| `s` | セッション選択（choose-tree、**名前順固定**） |
+| `s` | セッショングループ二段 picker（グループ menu → グループ内 choose-tree。グループ未使用時は従来のフラットな choose-tree） |
+| `C-g` | 現 session のグループ設定/解除（fzf popup、後述の Session グループ参照） |
 | `Tab` | 直前のセッションへトグル切替（`switch-client -l`、sesh 非依存） |
 | `L` | 直前のセッションへ（`sesh last`、picker 履歴を参照） |
 | `9` | 親プロジェクト session へジャンプ（`sesh connect --root`、worktree 等のネストから復帰） |
@@ -69,6 +70,13 @@ TokyoNight Night テーマ + 透過背景。Ghostty / Neovim 統合対応。
 | `)` | 次のセッション（名前順、リピート可） |
 | `f` | 色付きセッション picker（既存 tmux session のみ、`tmux-session-color.sh`）|
 | `C-f` | sesh picker（多段フィルタ: `^a` all / `^t` tmux / `^g` config / `^x` zoxide / `^f` find / `^d` kill）|
+
+prefix 不要のグループ移動キー（root table）:
+
+| キー | 動作 |
+|------|------|
+| `M-h` / `M-l` | 同グループ内の前/次 session へ（名前順・循環） |
+| `M-j` / `M-k` | 次/前のグループの先頭 session へ（ungrouped は末尾の 1 バケツ扱い・循環） |
 
 `choose-tree` と `( / )` は共に名前順で巡回するため、後述の命名規約 (`rcon-*`, `proj-*`, `pers-*`, `ops-*`) に従うとカテゴリ単位で束ねて見える／辿れる。`prefix f` と `prefix C-f` の使い分けは [sesh.md](./sesh.md) 参照。
 
@@ -290,6 +298,26 @@ OFF 中の視覚的変化:
 プレフィックスがアルファベット順で並ぶため、`prefix s` の choose-tree でも `prefix+( / )` の巡回でも近い用途のセッションが隣接する。rcon 由来のセッション名は既に `host-container` 形式で sanitize されているため `rcon-` プレフィックスを足すだけで整合する。
 
 固定セッション（`scratch`、`MAIN`）はプレフィックスなしで運用しても構わないが、choose-tree ではリスト末尾にまとめて並ぶ（大文字 → 小文字、プレフィックスあり → なしの順で分かれる）。
+
+## Session グループ (`@group`)
+
+名前規約に依存しない明示的なセッショングループ。各 session の `@group` user option
+(session-scoped) を唯一の真実とし、session 名は自由に付けられる。実装は
+`scripts/tmux-session-group.sh`。
+
+- 設定: `prefix C-g` の fzf popup で既存グループ選択 / 新規入力 / `(none)` で解除。
+  CLI からは `tmux-session-group.sh set <group> [session]`（グループ名は `A-Za-z0-9_-` のみ）
+- 移動: `M-h/l` で同グループ内、`M-j/k` でグループ間（前述のキー表参照）
+- 一覧: `prefix s` がグループ menu → 選択グループのみの choose-tree という二段 picker になる。
+  menu の `u` で ungrouped、`a` で全 session のフラット表示
+- 永続化: user option は tmux server 再起動で消え resurrect も復元しないため、
+  `$XDG_STATE_HOME/tmux/session-groups`（`session名<TAB>group`）に同期し、
+  session-created hook / config load で再適用する。死んだ session のエントリは
+  保持され、同名 session の再作成（resurrect 復元含む）時に自動でグループが戻る
+
+worktree 毎に session を切る運用では、session 作成側で
+`tmux-session-group.sh set <repo名> <session名>` を呼べば同一プロジェクトの
+worktree 群が 1 グループにまとまる。
 
 ## Per-session アクセントカラー
 

--- a/scripts/tmux-session-group.sh
+++ b/scripts/tmux-session-group.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Session groups for tmux.
+# 各 session の @group user option (session-scoped) を唯一の真実とし、
+# session 名には依存しない (名前は自由に付けられる)。user option は tmux server
+# 再起動で消え resurrect も復元しないため、state file に永続化して
+# session-created hook / config load 時に再適用する。
+#
+# Subcommands:
+#   set <group>             — 現在の session にグループを設定 (A-Za-z0-9_- のみ)
+#   unset                   — 現在の session からグループを外す
+#   menu                    — fzf popup: 既存グループ選択 / 新規入力 / (none) で解除
+#   next | prev             — 同グループ内の次/前の session へ (名前順・循環)
+#   next-group | prev-group — 隣のグループの先頭 session へ (循環)
+#   picker                  — グループ一覧メニュー → グループ内 choose-tree の二段 picker
+#   apply <session>         — state file からグループを再適用 (session-created hook 用)
+#   restore                 — 全 live session に apply (config load 用)
+#   sync                    — live の @group を state file へ書き出し (session-renamed hook 用)
+#
+# state file: $XDG_STATE_HOME/tmux/session-groups (session_name<TAB>group)
+# 死んでいる session のエントリは保持する (resurrect 後の同名 session に再適用するため)。
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/tmux"
+STATE_FILE="$STATE_DIR/session-groups"
+TAB=$'\t'
+
+# name<TAB>group を名前順で出力 (@group は format 展開で session-scoped に解決される)
+list_all() {
+  tmux list-sessions -F "#{session_name}${TAB}#{@group}" 2>/dev/null | sort
+}
+
+# run-shell -b の子プロセスは key を押した client/pane の文脈を持たない (tmux が
+# 「最後に使った session」等へ勝手に解決し誤動作する) ため、bind 側の format 展開で
+# '#{client_name}' '#{client_session}' 等を引数として受け取る。引数がなければ
+# (pane 内での手動実行など) 文脈解決にフォールバック。
+sess_of()     { [ -n "${1:-}" ] && printf '%s' "$1" || tmux display-message -p '#{session_name}'; }
+cur_group()   { tmux show-options -t "$1" -qv @group; }
+
+# $1: client_name ('' なら文脈解決), $2: target session
+switch_to() {
+  if [ -n "$1" ]; then
+    tmux switch-client -c "$1" -t "$2"
+  else
+    tmux switch-client -t "$2"
+  fi
+}
+
+cmd_sync() {
+  mkdir -p "$STATE_DIR"
+  local tmp
+  tmp=$(mktemp "$STATE_DIR/.session-groups.XXXXXX") || return 1
+  {
+    # live の非空グループ + live に存在しない (死んだ) session の既存エントリ
+    list_all | awk -F "$TAB" '$2 != ""'
+    [ -f "$STATE_FILE" ] &&
+      awk -F "$TAB" 'NR==FNR { live[$1] = 1; next } !($1 in live)' \
+        <(list_all) "$STATE_FILE"
+  } > "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
+
+cmd_apply() {
+  local session="$1" grp
+  [ -n "$session" ] && [ -f "$STATE_FILE" ] || return 0
+  grp=$(awk -F "$TAB" -v s="$session" '$1 == s { print $2; exit }' "$STATE_FILE")
+  [ -n "$grp" ] && tmux set-option -t "$session" @group "$grp"
+  return 0
+}
+
+cmd_restore() {
+  local s
+  while IFS= read -r s; do
+    cmd_apply "$s"
+  done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null)
+}
+
+cmd_set() {
+  local sess="$1" grp="$2"
+  # `,` は choose-tree filter (#{==:...}) を、空白等は menu/hook を壊すため制限
+  case "$grp" in
+    '' | *[!A-Za-z0-9_-]*)
+      tmux display-message "invalid group name: '$grp' (A-Za-z0-9_- only)"
+      return 1
+      ;;
+  esac
+  tmux set-option -t "$sess" @group "$grp"
+  cmd_sync
+}
+
+cmd_unset() {
+  tmux set-option -t "$1" -u @group
+  cmd_sync
+}
+
+# $1: client_name, $2: client_session — menu popup を開くラッパー。
+# display-popup はコマンド文字列を format 展開せず、popup 内の display-message も
+# client の session を解決できない (任意の session に化ける) ため、format 展開が
+# 正しく効く run-shell -b から本サブコマンドを経由して session 名を焼き込む。
+cmd_menu_popup() {
+  local client="${1:-}" sess="${2:-}"
+  local popup_opts=()
+  [ -n "$client" ] && popup_opts=(-c "$client")
+  tmux display-popup "${popup_opts[@]}" -E -w 50% -h 50% "'$0' menu '$sess'"
+}
+
+# display-popup -E 内で実行される前提 (fzf が pty を要求するため)
+cmd_menu() {
+  local cur out rc sel
+  cur=$(sess_of "${1:-}")
+  out=$(
+    {
+      echo "(none)"
+      list_all | awk -F "$TAB" '$2 != "" { print $2 }' | sort -u
+    } | fzf --print-query \
+        --prompt "group ($cur)> " \
+        --header "select / type new group / (none) clears"
+  )
+  rc=$?
+  # 0=選択, 1=マッチなし (query を新規グループ名として採用), 130=abort
+  [ $rc -ne 0 ] && [ $rc -ne 1 ] && return 0
+  sel=$(printf '%s' "$out" | tail -n 1)
+  [ -z "$sel" ] && return 0
+  if [ "$sel" = "(none)" ]; then
+    cmd_unset "$cur"
+  else
+    cmd_set "$cur" "$sel"
+  fi
+}
+
+# $1: 1 (next) / -1 (prev), $2: client_name, $3: current session — 同グループ内を名前順で循環
+cmd_step() {
+  local dir="$1" client="${2:-}" cur grp s n i idx=0
+  local members=()
+  cur=$(sess_of "${3:-}")
+  grp=$(cur_group "$cur")
+  while IFS= read -r s; do
+    members+=("$s")
+  done < <(list_all | awk -F "$TAB" -v g="$grp" '$2 == g { print $1 }')
+  n=${#members[@]}
+  if [ "$n" -le 1 ]; then
+    tmux display-message -d 800 "no other session in group '${grp:-ungrouped}'"
+    return 0
+  fi
+  for ((i = 0; i < n; i++)); do
+    [ "${members[$i]}" = "$cur" ] && idx=$i
+  done
+  switch_to "$client" "${members[$(((idx + dir + n) % n))]}"
+}
+
+# $1: 1 (next-group) / -1 (prev-group), $2: client_name, $3: current session —
+# グループ間を循環し先頭 session へ。
+# ungrouped session 群は末尾の 1 バケツ (空文字グループ) として扱う
+cmd_step_group() {
+  local dir="$1" client="${2:-}" cur grp all g n i idx=0 target
+  local grps=()
+  cur=$(sess_of "${3:-}")
+  grp=$(cur_group "$cur")
+  all=$(list_all)
+  while IFS= read -r g; do
+    grps+=("$g")
+  done < <(printf '%s\n' "$all" | awk -F "$TAB" '$2 != "" { print $2 }' | sort -u)
+  if printf '%s\n' "$all" | awk -F "$TAB" '$2 == "" { found = 1 } END { exit !found }'; then
+    grps+=("")
+  fi
+  n=${#grps[@]}
+  if [ "$n" -le 1 ]; then
+    tmux display-message -d 800 "no other session group"
+    return 0
+  fi
+  for ((i = 0; i < n; i++)); do
+    [ "${grps[$i]}" = "$grp" ] && idx=$i
+  done
+  target="${grps[$(((idx + dir + n) % n))]}"
+  switch_to "$client" "$(printf '%s\n' "$all" | awk -F "$TAB" -v g="$target" '$2 == g { print $1; exit }')"
+}
+
+# $1: client_name, $2: pane_id — menu 表示先の client と choose-tree を開く pane。
+# 明示ターゲット必須: menu 選択コマンドは選択した client の文脈で実行されず、
+# サーバー側の「最後に使った pane」等へ勝手に解決されて見えない pane に mode が開く。
+cmd_picker() {
+  local client="${1:-}" pane="${2:-}" all g n i key tgt=''
+  local grps=() args=() menu_opts=()
+  [ -n "$pane" ] && tgt=" -t '$pane'"
+  [ -n "$client" ] && menu_opts=(-c "$client")
+  all=$(list_all)
+  while IFS= read -r g; do
+    [ -n "$g" ] && grps+=("$g")
+  done < <(printf '%s\n' "$all" | awk -F "$TAB" '$2 != "" { print $2 }' | sort -u)
+  # グループが 1 つもなければ従来のフラットな choose-tree へ
+  if [ ${#grps[@]} -eq 0 ]; then
+    if [ -n "$pane" ]; then
+      exec tmux choose-tree -Zs -O name -t "$pane"
+    fi
+    exec tmux choose-tree -Zs -O name
+  fi
+  # filter の ## エスケープ必須: menu item のコマンドは実行時に一度 format 展開される
+  # ため、素の #{...} だと空文脈で '0' に潰れて filter が全滅する
+  i=1
+  for g in "${grps[@]}"; do
+    n=$(printf '%s\n' "$all" | awk -F "$TAB" -v g="$g" '$2 == g' | grep -c .)
+    key=''
+    [ $i -le 9 ] && key=$i
+    args+=("$g ($n)" "$key" "choose-tree -Zs -O name$tgt -f '##{==:##{@group},$g}'")
+    i=$((i + 1))
+  done
+  n=$(printf '%s\n' "$all" | awk -F "$TAB" '$2 == ""' | grep -c .)
+  [ "$n" -gt 0 ] &&
+    args+=("(ungrouped) ($n)" u "choose-tree -Zs -O name$tgt -f '##{==:##{@group},}'")
+  args+=("")
+  args+=("all sessions" a "choose-tree -Zs -O name$tgt")
+  tmux display-menu "${menu_opts[@]}" -T " Session Groups " -x C -y C "${args[@]}"
+}
+
+case "${1:-}" in
+  set)        cmd_set "$(sess_of "${3:-}")" "${2:-}" ;;
+  unset)      cmd_unset "$(sess_of "${2:-}")" ;;
+  menu-popup) cmd_menu_popup "${2:-}" "${3:-}" ;;
+  menu)       cmd_menu "${2:-}" ;;
+  next)       cmd_step 1 "${2:-}" "${3:-}" ;;
+  prev)       cmd_step -1 "${2:-}" "${3:-}" ;;
+  next-group) cmd_step_group 1 "${2:-}" "${3:-}" ;;
+  prev-group) cmd_step_group -1 "${2:-}" "${3:-}" ;;
+  picker)     cmd_picker "${2:-}" "${3:-}" ;;
+  apply)      cmd_apply "${2:-}" ;;
+  restore)    cmd_restore ;;
+  sync)       cmd_sync ;;
+  *)
+    echo "usage: $(basename "$0") {set <group> [session]|unset [session]|menu [session]" \
+         "|next|prev|next-group|prev-group [client] [session]|picker [client] [pane]|apply <session>|restore|sync}" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

セッションを名前規約に依存せず明示的にグループ化する仕組みを追加。各 session の `@group` user option を唯一の真実とし、state file 永続化で server 再起動・resurrect 復元後もグループが維持される。worktree 毎にセッションを切る運用で、同一プロジェクトの worktree 群を 1 グループにまとめる用途を想定。

## Changes

- `scripts/tmux-session-group.sh` を新規追加
  - `set` / `unset` / `menu` (fzf popup) でグループ管理
  - `next` / `prev` (同グループ内循環)、`next-group` / `prev-group` (グループ間移動、ungrouped は末尾の 1 バケツ扱い)
  - `picker`: グループ一覧 menu → グループ内 choose-tree の二段 picker。グループ未使用時は従来のフラット choose-tree にフォールバック
  - `sync` / `apply` / `restore`: `$XDG_STATE_HOME/tmux/session-groups` への永続化と再適用 (死んだ session のエントリは保持し、同名再作成時に復元)
- `tmux.conf`
  - `prefix+s` を二段 picker に変更、`prefix+C-g` でグループ設定 popup
  - `M-h/l` (グループ内移動)、`M-j/k` (グループ間移動) を root table に追加
  - session-created / session-renamed hook と config load 時の restore を登録
- `docs/tools/tmux.md` にキーバインドと仕組みを追記

実装中に判明した tmux の挙動 (コード内コメントに記録):

- bind の `run-shell -b` 子プロセスは押した client/pane の文脈を持たないため、`#{client_name}` 等を bind 時の format 展開で引数渡しする必要がある
- display-menu の item コマンドは実行時に一度 format 展開されるため、choose-tree filter は `##` エスケープが必要
- display-popup はコマンド文字列を format 展開せず、popup 内からの session 解決も不正確なため、run-shell 経由のラッパー (`menu-popup`) で session 名を焼き込む

## Test plan

- [x] 隔離 tmux server + ネスト tmux の実 pty client で実キー入力 E2E (M-h/l/j/k の全パターン・wrap 含む)
- [x] prefix+s: menu 表示 → グループ選択 → filter 済み choose-tree → session 選択で switch
- [x] prefix+C-g: 新規グループ設定 / `(none)` で解除、state file 同期
- [x] グループ 0 個時の prefix+s フラット choose-tree フォールバック
- [x] state 永続化: session kill 後もエントリ保持、同名再作成で apply、restore で全 session 再適用
- [x] グループ名バリデーション (`A-Za-z0-9_-` 以外を拒否)
- [x] ライブ server への config reload で bind / hook 登録を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1ACDW6bGodE3KFD6cb2Qy