### PR TITLE
feat(tmux): remember session group selection in sidebar

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -160,7 +160,7 @@ bind -r n select-window -t :+
 #                グループ未使用なら従来のフラットな choose-tree にフォールバック。
 #   prefix+C-g : 現 session のグループ設定/解除 (fzf popup。prefix+G は gh-dash が使用済み)
 #   M-h / M-l  : 同グループ内の前/次 session へ (名前順・循環)
-#   M-j / M-k  : 次/前のグループの先頭 session へ (ungrouped は末尾の 1 バケツ扱い)
+#   M-j / M-k  : 次/前のグループで最後に見ていた session へ (ungrouped は末尾の 1 バケツ扱い)
 # run-shell は -b 必須: display-menu は menu が閉じるまで CLI を返さないため、
 # フォアグラウンド run-shell だと client のコマンドキューを保持してしまう。
 # nav 系も -b でキュー保持を避ける (cb98ccd の fork レイテンシ対策と同方針)。
@@ -320,6 +320,7 @@ set-hook -ga session-created 'run-shell -b "~/dotfiles/scripts/tmux-session-grou
 set-hook -gu session-renamed
 set-hook -ga session-renamed 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh sync 2>/dev/null || true"'
 set-hook -ga client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -ga client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh remember #{session_name} 2>/dev/null || true"'
 set-hook -gu client-attached
 set-hook -ga client-attached 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
 set-hook -gu after-new-window

--- a/docs/tools/tmux.md
+++ b/docs/tools/tmux.md
@@ -76,7 +76,7 @@ prefix 不要のグループ移動キー（root table）:
 | キー | 動作 |
 |------|------|
 | `M-h` / `M-l` (`C-M-h` / `C-M-l`) | 同グループ内の前/次 session へ（名前順・循環） |
-| `M-j` / `M-k` (`C-M-j` / `C-M-k`) | 次/前のグループの先頭 session へ（ungrouped は末尾の 1 バケツ扱い・循環） |
+| `M-j` / `M-k` (`C-M-j` / `C-M-k`) | 次/前のグループで最後に見ていた session へ（未記録なら先頭、ungrouped は末尾の 1 バケツ扱い・循環） |
 
 ローカル macOS では aerospace が `alt-hjkl` / `alt-shift-hjkl` をウィンドウ操作で
 グローバルに掴んでいるため、`C-M-hjkl`（Ctrl+Option+hjkl）を使う。aerospace の
@@ -461,7 +461,7 @@ tmux-which-key 設定:
 
 AI エージェント状態監視（自前スクリプト）:
 - `scripts/tmux-agent-status.sh` が `~/.claude/projects/**/*.jsonl` を監視し、各セッションの Claude Code / Codex / Amp の running / done / error 状態を判定
-- `scripts/tmux-agent-sidebar.sh` が全エージェント状態を常時表示する pane を管理
+- `scripts/tmux-agent-sidebar.sh` がセッショングループ別のセッション一覧と全エージェント状態を常時表示する pane を管理（現在のグループ/セッションをハイライト）
 
 | キー | 動作 |
 |------|------|

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -6,11 +6,13 @@
 # 仕様: docs/specs/agent-stop-notification.md §5.3
 #
 # 表示例:
-#   AGENTS 5
+#   SESSIONS 4  AGENTS 5
 #   ──────────────
-#   main      󰌆 󰔟 ●
-#   scratch   ●
-#   ailab     󰔟
+#   ▸ work
+#     ▶ main  󰌆 󰔟 ●
+#       api   ●
+#   ▾ ungrouped
+#       scratch
 #
 # Usage:
 #   tmux-agent-sidebar.sh run      # サイドバー pane 内ループ(自動更新・非フリッカー)
@@ -32,6 +34,7 @@ REFRESH="${AGENT_SIDEBAR_REFRESH:-3}"
 WIDTH="${AGENT_SIDEBAR_WIDTH:-40}"
 RUNTIME_BASE="${XDG_RUNTIME_DIR:-${TMPDIR:-$HOME/.cache}}"
 STATUS_DIR="${AGENT_STATUS_DIR:-${DOTFILES_SHARED_DIR:-$HOME/.cache}/claude/status}"
+TAB=$'\t'
 ESC_K=$'\033[K'   # 行末までクリア(全画面クリアせず=チカチカしない)
 
 # どれかの client が zoom / choose-tree / copy-mode 中なら true。
@@ -106,19 +109,9 @@ collect_agents() {
     ' "${files[@]}" 2>/dev/null)
 }
 
