### PR TITLE
perf(tmux): cache agent pane inventory

### DIFF
--- a/common/tmux/.config/tmux/claude-hooks.tmux
+++ b/common/tmux/.config/tmux/claude-hooks.tmux
@@ -9,5 +9,8 @@ set-hook -g session-window-changed 'run-shell -b "~/dotfiles/scripts/tmux-claude
 # セッション切り替え時も同様
 set-hook -g client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-claude-focus.sh >/dev/null 2>&1 || true"'
 
+# agent pane/session indexer を起動(単一インスタンス保証。UI はこの cache を読む)
+run-shell -b "~/dotfiles/scripts/tmux-agent-index.sh daemon >/dev/null 2>&1 || true"
+
 # ハング検知ウォッチャを起動(単一インスタンス保証。設定再読込でも多重起動しない)
 run-shell -b "~/dotfiles/scripts/tmux-agent-hang-watch.sh >/dev/null 2>&1 || true"

--- a/scripts/tmux-agent-index.sh
+++ b/scripts/tmux-agent-index.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# tmux agent inventory cache.
+# Expensive global tmux scans live here so sidebar/status views can read one cache
+# instead of each running `tmux list-panes -a` independently.
+
+set -uo pipefail
+
+RUNTIME_BASE="${XDG_RUNTIME_DIR:-${TMPDIR:-$HOME/.cache}}"
+CACHE_DIR="${AGENT_INDEX_DIR:-$RUNTIME_BASE/claude/tmux-agent-index}"
+PANES_FILE="$CACHE_DIR/panes.tsv"
+SESSIONS_FILE="$CACHE_DIR/sessions.tsv"
+UPDATED_FILE="$CACHE_DIR/updated"
+LOCK_FILE="$CACHE_DIR/daemon.pid"
+REFRESH="${AGENT_INDEX_REFRESH:-3}"
+STALE="${AGENT_INDEX_STALE:-5}"
+US=$'\x1f'
+
+mtime() {
+  case "$(uname -s)" in
+    Darwin) stat -f %m "$1" 2>/dev/null ;;
+    *) stat -c %Y "$1" 2>/dev/null ;;
+  esac
+}
+
+refresh() {
+  mkdir -p "$CACHE_DIR" 2>/dev/null || return 1
+  local panes_tmp sessions_tmp updated_tmp
+  panes_tmp="$PANES_FILE.$$"
+  sessions_tmp="$SESSIONS_FILE.$$"
+  updated_tmp="$UPDATED_FILE.$$"
+
+  tmux list-panes -a -F "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}${US}#{@agent_sidebar_pane}" >"$panes_tmp" || {
+    rm -f "$panes_tmp" "$sessions_tmp" "$updated_tmp"
+    return 1
+  }
+  tmux list-sessions -F "#{session_name}${US}#{@group}${US}#{session_attached}" >"$sessions_tmp" || {
+    rm -f "$panes_tmp" "$sessions_tmp" "$updated_tmp"
+    return 1
+  }
+  date +%s >"$updated_tmp"
+  mv "$panes_tmp" "$PANES_FILE"
+  mv "$sessions_tmp" "$SESSIONS_FILE"
+  mv "$updated_tmp" "$UPDATED_FILE"
+}
+
+ensure_fresh() {
+  local now mt age
+  now=$(date +%s)
+  mt=$(mtime "$UPDATED_FILE")
+  age=$(( now - ${mt:-0} ))
+  if [[ ! -s "$PANES_FILE" || ! -s "$SESSIONS_FILE" || "$age" -gt "$STALE" ]]; then
+    refresh >/dev/null 2>&1 || true
+  fi
+}
+
+daemon() {
+  mkdir -p "$CACHE_DIR" 2>/dev/null || exit 0
+  if [[ -f "$LOCK_FILE" ]] && kill -0 "$(cat "$LOCK_FILE" 2>/dev/null)" 2>/dev/null; then
+    exit 0
+  fi
+  echo $$ >"$LOCK_FILE"
+  cleanup() { [[ "$(cat "$LOCK_FILE" 2>/dev/null)" == "$$" ]] && rm -f "$LOCK_FILE"; }
+  trap cleanup EXIT
+  trap 'cleanup; exit 0' INT TERM
+
+  while true; do
+    tmux info >/dev/null 2>&1 || exit 0
+    owner="$(cat "$LOCK_FILE" 2>/dev/null || true)"
+    [[ -n "$owner" && "$owner" != "$$" ]] && exit 0
+    refresh >/dev/null 2>&1 || true
+    sleep "$REFRESH" & wait $! || true
+  done
+}
+
+case "${1:-panes}" in
+  daemon) daemon ;;
+  refresh) refresh ;;
+  panes) ensure_fresh; cat "$PANES_FILE" 2>/dev/null || true ;;
+  sessions) ensure_fresh; cat "$SESSIONS_FILE" 2>/dev/null || true ;;
+  *) echo "Usage: $0 {daemon|refresh|panes|sessions}" >&2; exit 1 ;;
+esac

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -82,7 +82,9 @@ collect_agents() {
     # stash 済みはアイコン(グリフ)を変えず色だけ灰色(240)にして、サイドバーでも stash と分かるように
     [[ -n "$stashed" ]] && rg=$(printf '%s' "$rg" | sed 's/38;5;[0-9]*m/38;5;240m/')
     printf '%s\t%s\n' "$sess" "$rg"
-  done < <(tmux list-panes -a -F "#{session_name}$(printf '\x1f')#{@agent_status}$(printf '\x1f')#{pane_current_command}$(printf '\x1f')#{@agent_stashed}")
+  done < <(agent_index_panes | while IFS="$US" read -r _pid sess _win status _hb _path cmd _title stashed _sidebar; do
+    printf '%s\x1f%s\x1f%s\x1f%s\n' "$sess" "$status" "$cmd" "$stashed"
+  done)
 
   # file store (リモート/コンテナ)。workspace ごと最新のみ採用。
   # tmux_session が「ローカルセッション」に一致する行はローカル pane の重複なので除外し、
@@ -90,7 +92,7 @@ collect_agents() {
   [[ -d "$STATUS_DIR" ]] || return 0
   command -v jq >/dev/null 2>&1 || return 0
   local local_sessions ws_seen="" status ws tsess project _u
-  local_sessions="|$(tmux list-sessions -F '#{session_name}' 2>/dev/null | tr '\n' '|')"
+  local_sessions="|$(agent_index_sessions | awk -F "$US" '{print $1}' | tr '\n' '|')"
   # 全ファイルを1回の jq で処理(ファイル数分 jq を spawn しない)
   local files=("$STATUS_DIR"/*.json)
   [[ -e "${files[0]}" ]] || return 0
@@ -168,7 +170,7 @@ render() {
   local rows total sessions session_count cur_session cur_group
   rows=$(collect_agents | sort -t$'\t' -k1,1 -k2,2n)
   total=$(printf '%s' "$rows" | grep -c . 2>/dev/null)
-  sessions=$(tmux list-sessions -F "#{session_name}${TAB}#{@group}" 2>/dev/null | sort)
+  sessions=$(agent_index_sessions | awk -F "$US" -v tab="$TAB" '{print $1 tab $2}' | sort)
   session_count=$(printf '%s' "$sessions" | grep -c . 2>/dev/null)
   cur_session=$(tmux display-message -p -t "${TMUX_PANE}" '#{session_name}' 2>/dev/null || true)
   cur_group=$(tmux show-options -t "$cur_session" -qv @group 2>/dev/null || true)

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -23,11 +23,22 @@ set -euo pipefail
 
 [[ -z "${TMUX:-}" ]] && exit 0
 
-SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 RUNTIME_BASE="${XDG_RUNTIME_DIR:-${TMPDIR:-$HOME/.cache}}"
 STATUS_DIR="${AGENT_STATUS_DIR:-${DOTFILES_SHARED_DIR:-$HOME/.cache}/claude/status}"
 JUMP_FILE="$RUNTIME_BASE/claude/agentpop-jump"
 US=$'\x1f'
+
+agent_index_panes() {
+  "$SCRIPT_DIR/tmux-agent-index.sh" panes 2>/dev/null || tmux list-panes -a -F \
+    "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}${US}#{@agent_sidebar_pane}"
+}
+
+agent_index_sessions() {
+  "$SCRIPT_DIR/tmux-agent-index.sh" sessions 2>/dev/null || tmux list-sessions -F \
+    "#{session_name}${US}#{@group}${US}#{session_attached}"
+}
 
 C_RED=$'\e[38;5;203m'; C_AMBER=$'\e[38;5;214m'; C_DIM=$'\e[2m'; C_BOLD=$'\e[1m'; C_RST=$'\e[0m'
 C_CUR=$'\e[38;5;45m'   # 現在の pane 強調(シアン)。prefix+a を押した pane を枠線で示す
@@ -48,7 +59,7 @@ trunc() { local s="$1" n="$2"; s="${s//$'\t'/ }"; if (( ${#s} > n )); then print
 build_local_rows() {
   # 現在 pane(prefix+a を押した pane)は bind が @agent_cur_pane に保存している
   local now cur; now=$(date +%s); cur="$(tmux show-options -gv @agent_cur_pane 2>/dev/null || echo "")"
-  while IFS="$US" read -r pid sess win status hb path cmd title stashed; do
+  while IFS="$US" read -r pid sess win status hb path cmd title stashed _sidebar; do
     is_agent "$status" || continue          # 停止状態 + running を対象
     is_shell "$cmd" && continue             # シェル復帰(終了済み)は除外
     local rank icon col task branch elapsed loc tool line1 line2 g1 g2 mk
@@ -67,8 +78,7 @@ build_local_rows() {
     line1=$(printf '%s%s%s %-10s%s %s%s' "$g1" "$col" "$icon" "$status" "$C_RST" "$task" "$mk")
     line2=$(printf '%s%s%s · %s · %s · %s · %s%s' "$g2" "$C_DIM" "$sess" "$branch" "$loc" "$tool" "${elapsed}前" "$C_RST")
     printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$rank" "$pid" "$loc" "$status" "$line1" "$line2"
-  done < <(tmux list-panes -a -F \
-    "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}")
+  done < <(agent_index_panes)
 }
 
 # リモート/コンテナ(file store)行 → sortable 6 フィールド。seen_windows の window は除外


### PR DESCRIPTION
## Summary
- Add a single `tmux-agent-index.sh` cache daemon for pane/session inventory.
- Start the indexer from the tmux Claude hooks alongside the hang watcher.
- Make agent sidebar/status views read cached inventory instead of each running full tmux scans.

## Changes
- Cache `list-panes -a` and `list-sessions` output under the runtime cache dir.
- Add stale-cache refresh fallback for direct script invocations.
- Reuse the cached inventory in `tmux-agent-sidebar.sh` and `tmux-agent-status.sh`.

## Test plan
- [x] `bash -n scripts/tmux-agent-index.sh scripts/tmux-agent-status.sh scripts/tmux-agent-sidebar.sh`
- [x] `shellcheck --severity=warning scripts/tmux-agent-index.sh scripts/tmux-agent-status.sh scripts/tmux-agent-sidebar.sh`
