### PR TITLE
fix(tmux): リモートのセッション移動 UX を修正 (ちらつき + バイナリ不一致)

### DIFF
--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -23,11 +23,14 @@ export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
 export TMUX_TMPDIR="${TMUX_TMPDIR:-${XDG_RUNTIME_DIR:-$HOME/.cache}}"
 
 # --- Path ---
-# Local bin (sheldon, zoxide, mise, etc.)
-[[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
-
 # Pixi global bin (no-sudo install: eza, bat, gh, fd, jq, rg, ...)
 [[ -d "$HOME/.pixi/bin" ]] && export PATH="$HOME/.pixi/bin:$PATH"
+
+# Local bin (source-built tmux 3.6a, sheldon, zoxide, mise, etc.). Prepended
+# AFTER .pixi/bin so ~/.local/bin wins over it. pixi の conda-forge tmux 3.6 は
+# attach 時にクラッシュする ("server exited unexpectedly") ため、source-built の
+# 3.6a で shadow する必要がある。.zshenv / rcon() と同順序。
+[[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
 
 # Bun (installed via curl_pipe into ~/.bun; installer exports this in .bashrc but
 # not in .zshrc, so zsh sessions miss it without this line)

--- a/scripts/tmux-layout
+++ b/scripts/tmux-layout
@@ -281,7 +281,18 @@ def apply_preset(name: str, win: str, *, quiet: bool = False) -> int:
     for src, dst in zip(leaves(preset_tree), leaves(current_tree)):
         src.pane_id = dst.pane_id
     rescale(preset_tree, current_tree.w, current_tree.h, current_tree.x, current_tree.y)
-    run(["tmux", "select-layout", "-t", win, with_checksum(serialize(preset_tree))])
+    # Skip select-layout when the window already matches the preset. Autoapply fires
+    # on every session/window switch (pane-focus-in / client-session-changed); an
+    # unconditional select-layout re-lays-out (and force-unzooms) even when nothing
+    # drifted, which shows as a flicker on each move — worse on a fork-latency-bound
+    # server where the async hook lands a frame after the switch already redrew.
+    target = serialize(preset_tree)
+    if target == serialize(current_tree):
+        run(["tmux", "set-window-option", "-t", win, "@layout-preset", name])
+        if not quiet:
+            print(f"applied {name} to {win}")
+        return 0
+    run(["tmux", "select-layout", "-t", win, with_checksum(target)])
     run(["tmux", "set-window-option", "-t", win, "@layout-preset", name])
     if not quiet:
         print(f"applied {name} to {win}")


### PR DESCRIPTION
## 背景

ssh ailab remote で C-M-hjkl (session group 移動) を押す度に pane 構成が一瞬変わって元に戻るちらつきが出る問題の原因究明と修正。調査中に別の根本バグ (tmux バイナリ不一致) も判明したため同時に修正する。

## 修正

### 1. ちらつき (根治): tmux-layout autoapply の冪等化
`apply_preset` は現在の window レイアウトが preset と一致していても無条件で `select-layout` (force-unzoom 付き) を実行していた。autoapply は `pane-focus-in` / `client-session-changed` の度に発火するため、セッション移動毎に不要な relayout が走りちらついていた。

現レイアウトが preset と一致する場合は `select-layout` をスキップするガードを追加。`serialize(parse(x)) == x` の round-trip 恒等で比較が成立することを確認済み。

### 2. `server exited unexpectedly` (根治): PATH 順の不一致
- 稼働サーバ (rcon 起動): `~/.local/bin/tmux` = 3.6a
- 対話シェルで勝つ tmux: `~/.pixi/bin/tmux` = 3.6 (conda-forge, attach でクラッシュする既知物)

`.zshenv` と `rcon()` は `.local/bin` 優先で揃っていたが、`.zshrc.common` だけ PATH 構築順が逆で `.zshenv` の正しい順序を上書きし pixi 3.6 を勝たせていた。3.6 client が 3.6a server に触ると弾かれる。`.zshrc.common` を `.pixi/bin`→`.local/bin` の順 (.zshenv と同順) に修正。

## 検証

- round-trip 恒等 / guard 比較を実測
- PATH 解決をシミュレートし `.local/bin` 先頭を確認
- 構文チェック (python compile / zsh -n)

サーバ再起動は不要 (稼働中 3.6a サーバはそのまま正しい)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)