### PR TITLE
docs(claude): switch version-control guidance from jj to git

### DIFF
--- a/common/claude/.claude/rules/version-control.md
+++ b/common/claude/.claude/rules/version-control.md
@@ -1,15 +1,11 @@
 # Version Control
 
-`.jj/` が存在するリポジトリでは Jujutsu (`jj`) を version-control write の標準にする。
+Git を version-control write の標準とする。`.jj/` が存在するリポジトリでも jj は使わず git 経路で作業する。
 
-- colocated 前提（`jj git init --colocate`、jj v0.39+ は `jj git init` で既定）。Git read-only と jj write の両立はこれが条件
-- 作業前に `jj status` を実行し、snapshot と状態確認を行う
-- 変更確認は `jj status` / `jj diff` / `jj log` を使う
-- ローカル作業の参照は Git hash より jj change ID を優先する
-- 現在の変更に名前を付ける時は `jj describe -m "<message>"`
-- 論理変更が完了したら `jj new` で次の working-copy commit に移る
-- agent が作った雑な履歴は `jj split` / `jj squash` / `jj describe` で整理する
-- 復旧は `jj undo`、必要なら `jj op log` → `jj op restore <op>` を使う
-- bookmark は active branch ではない。push 直前に作成・移動する
-- GitHub へは `jj git push --change @-` または明示 bookmark で push する
-- `.jj/` 配下では `git commit` / `git add` / `git reset` / `git checkout` / `git rebase` / `git clean` などの Git 書き込み系を避ける（read-only Git は可）
+- 作業前に `git status` で状態を確認する
+- 変更確認は `git status` / `git diff` / `git log` を使う
+- ブランチ作成は `git checkout -b <name>`
+- コミットは変更したファイルを明示的に `git add <path>` してから `git commit -m "<message>"`。`git add .` / `-A` は使わない
+- push はユーザーが明示的に要求した時のみ `git push`
+- develop / main への commit / push はしない。作業は feature ブランチで行い PR を出す
+- プロジェクト側に jj 用ルール (例: `version-control-jj.md`) が存在しても従わない。上記 git 経路を優先する


### PR DESCRIPTION
## What

Claude 向け version-control ルール (`common/claude/.claude/rules/version-control.md`) を jj 前提から git 前提へ変更する。

- git を version-control write の標準に戻す
- colocated (`.jj/` あり) リポでも jj を使わず git 経路で作業するよう明記
- プロジェクト側に jj 用ルールがあっても従わない旨を追記

## Why

jj は個人の試験導入のみで、git メインのプロジェクトでの併用が負担になったため全面的に git へ戻す。

https://claude.ai/code/session_01UZD91nhCidtLkcHGLTAYMC
