### PR TITLE
fix(tmux): aerospace と衝突しない C-M-hjkl の session group 移動キーを追加

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -173,6 +173,13 @@ bind -n M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{clien
 bind -n M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
 bind -n M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
 bind -n M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
+# C-M-hjkl は M-hjkl の別名。ローカル macOS では aerospace が alt-hjkl / alt-shift-hjkl を
+# グローバルに掴んでいて terminal まで届かないため、Ctrl 併用で回避する。
+# aerospace のいない環境 (リモート Linux 等) では M-hjkl がそのまま使える。
+bind -n C-M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{client_name}' '#{client_session}'"
+bind -n C-M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
+bind -n C-M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
+bind -n C-M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
 bind Tab switch-client -l
 
 # AI Agent 横断ビュー: popup 内にセレクタ + 選択エージェントの実ペインを swap-pane で表示。

--- a/docs/tools/tmux.md
+++ b/docs/tools/tmux.md
@@ -75,8 +75,12 @@ prefix 不要のグループ移動キー（root table）:
 
 | キー | 動作 |
 |------|------|
-| `M-h` / `M-l` | 同グループ内の前/次 session へ（名前順・循環） |
-| `M-j` / `M-k` | 次/前のグループの先頭 session へ（ungrouped は末尾の 1 バケツ扱い・循環） |
+| `M-h` / `M-l` (`C-M-h` / `C-M-l`) | 同グループ内の前/次 session へ（名前順・循環） |
+| `M-j` / `M-k` (`C-M-j` / `C-M-k`) | 次/前のグループの先頭 session へ（ungrouped は末尾の 1 バケツ扱い・循環） |
+
+ローカル macOS では aerospace が `alt-hjkl` / `alt-shift-hjkl` をウィンドウ操作で
+グローバルに掴んでいるため、`C-M-hjkl`（Ctrl+Option+hjkl）を使う。aerospace の
+いない環境（リモート Linux 等）では `M-hjkl` がそのまま届く。
 
 `choose-tree` と `( / )` は共に名前順で巡回するため、後述の命名規約 (`rcon-*`, `proj-*`, `pers-*`, `ops-*`) に従うとカテゴリ単位で束ねて見える／辿れる。`prefix f` と `prefix C-f` の使い分けは [sesh.md](./sesh.md) 参照。
 


### PR DESCRIPTION
## Summary

#269 の M-hjkl (Alt+hjkl) session group 移動キーが、ローカル macOS では aerospace のグローバルバインド (`alt-hjkl` = focus 移動, `alt-shift-hjkl` = window 移動) に横取りされ terminal まで届かない問題への対応。`C-M-hjkl` (Ctrl+Option+hjkl) を別名として追加する。

## Changes

- `tmux.conf`: `C-M-h/l` (同グループ内移動) / `C-M-j/k` (グループ間移動) を root table に追加。既存の `M-hjkl` は aerospace のいないリモート Linux 等でそのまま使えるため残す
- `docs/tools/tmux.md`: キー表と aerospace 衝突の注記を更新

## Test plan

- [x] 隔離 tmux server + ネスト tmux の実 pty client で C-M-hjkl 全 4 キーの実キー入力 E2E (グループ内循環・グループ間移動・wrap)
- [x] ライブ server への config reload で root table に 4 bind の登録を確認
- [ ] Ghostty + aerospace 環境で Ctrl+Option+hjkl の実操作確認 (ユーザー確認待ち)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1ACDW6bGodE3KFD6cb2Qy