### PR TITLE
feat(pi): add autonomous goal package

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -66,9 +66,16 @@ guarantees, prefer adopting it over maintaining the custom one.
 - Persistent across sessions via plain Markdown files in `~/.pi/agent/memory/`
 - Tools: `memory_write`, `memory_read`, `memory_search`, `scratchpad`
 - Format: pi-memory compatible (MEMORY.md, SCRATCHPAD.md, daily/)
-- Context auto-injected on session start (goal + scratchpad + today/yesterday log + MEMORY.md)
+- Context auto-injected on session start (pinned note + scratchpad + today/yesterday log + MEMORY.md)
 - Install `qmd` for semantic/vector search upgrade
-- `/goal <text>` — set a pinned session goal (injected as context + shown in the statusline). `/goal` shows it, `/goal clear` clears it.
+- `/pin-goal <text>` — set a pinned session note (injected as context + shown in the statusline). `/pin-goal` shows it, `/pin-goal clear` clears it.
+
+## Goal Mode
+
+- `@narumitw/pi-goal` owns `/goal` for autonomous, verifiable task completion.
+- Use `/goal <goal>` when the agent should continue until it calls `goal_complete` or reports a true blocker.
+- Use `/goal pause`, `/goal resume`, and `/goal clear` to control an active goal.
+- Use `/pin-goal` only for lightweight session context that should not auto-continue.
 
 ## Agent Delegation (pi-subagents + custom)
 

--- a/common/pi/.pi/agent/AGENTS.md.mac
+++ b/common/pi/.pi/agent/AGENTS.md.mac
@@ -51,9 +51,9 @@ guarantees, prefer adopting it over maintaining the custom one.
 - Persistent across sessions via plain Markdown files in `~/.pi/agent/memory/`
 - Tools: `memory_write`, `memory_read`, `memory_search`, `scratchpad`
 - Format: pi-memory compatible (MEMORY.md, SCRATCHPAD.md, daily/)
-- Context auto-injected on session start (goal + scratchpad + today/yesterday log + MEMORY.md)
+- Context auto-injected on session start (pinned note + scratchpad + today/yesterday log + MEMORY.md)
 - Install `qmd` for semantic/vector search upgrade
-- `/goal <text>` — set a pinned session goal (injected as context + shown in the statusline). `/goal` shows it, `/goal clear` clears it.
+- `/pin-goal <text>` — set a pinned session note (injected as context + shown in the statusline). `/pin-goal` shows it, `/pin-goal clear` clears it.
 
 ## Agent Delegation (pi-subagents + custom)
 

--- a/common/pi/.pi/agent/extensions/memory.ts
+++ b/common/pi/.pi/agent/extensions/memory.ts
@@ -30,7 +30,7 @@ const MEMORY_DIR = join(homedir(), ".pi", "agent", "memory");
 const MEMORY_FILE = join(MEMORY_DIR, "MEMORY.md");
 const SCRATCHPAD_FILE = join(MEMORY_DIR, "SCRATCHPAD.md");
 const DAILY_DIR = join(MEMORY_DIR, "daily");
-// Pinned session goal (set via /goal). statusline.ts reads the same path.
+// Pinned session note (set via /pin-goal). statusline.ts reads the same path.
 const GOAL_FILE = join(homedir(), ".pi", "agent", "goal");
 
 const INJECTION_MAX = 8000;