-# セッションブロックを出力(セッション名を独立行、アイコンは折返してインデント表示)。
-# 動的スコープで render の cur/glyphs/WIDTH/_lines を参照し、_lines 配列に追記する。
-_sb_flush() {
-  [[ -z "$cur" ]] && return
-  _lines+=("$(printf '%s%s%s' "$C_BOLD" "$(trunc_w "$cur" $(( WIDTH - 2 )))" "$C_RST")")
-  local per=$(( (WIDTH - 4) / 2 )); (( per < 1 )) && per=1
-  local i=0 line="  " g
-  for g in "${glyphs[@]}"; do
-    line+="$g "
-    (( i++ ))
-    if (( i % per == 0 )); then _lines+=("$line"); line="  "; fi
-  done
-  [[ "$line" != "  " ]] && _lines+=("$line")
+session_glyphs() {
+  local rows="$1" sess="$2"
+  printf '%s\n' "$rows" | awk -F "$TAB" -v s="$sess" '$1 == s { printf "%s ", $3 }'
 }
 
 # 各 AI の使用量(セッションリミット)を2行で出力(1行目: アイコン+残り時間 / 2行目: ゲージ+%)
@@ -172,11 +165,13 @@ usage_section() {
 }
 
 render() {
-  local rows total cur="" s _rank glyph
-  local glyphs=()
-  local _lines=()   # AGENTS ブロックの各行(_sb_flush が追記)
+  local rows total sessions session_count cur_session cur_group
   rows=$(collect_agents | sort -t$'\t' -k1,1 -k2,2n)
   total=$(printf '%s' "$rows" | grep -c . 2>/dev/null)
+  sessions=$(tmux list-sessions -F "#{session_name}${TAB}#{@group}" 2>/dev/null | sort)
+  session_count=$(printf '%s' "$sessions" | grep -c . 2>/dev/null)
+  cur_session=$(tmux display-message -p -t "${TMUX_PANE}" '#{session_name}' 2>/dev/null || true)
+  cur_group=$(tmux show-options -t "$cur_session" -qv @group 2>/dev/null || true)
 
   # --- pane の幅/高さを取得(divider 長・最下部揃えに使用) ---
   local H W
@@ -190,25 +185,38 @@ render() {
   # divider は pane 幅ちょうどの罫線(リサイズに追従、折返し防止)
   local div; div=$(printf '─%.0s' $(seq 1 "$W"))
 
-  # --- AGENTS ブロックを配列に構築(上部) ---
+  # --- SESSIONS ブロックを配列に構築(上部) ---
   local top=()
-  top+=("$(printf '%s AGENTS%s %s%s%s' "$C_BOLD" "$C_RST" "$C_DIM" "$total" "$C_RST")")
+  top+=("$(printf '%s SESSIONS%s %s%s  AGENTS %s%s' "$C_BOLD" "$C_RST" "$C_DIM" "$session_count" "$total" "$C_RST")")
   top+=("$(printf '%s%s%s' "$C_DIM" "$div" "$C_RST")")
-  if [[ -z "$rows" ]]; then
-    top+=("$(printf '%s(エージェントなし)%s' "$C_DIM" "$C_RST")")
+  if [[ -z "$sessions" ]]; then
+    top+=("$(printf '%s(セッションなし)%s' "$C_DIM" "$C_RST")")
   else
-    # セッションごとに: 名前を独立行、アイコンを折返してインデント表示
-    while IFS=$'\t' read -r s _rank glyph; do
-      [[ -z "$s" ]] && continue
-      if [[ "$s" != "$cur" ]]; then
-        _sb_flush
-        cur="$s"; glyphs=("$glyph")
+    local groups=() g s label marker name icons line
+    while IFS= read -r g; do [[ -n "$g" ]] && groups+=("$g"); done < <(printf '%s\n' "$sessions" | awk -F "$TAB" '$2 != "" { print $2 }' | sort -u)
+    if printf '%s\n' "$sessions" | awk -F "$TAB" '$2 == "" { found = 1 } END { exit !found }'; then groups+=(""); fi
+    for g in "${groups[@]}"; do
+      label="${g:-ungrouped}"
+      if [[ "$g" == "$cur_group" ]]; then
+        top+=("$(printf '%s▸ %s%s' "$C_CUR$C_BOLD" "$(trunc_w "$label" $(( WIDTH - 3 )))" "$C_RST")")
       else
-        glyphs+=("$glyph")
+        top+=("$(printf '%s▾ %s%s' "$C_DIM" "$(trunc_w "$label" $(( WIDTH - 3 )))" "$C_RST")")
       fi
-    done <<< "$rows"
-    _sb_flush
-    top+=("${_lines[@]}")
+      while IFS= read -r s; do
+        [[ -z "$s" ]] && continue
+        icons=$(session_glyphs "$rows" "$s")
+        marker="  "
+        [[ "$s" == "$cur_session" ]] && marker="▶ "
+        name=$(trunc_w "$s" $(( WIDTH - 6 )))
+        line="  ${marker}${name}"
+        [[ -n "$icons" ]] && line+=" $icons"
+        if [[ "$s" == "$cur_session" ]]; then
+          top+=("$(printf '%s%s%s' "$C_CUR$C_BOLD" "$line" "$C_RST")")
+        else
+          top+=("$line")
+        fi
+      done < <(printf '%s\n' "$sessions" | awk -F "$TAB" -v g="$g" '$2 == g { print $1 }')
+    done
   fi
 
   # --- USAGE ブロックを配列に構築(下部) ---
@@ -222,7 +230,7 @@ render() {
   local pad=$(( H - n_top - n_bot ))
   (( pad < 1 )) && pad=1   # 重なり防止に最低1行は空ける
 
-  # 全行を1配列にまとめる(上: AGENTS / 中: パディング / 下: USAGE)
+  # 全行を1配列にまとめる(上: SESSIONS / 中: パディング / 下: USAGE)
   local out=()
   local i
   for (( i = 0; i < n_top; i++ )); do out+=("${top[i]}"); done
@@ -231,7 +239,7 @@ render() {
 
   # 1フレームを1文字列に組み立て、同期更新(DEC 2026)で囲んで1回の write でアトミックに出す。
   # 行ごとに printf するとティアリング(部分描画)でちらつくため必ずまとめて出力する。
-  # 最終行に改行を付けると1行スクロールし先頭(AGENTS ヘッダー)が画面外へ落ちるため改行なし。
+  # 最終行に改行を付けると1行スクロールし先頭(SESSIONS ヘッダー)が画面外へ落ちるため改行なし。
   local frame="" n_out=${#out[@]}
   for (( i = 0; i < n_out; i++ )); do
     if (( i < n_out - 1 )); then

--- a/scripts/tmux-session-group.sh
+++ b/scripts/tmux-session-group.sh
@@ -10,11 +10,12 @@
 #   unset                   — 現在の session からグループを外す
 #   menu                    — fzf popup: 既存グループ選択 / 新規入力 / (none) で解除
 #   next | prev             — 同グループ内の次/前の session へ (名前順・循環)
-#   next-group | prev-group — 隣のグループの先頭 session へ (循環)
+#   next-group | prev-group — 隣のグループで最後に見ていた session へ (循環)
 #   picker                  — グループ一覧メニュー → グループ内 choose-tree の二段 picker
 #   apply <session>         — state file からグループを再適用 (session-created hook 用)
 #   restore                 — 全 live session に apply (config load 用)
 #   sync                    — live の @group を state file へ書き出し (session-renamed hook 用)
+#   remember <session>      — その session をグループの直近表示 session として記録
 #
 # state file: $XDG_STATE_HOME/tmux/session-groups (session_name<TAB>group)
 # 死んでいる session のエントリは保持する (resurrect 後の同名 session に再適用するため)。
@@ -32,7 +33,9 @@ list_all() {
 # 「最後に使った session」等へ勝手に解決し誤動作する) ため、bind 側の format 展開で
 # '#{client_name}' '#{client_session}' 等を引数として受け取る。引数がなければ
 # (pane 内での手動実行など) 文脈解決にフォールバック。
-sess_of()     { [ -n "${1:-}" ] && printf '%s' "$1" || tmux display-message -p '#{session_name}'; }
+sess_of() {
+  if [ -n "${1:-}" ]; then printf '%s' "$1"; else tmux display-message -p '#{session_name}'; fi
+}
 cur_group()   { tmux show-options -t "$1" -qv @group; }
 
 # $1: client_name ('' なら文脈解決), $2: target session
@@ -41,6 +44,26 @@ switch_to() {
     tmux switch-client -c "$1" -t "$2"
   else
     tmux switch-client -t "$2"
+  fi
+}
+
+group_key() {
+  if [ -n "$1" ]; then printf '%s' "$1"; else printf '__ungrouped__'; fi
+}
+
+remember_group_session() {
+  local grp="$1" sess="$2"
+  [ -n "$sess" ] || return 0
+  tmux set-option -g "@session_group_last_$(group_key "$grp")" "$sess" 2>/dev/null || true
+}
+
+session_for_group() {
+  local all="$1" grp="$2" last
+  last=$(tmux show-options -gqv "@session_group_last_$(group_key "$grp")" 2>/dev/null || true)
+  if [ -n "$last" ] && printf '%s\n' "$all" | awk -F "$TAB" -v g="$grp" -v s="$last" '$1 == s && $2 == g { found = 1 } END { exit !found }'; then
+    printf '%s' "$last"
+  else
+    printf '%s\n' "$all" | awk -F "$TAB" -v g="$grp" '$2 == g { print $1; exit }'
   fi
 }
 
@@ -83,12 +106,20 @@ cmd_set() {
       ;;
   esac
   tmux set-option -t "$sess" @group "$grp"
+  remember_group_session "$grp" "$sess"
   cmd_sync
 }
 
 cmd_unset() {
   tmux set-option -t "$1" -u @group
+  remember_group_session "" "$1"
   cmd_sync
+}
+
+cmd_remember() {
+  local sess
+  sess=$(sess_of "${1:-}")
+  remember_group_session "$(cur_group "$sess")" "$sess"
 }
 
 # $1: client_name, $2: client_session — menu popup を開くラッパー。
@@ -143,12 +174,14 @@ cmd_step() {
   for ((i = 0; i < n; i++)); do
     [ "${members[$i]}" = "$cur" ] && idx=$i
   done
-  switch_to "$client" "${members[$(((idx + dir + n) % n))]}"
+  local target="${members[$(((idx + dir + n) % n))]}"
+  remember_group_session "$grp" "$target"
+  switch_to "$client" "$target"
 }
 
 # $1: 1 (next-group) / -1 (prev-group), $2: client_name, $3: current session —
-# グループ間を循環し先頭 session へ。
-# ungrouped session 群は末尾の 1 バケツ (空文字グループ) として扱う
+# グループ間を循環し、戻り先グループで最後に見ていた session へ。
+# 未記録なら先頭 session。ungrouped session 群は末尾の 1 バケツ (空文字グループ) として扱う
 cmd_step_group() {
   local dir="$1" client="${2:-}" cur grp all g n i idx=0 target
   local grps=()
@@ -169,8 +202,9 @@ cmd_step_group() {
   for ((i = 0; i < n; i++)); do
     [ "${grps[$i]}" = "$grp" ] && idx=$i
   done
+  remember_group_session "$grp" "$cur"
   target="${grps[$(((idx + dir + n) % n))]}"
-  switch_to "$client" "$(printf '%s\n' "$all" | awk -F "$TAB" -v g="$target" '$2 == g { print $1; exit }')"
+  switch_to "$client" "$(session_for_group "$all" "$target")"
 }
 
 # $1: client_name, $2: pane_id — menu 表示先の client と choose-tree を開く pane。
@@ -223,9 +257,10 @@ case "${1:-}" in
   apply)      cmd_apply "${2:-}" ;;
   restore)    cmd_restore ;;
   sync)       cmd_sync ;;
+  remember)   cmd_remember "${2:-}" ;;
   *)
     echo "usage: $(basename "$0") {set <group> [session]|unset [session]|menu [session]" \
-         "|next|prev|next-group|prev-group [client] [session]|picker [client] [pane]|apply <session>|restore|sync}" >&2
+         "|next|prev|next-group|prev-group [client] [session]|picker [client] [pane]|apply <session>|restore|sync|remember [session]}" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
Ctrl-Option-J/K でセッショングループ間を移動したとき、戻り先グループで最後に見ていた session へ戻るようにしました。
あわせて `prefix b` の AI エージェントサイドバーをグループ階層つきの session 一覧にし、現在のグループ/session をハイライトします。

## Changes
- グループごとの直近 session を tmux global option に記録し、グループ移動時の戻り先として使用
- `client-session-changed` hook で通常の session 切替も直近 session として追跡
- サイドバー表示を `SESSIONS / AGENTS` に変更し、グループ → session のインデント表示へ整理
- 現在のセッショングループと session をシアン太字でハイライト
- tmux ドキュメントを新しい挙動に更新

## Test plan
- [x] `bash -n scripts/tmux-session-group.sh scripts/tmux-agent-sidebar.sh scripts/tmux-agent-status.sh`
- [x] `shellcheck scripts/tmux-session-group.sh scripts/tmux-agent-sidebar.sh`
