### PR TITLE
perf(tmux): dispatch hooks through one script

### DIFF
--- a/common/tmux/.config/tmux/claude-hooks.tmux
+++ b/common/tmux/.config/tmux/claude-hooks.tmux
@@ -2,12 +2,8 @@
 # Claude Code tmux 通知統合
 # Ghostty + tmux環境でClaude Codeの通知をtmuxステータスバーに表示
 
-# ウィンドウ切り替え時にフォーカス処理を実行（2秒/5秒タイマー）
-# run-shell は stdout を copy-mode で表示するため、全出力を抑制する
-set-hook -g session-window-changed 'run-shell -b "~/dotfiles/scripts/tmux-claude-focus.sh >/dev/null 2>&1 || true"'
-
-# セッション切り替え時も同様
-set-hook -g client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-claude-focus.sh >/dev/null 2>&1 || true"'
+# フォーカス系 hook は tmux.conf の tmux-hook-dispatch.sh に集約する。
+# ここでは常駐 watcher だけを起動する。
 
 # ハング検知ウォッチャを起動(単一インスタンス保証。設定再読込でも多重起動しない)
 run-shell -b "~/dotfiles/scripts/tmux-agent-hang-watch.sh >/dev/null 2>&1 || true"

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -308,23 +308,17 @@ bind y display-menu -T "Theme" -x C -y C \
 # Claude Code 通知統合
 source-file ~/.config/tmux/claude-hooks.tmux
 
-# Per-session accent color hooks (claude-hooks.tmux の後に追加、-ga で append)
-# -gu でリセットしてから append しないと prefix+r のリロードごとに同じ
-# run-shell が蓄積する。client-session-changed のみ claude-hooks.tmux が
-# -g (上書き) で先に登録するため -gu 不要 (-gu すると claude-hooks 側が消える)。
+# Hook dispatch: tmux hook から直接複数 script を fork せず、イベントごとに1本へ集約する。
+set-hook -g session-window-changed 'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh session-window-changed #{client_session} 2>/dev/null || true"'
+set-hook -g client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh client-session-changed #{client_session} 2>/dev/null || true"'
 set-hook -gu session-created
-set-hook -ga session-created 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh apply #{session_name} 2>/dev/null || true"'
-# Session group 再適用: 同名 session の再作成 (resurrect 復元含む) 時に state file から
-# @group を復元する。rename 時は state file を live 状態に同期。
-set-hook -ga session-created 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh apply #{session_name} 2>/dev/null || true"'
+set-hook -ga session-created 'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh session-created #{session_name} 2>/dev/null || true"'
 set-hook -gu session-renamed
-set-hook -ga session-renamed 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh sync 2>/dev/null || true"'
-set-hook -ga client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
-set-hook -ga client-session-changed 'run-shell -b "~/dotfiles/scripts/tmux-session-group.sh remember #{session_name} 2>/dev/null || true"'
+set-hook -ga session-renamed 'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh session-renamed #{session_name} 2>/dev/null || true"'
 set-hook -gu client-attached
-set-hook -ga client-attached 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -ga client-attached 'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh client-attached #{session_name} 2>/dev/null || true"'
 set-hook -gu after-new-window
-set-hook -ga after-new-window 'run-shell -b "~/dotfiles/scripts/tmux-session-color.sh refresh #{session_name} 2>/dev/null || true"'
+set-hook -ga after-new-window 'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh after-new-window #{session_name} 2>/dev/null || true"'
 
 # Pane-sticky zoom: register after-select-pane hook once (reload-safe via @zoom-hooks-loaded)
 run-shell "~/dotfiles/scripts/tmux-zoom-hooks.sh"
@@ -421,16 +415,14 @@ set -g status-style bg=default
 
 # サイドバー幅の即時補正: window-size latest 再適用後の比例リサイズ丸めで幅がドリフトするため、
 # resize/session 切替の都度サイドバー pane を固定幅へ戻す (run ループの 3 秒補正の即時版)。
-# -gu でリセットしてから append しないと prefix+r リロードの度に同じ run-shell が蓄積する
-# (278-281 の client-attached 等と同じ理由)。client-session-changed のみ claude-hooks.tmux が
-# -g で先に上書きするため -gu 不要。
+# -gu でリセットしてから append しないと prefix+r リロードの度に同じ run-shell が蓄積する。
+# client-session-changed のサイドバー補正は上の hook dispatcher に集約済み。
 set-hook -gu client-resized
