### PR TITLE
fix(tmux): reload 時に既存サイドバー window の zoom ガード hook を張り直す

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -424,5 +424,9 @@ set-hook -ga client-resized          'run-shell -b "~/dotfiles/scripts/tmux-hook
 set-hook -gu window-layout-changed
 set-hook -ga window-layout-changed   'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh window-layout-changed #{window_id} 2>/dev/null || true"'
 
+# 既存サイドバー window の per-window hook を最新版へ張り直す (reload で全 window に反映)。
+# per-window hook は toggle 時に焼き込まれるため、スクリプト更新だけでは既存 window に伝播しない。
+run-shell -b "~/dotfiles/scripts/tmux-agent-sidebar.sh rehook 2>/dev/null || true"
+
 # Layout presets are explicit only: prefix+A opens the tmux-layout menu.
 # 自動適用 hook は pane focus / session switch の度に fork するため使わない。

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -333,8 +333,19 @@ case "${1:-toggle}" in
       tmux resize-pane -t "$pane" -x "$WIDTH" 2>/dev/null || true
     done < <(tmux list-windows -a -F "#{window_id}$(printf '\t')#{session_attached}$(printf '\t')#{@agent_sidebar_pane}" 2>/dev/null)
     ;;
+  rehook)
+    # 既存サイドバー window の window-layout-changed hook を最新版へ張り直す。
+    # per-window hook は toggle 時に window 単位で焼き込まれるため、スクリプト更新は
+    # 「新規サイドバー」にしか効かず既存 window には古い hook が残る。config reload
+    # (prefix r) から本コマンドを呼ぶことで、稼働中の全 window(リモート含む)に反映する。
+    while IFS=$'\t' read -r win pane; do
+      [[ -z "$pane" ]] && continue
+      tmux list-panes -t "$win" -F '#{pane_id}' 2>/dev/null | grep -qxF "$pane" || continue
+      tmux set-hook -w -t "$win" window-layout-changed "if-shell -F '#{?window_zoomed_flag,0,1}' 'resize-pane -t $pane -x $WIDTH'" 2>/dev/null || true
+    done < <(tmux list-windows -a -F "#{window_id}$(printf '\t')#{@agent_sidebar_pane}" 2>/dev/null)
+    ;;
   once)
     render ;;
   *)
-    echo "Usage: $0 {run|toggle|once|resize-all}" >&2; exit 1 ;;
+    echo "Usage: $0 {run|toggle|once|resize-all|rehook}" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

#278 で `window-layout-changed` hook に zoom ガードを入れたが、リモートや既存の稼働中サイドバー window では prefix z の zoom がまだ効かない問題を修正する。

原因は per-window hook が `toggle`（サイドバー生成）時に window 単位で焼き込まれる設計のため。スクリプト更新だけでは既に存在する window には伝播せず、古い無ガード hook が残り続ける。config reload しても per-window hook は張り直されない。

## Changes

- `scripts/tmux-agent-sidebar.sh`: `rehook` サブコマンドを追加。全サイドバー window（`@agent_sidebar_pane` を持つ window）の `window-layout-changed` hook を最新の zoom ガード版へ張り直す
- `common/tmux/.config/tmux/tmux.conf`: config ロード時に `rehook` を呼び出し。`prefix r`（reload）でどのサーバー（ローカル/リモート）でも稼働中の全 window に修正が反映される

## Test plan

- [x] window の hook を旧無ガード版に戻した状態で `rehook` を実行 → if-shell ガード版へ張り直されることを確認
- [x] rehook 後に zoom が保持される（`window_zoomed_flag` が 1 のまま）
- [ ] リモート環境で dotfiles 更新 + `prefix r` → 既存サイドバー window で prefix z が機能

## Note

リモートで反映するには、リモート側で dotfiles を更新（pull/install）した上で `prefix r` で config reload が必要。