@@ -105,7 +105,7 @@ function buildInjection(): string {
   const parts: string[] = [];
   let used = 0;
 
-  // 0. Pinned goal (set via /goal)
+  // 0. Pinned session note (set via /pin-goal)
   const goal = readIfExists(GOAL_FILE).trim();
   if (goal) {
     const text = `## Current Goal\n${goal}`;
@@ -219,22 +219,23 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_before_compact", async () => writeHandoff());
 
   // -----------------------------------------------------------------------
-  // Command: /goal <text> | /goal | /goal clear
-  // Pinned goal: injected as context (session start + on set) and shown in the
-  // statusline (statusline.ts reads GOAL_FILE).
+  // Command: /pin-goal <text> | /pin-goal | /pin-goal clear
+  // Pinned session note: injected as context (session start + on set) and shown
+  // in the statusline (statusline.ts reads GOAL_FILE). `/goal` is reserved for
+  // the pi-goal package.
   // -----------------------------------------------------------------------
-  pi.registerCommand("goal", {
-    description: "Set/show/clear the pinned session goal (injected as context + shown in statusline)",
+  pi.registerCommand("pin-goal", {
+    description: "Set/show/clear the pinned session note (injected as context + shown in statusline)",
     handler: async (args, ctx) => {
       const arg = (args || "").trim();
       if (!arg) {
         const g = readIfExists(GOAL_FILE).trim();
-        ctx.ui.notify(g ? `🎯 Goal: ${g}` : "No goal set. Usage: /goal <text> (or /goal clear)", "info");
+        ctx.ui.notify(g ? `🎯 Pinned: ${g}` : "No pinned note set. Usage: /pin-goal <text> (or /pin-goal clear)", "info");
         return;
       }
       if (arg === "clear") {
         writeFile(GOAL_FILE, "");
-        ctx.ui.notify("Goal cleared", "info");
+        ctx.ui.notify("Pinned note cleared", "info");
         return;
       }
       writeFile(GOAL_FILE, arg);
@@ -243,7 +244,7 @@ export default function (pi: ExtensionAPI) {
         { customType: "goal", content: `## Current Goal\n${arg}`, display: false },
         { deliverAs: "nextTurn" }
       );
-      ctx.ui.notify(`🎯 Goal set: ${arg}`, "info");
+      ctx.ui.notify(`🎯 Pinned note set: ${arg}`, "info");
     },
   });
 

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -102,7 +102,7 @@ function readStats(): StatsSnapshot {
   return s;
 }
 
-// Pinned goal (set via /goal in the memory extension). Tiny file — read directly.
+// Pinned session note (set via /pin-goal in the memory extension). Tiny file — read directly.
 const GOAL_FILE = join(homedir(), ".pi", "agent", "goal");
 function readGoal(): string {
   try { return readFileSync(GOAL_FILE, "utf-8").trim(); } catch { return ""; }
@@ -245,7 +245,7 @@ export default function (pi: ExtensionAPI) {
 
           const lines: string[] = [];
 
-          // Pinned goal (top, most visible)
+          // Pinned session note (top, most visible)
           const goal = readGoal();
           if (goal) lines.push(truncateToWidth(theme.fg("warning", `🎯 ${goal}`), width));
 

--- a/common/pi/.pi/agent/settings.json
+++ b/common/pi/.pi/agent/settings.json
@@ -73,6 +73,7 @@
     "npm:pi-subagents",
     "npm:@quintinshaw/pi-dynamic-workflows",
     "npm:@trevonistrevon/pi-loop",
+    "npm:@narumitw/pi-goal",
     "npm:pi-remote-control",
     "npm:pi-cursor-agent",
     "npm:pi-commandcode-provider",

--- a/docs/ai-agents/pi/memory.md
+++ b/docs/ai-agents/pi/memory.md
@@ -6,6 +6,7 @@
 
 ```
 セッション開始
+  ├─ /pin-goal の pinned note を inject
   ├─ SCRATCHPAD.md の未完了項目を inject
   ├─ 今日の daily log 末尾を inject
   └─ MEMORY.md を inject（middle-truncate）
@@ -49,11 +50,12 @@
 
 | Priority | Source | Budget |
 |:--------:|--------|:------:|
+| 0 | `/pin-goal` の pinned note | 1K |
 | 1 | 未完了 scratchpad 項目 | 2K |
 | 2 | 今日の daily log (末尾) | 3K |
 | 3 | MEMORY.md (middle-truncate) | 4K |
 
-注入は `pi.sendMessage()` で行い、会話履歴には表示されない（`display: false`）。
+注入は `pi.sendMessage()` で行い、会話履歴には表示されない（`display: false`）。`/goal` は `pi-goal` package の autonomous goal mode 用に予約し、軽量な固定コンテキストは `/pin-goal` を使う。
 
 ## Handoff
 

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -12,6 +12,7 @@
 | pi-cursor-agent | Cursor サブスク → pi プロバイダ | `settings.json` の `packages` → `pi install npm:pi-cursor-agent` |
 | pi-dynamic-workflows | Claude Code-style workflow / fan-out orchestration | `settings.json` の `packages` → `pi install npm:@quintinshaw/pi-dynamic-workflows` |
 | pi-loop | cron/event-based agent re-wake loops と background monitor | `settings.json` の `packages` → `pi install npm:@trevonistrevon/pi-loop` |
+| pi-goal | `/goal` で完了まで継続する goal mode | `settings.json` の `packages` → `pi install npm:@narumitw/pi-goal` |
 | AGENTS.md | グローバル指示書 | `common/pi/.pi/agent/AGENTS.md` → `~/.pi/agent/AGENTS.md` |
 | pueue | バックグラウンドタスク・並列 delegation 用キュー | `config/Brewfile` (mac), `packages.linux.{apt,alpine}.txt` (linux) |
 


### PR DESCRIPTION
## Summary
- Add `@narumitw/pi-goal` to the global Pi package list.
- Reserve `/goal` for the pi-goal package and rename the existing memory pinned-context command to `/pin-goal`.
- Update Pi instructions and memory docs to distinguish autonomous goal mode from lightweight pinned context.

## Stack
- Base PR: #288

## Test plan
- [x] `node -e "JSON.parse(require('fs').readFileSync('common/pi/.pi/agent/settings.json','utf8'))"`
- [x] `jj diff --stat -r pi-goal-mode`
- [x] `rg '/goal' common/pi docs/ai-agents/pi` to verify remaining `/goal` references point to pi-goal or explain the reservation