-set-hook -ga client-resized          'run-shell -b "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all 2>/dev/null || true"'
-set-hook -ga client-session-changed  'run-shell -b "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all 2>/dev/null || true"'
+set-hook -ga client-resized          'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh client-resized 2>/dev/null || true"'
 # window-layout-changed: prefix+a の swap-pane 等でレイアウトが変わるとサイドバーが比例配分で
 # 広がるため、変更のあった window のみ固定幅へ snap し直す (resize-all 側に再発火ループ防止ガードあり)。
 set-hook -gu window-layout-changed
-set-hook -ga window-layout-changed   'run-shell -b "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all #{window_id} 2>/dev/null || true"'
+set-hook -ga window-layout-changed   'run-shell -b "~/dotfiles/scripts/tmux-hook-dispatch.sh window-layout-changed #{window_id} 2>/dev/null || true"'
 
 # Layout auto-apply: window/session 切替で、その window に記憶された @layout-preset
 # (tmux-layout apply 時に付与) があれば保存済み構成へ自動リサイズ。

--- a/scripts/tmux-hook-dispatch.sh
+++ b/scripts/tmux-hook-dispatch.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Single tmux hook entrypoint. Keep tmux hooks cheap: one fork per event, then
+# dispatch related maintenance from here.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNTIME_BASE="${XDG_RUNTIME_DIR:-${TMPDIR:-$HOME/.cache}}"
+LOCK_DIR="$RUNTIME_BASE/claude/tmux-hook-dispatch"
+
+run_script() {
+  local script="$1"
+  shift
+  "$SCRIPT_DIR/$script" "$@" >/dev/null 2>&1 || true
+}
+
+with_lock() {
+  local name="$1"
+  shift
+  mkdir -p "$LOCK_DIR" 2>/dev/null || return 0
+  local lock="$LOCK_DIR/$name.lock"
+  mkdir "$lock" 2>/dev/null || return 0
+  trap 'rm -rf "$lock"' RETURN
+  "$@"
+}
+
+dispatch() {
+  local event="${1:-}"
+  shift || true
+  case "$event" in
+    session-window-changed)
+      run_script tmux-claude-focus.sh
+      ;;
+    client-session-changed)
+      local session="${1:-}"
+      run_script tmux-claude-focus.sh
+      run_script tmux-session-color.sh refresh "$session"
+      run_script tmux-session-group.sh remember "$session"
+      run_script tmux-agent-sidebar.sh resize-all
+      ;;
+    session-created)
+      local session="${1:-}"
+      run_script tmux-session-color.sh apply "$session"
+      run_script tmux-session-group.sh apply "$session"
+      ;;
+    session-renamed)
+      run_script tmux-session-group.sh sync
+      ;;
+    client-attached|after-new-window)
+      local session="${1:-}"
+      run_script tmux-session-color.sh refresh "$session"
+      ;;
+    client-resized)
+      run_script tmux-agent-sidebar.sh resize-all
+      ;;
+    window-layout-changed)
+      run_script tmux-agent-sidebar.sh resize-all "${1:-}"
+      ;;
+  esac
+}
+
+case "${1:-}" in
+  client-resized|window-layout-changed)
+    with_lock "${1:-hook}" dispatch "$@"
+    ;;
+  *)
+    dispatch "$@"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add `tmux-hook-dispatch.sh` as the single entrypoint for common tmux hook work.
- Move Claude focus, session color/group, and sidebar resize maintenance behind one dispatcher call per event.
- Add lightweight nonblocking locks for resize/layout-change events to avoid hook storms.

## Changes
- Stop installing Claude focus hooks from `claude-hooks.tmux`; tmux.conf now owns hook registration.
- Replace multiple `client-session-changed`, `session-created`, and resize/layout hook script calls with dispatcher invocations.
- Keep explicit layout auto-apply hooks unchanged; those are removed in a separate PR.

## Test plan
- [x] `bash -n scripts/tmux-hook-dispatch.sh scripts/tmux-agent-sidebar.sh scripts/tmux-session-color.sh scripts/tmux-session-group.sh`
- [x] `shellcheck --severity=warning scripts/tmux-hook-dispatch.sh`
