### PR TITLE
fix(tmux): サイドバー幅補正 hook が zoom を解除するのを防止

### DIFF
--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -304,7 +304,10 @@ case "${1:-toggle}" in
       # リサイズ/swap の度にサイドバーが一瞬広がってから戻る=ちらつく。直接コマンドは command
       # queue 内で同期実行され中間フレームを描画前に潰す(fork なし=fork-latency にも無害)。
       # 既に WIDTH の時 resize-pane は no-op でレイアウト不変=再発火せず1回で収束。
-      tmux set-hook -w -t "$win" window-layout-changed "resize-pane -t $pane -x $WIDTH" 2>/dev/null || true
+      # zoom 中は補正しない: zoom もレイアウト変更なので本 hook を撃つが、resize-pane は
+      # zoom 中の window を unzoom してしまう(prefix-z が一瞬で戻る)。if-shell -F は format
+      # 評価のみで shell を fork しないため、同期・無 fork のまま zoom を素通しできる。
+      tmux set-hook -w -t "$win" window-layout-changed "if-shell -F '#{?window_zoomed_flag,0,1}' 'resize-pane -t $pane -x $WIDTH'" 2>/dev/null || true
       tmux select-pane -t "$src" 2>/dev/null || true   # 作業 pane にフォーカスを残す
     fi
     ;;


### PR DESCRIPTION
## Summary

prefix z の zoom が一瞬で解除されて効かない問題を修正。サイドバー作成時に設置される `window-layout-changed` hook が無ガードの `resize-pane` を実行しており、zoom（レイアウト変更）で発火してサイドバー pane を resize → tmux が window を即 unzoom していた。

## Changes

- `scripts/tmux-agent-sidebar.sh`: `toggle` が設置する `window-layout-changed` hook を `if-shell -F '#{?window_zoomed_flag,0,1}'` でラップし、zoom 中は幅補正 resize をスキップ
- `if-shell -F` は format 評価のみで shell を fork しないため、既存の同期・無 fork（fork-latency 無害）特性を維持
- 補正パス（`resize-all` / run ループ）は既に `sidebar_user_busy` で zoom をスキップ済み。この直接 hook だけガードが抜けていたデグレを解消

## Test plan

- [x] zoom 後に `window_zoomed_flag` が 1 のまま保持される
- [x] zoom 中はサイドバー幅が WIDTH(40) を維持
- [x] unzoom 後にサイドバー幅が WIDTH へ補正される
- [x] 稼働中 window の hook 差し替えでリロード無しでも prefix z が機能