### PR TITLE
perf(tmux): remove automatic layout apply hooks

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -432,9 +432,5 @@ set-hook -ga client-session-changed  'run-shell -b "~/dotfiles/scripts/tmux-agen
 set-hook -gu window-layout-changed
 set-hook -ga window-layout-changed   'run-shell -b "~/dotfiles/scripts/tmux-agent-sidebar.sh resize-all #{window_id} 2>/dev/null || true"'
 
-# Layout auto-apply: window/session 切替で、その window に記憶された @layout-preset
-# (tmux-layout apply 時に付与) があれば保存済み構成へ自動リサイズ。
-# プリセット未設定の window は autoapply 内で即 return = ゼロコスト・非フリッカー。
-set-hook -gu pane-focus-in
-set-hook -ga pane-focus-in           'run-shell -b "~/dotfiles/scripts/tmux-layout autoapply 2>/dev/null || true"'
-set-hook -ga client-session-changed  'run-shell -b "~/dotfiles/scripts/tmux-layout autoapply 2>/dev/null || true"'
+# Layout presets are explicit only: prefix+A opens the tmux-layout menu.
+# 自動適用 hook は pane focus / session switch の度に fork するため使わない。


### PR DESCRIPTION
## Summary
- Remove automatic tmux layout auto-apply hooks.
- Keep layout presets available through the explicit prefix+A menu only.

## Changes
- Delete `pane-focus-in` autoapply hook.
- Delete `client-session-changed` autoapply hook.
- Leave the `@popup-layout` / prefix+A menu path intact.

## Test plan
- [x] Verified no `tmux-layout autoapply` hook remains in `common/tmux/.config/tmux/tmux.conf`
