### PR TITLE
fix(tmux): サイドバーがある window では layout autoapply をスキップ (flicker 根治)

### DIFF
--- a/scripts/tmux-layout
+++ b/scripts/tmux-layout
@@ -325,6 +325,15 @@ def cmd_autoapply(args: argparse.Namespace) -> int:
     name = tmux_get("#{@layout-preset}", win)
     if not name:
         return 0
+    # Defer to the agent sidebar's own width management. A window with an open
+    # sidebar pane force-holds it at a fixed width (tmux-agent-sidebar resize-all).
+    # If the preset was saved at a different sidebar width, autoapply keeps re-applying
+    # the preset width while resize-all snaps it back — an endless fight visible as a
+    # sidebar flicker on every session switch. The idempotency guard can't break it
+    # because the two never converge. Skip while a sidebar is open; the preset applies
+    # once it's closed.
+    if tmux_get("#{@agent_sidebar_pane}", win):
+        return 0
     # Yield to the user's active zoom / pane mode. apply_preset runs `select-layout`,
     # which force-unzooms and cancels choose-tree/copy-mode — so a background
     # focus/session event (agent churn while Claude works) would snap a manually


### PR DESCRIPTION
## 背景

#271 で autoapply を冪等化したが、C-M-hjkl のセッション移動時のちらつきが残っていた。実測で真の原因を特定。

## 根本原因 (実測で確定)

対象 window は sidebar pane と `@layout-preset=vertical` を両方持つ。保存済み preset のサイドバー列は幅33、ライブのサイドバーは固定幅40。セッション切替の度に:

1. autoapply が preset を適用 → サイドバー列が 33 になる
2. tmux-agent-sidebar の resize-all がサイドバーを 40 へ戻す

の綱引きが発生。両者は永久に収束しない (preset=33 ⇔ 固定=40) ため、#271 の冪等ガード (current==preset ならスキップ) は発火しない。

switch-client の A/B 実測:
- preset あり: サイドバー幅が `40 → 33 → 40` と振動 (ちらつき本体)
- preset を外す: `40` 固定、遷移ゼロ

## 修正

`cmd_autoapply` で、window が sidebar pane (`@agent_sidebar_pane`) を持つ場合はスキップ。サイドバーの幅管理に委ね、綱引きを断つ。サイドバーを閉じれば preset は通常通り適用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)