### PR TITLE
feat(claude): add ccusage usage snapshots

### DIFF
--- a/common/claude/.claude/ccusage.json
+++ b/common/claude/.claude/ccusage.json
@@ -1,0 +1,7 @@
+{
+  "defaults": {
+    "timezone": "Asia/Tokyo",
+    "offline": true,
+    "mode": "auto"
+  }
+}

--- a/common/pi/.pi/agent/extensions/skill-highlight.ts
+++ b/common/pi/.pi/agent/extensions/skill-highlight.ts
@@ -1,0 +1,113 @@
+// Highlight names of Pi's currently loaded skills in the prompt editor.
+// Wrap the existing editor factory so package-provided editors (e.g. workflows)
+// retain their input behavior and rendering.
+
+import { CustomEditor, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+type AnsiToken = { escape?: string; character?: string };
+type HighlightState = { names: string[] };
+type EditorFactory = NonNullable<ReturnType<ExtensionContext["ui"]["getEditorComponent"]>>;
+type MarkedFactory = EditorFactory & { __piSkillHighlightState?: HighlightState };
+
+const factoryMarker = "__piSkillHighlightState" as const;
+
+function decodeXml(value: string): string {
+  return value.replace(/&(amp|lt|gt|quot|apos);/g, (_match, entity: string) => ({
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+  })[entity]!);
+}
+
+export function skillNamesFromPrompt(prompt: string): string[] {
+  const section = prompt.match(/<available_skills>([\s\S]*?)<\/available_skills>/)?.[1] ?? "";
+  return [...section.matchAll(/<name>([\s\S]*?)<\/name>/g)]
+    .map((match) => decodeXml(match[1]!).trim())
+    .filter(Boolean);
+}
+
+function tokenizeAnsi(line: string): AnsiToken[] {
+  const tokens: AnsiToken[] = [];
+  for (let index = 0; index < line.length;) {
+    if (line[index] !== "\x1b") {
+      tokens.push({ character: line[index++]! });
+      continue;
+    }
+
+    let end = index + 1;
+    if (line[end] === "[") {
+      while (++end < line.length && !(line[end]! >= "@" && line[end]! <= "~")) {}
+      end++;
+    } else if (["]", "_", "P", "^"].includes(line[end] ?? "")) {
+      while (++end < line.length && line[end] !== "\x07" && !(line[end] === "\x1b" && line[end + 1] === "\\")) {}
+      end += line[end] === "\x1b" ? 2 : 1;
+    } else {
+      end++;
+    }
+    tokens.push({ escape: line.slice(index, end) });
+    index = end;
+  }
+  return tokens;
+}
+
+function skillRanges(text: string, names: string[]): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  for (const name of names) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`(?<![A-Za-z0-9_-])${escaped}(?![A-Za-z0-9_-])`, "gi");
+    for (let match = pattern.exec(text); match; match = pattern.exec(text)) {
+      ranges.push([match.index, match.index + match[0].length]);
+    }
+  }
+  return ranges;
+}
+
+export function highlightSkills(line: string, names: string[], accent: (text: string) => string): string {
+  if (names.length === 0) return line;
+
+  const tokens = tokenizeAnsi(line);
+  const ranges = skillRanges(tokens.flatMap((token) => token.character ?? []).join(""), names);
+  if (ranges.length === 0) return line;
+
+  let visibleIndex = 0;
+  return tokens.map((token) => {
+    if (token.escape !== undefined) return token.escape;
+    const highlighted = ranges.some(([start, end]) => visibleIndex >= start && visibleIndex < end);
+    visibleIndex++;
+    return highlighted ? accent(token.character!) : token.character!;
+  }).join("");
+}
+
+export default function (pi: ExtensionAPI) {
+  let state: HighlightState = { names: [] };
+
+  const updateNames = (names: Iterable<string>) => {
+    state.names = [...new Set([...names].filter(Boolean))].sort((a, b) => b.length - a.length);
+  };
+
+  pi.on("resources_discover", (_event, ctx) => {
+    const names = skillNamesFromPrompt(ctx.getSystemPrompt());
+    const existing = ctx.ui.getEditorComponent() as MarkedFactory | undefined;
+    if (existing?.[factoryMarker]) {
+      state = existing[factoryMarker]!;
+      updateNames(names);
+      return;
+    }
+    updateNames(names);
+
+    const factory: MarkedFactory = (tui, theme, keybindings) => {
+      const editor = existing ? existing(tui, theme, keybindings) : new CustomEditor(tui, theme, keybindings);
+      const render = editor.render.bind(editor);
+      editor.render = (width) => render(width).map((line) => highlightSkills(line, state.names, (text) => ctx.ui.theme.fg("accent", text)));
+      return editor;
+    };
+    factory[factoryMarker] = state;
+    ctx.ui.setEditorComponent(factory);
+  });
+
+  pi.on("before_agent_start", (event) => {
+    updateNames(event.systemPromptOptions.skills?.map((skill) => skill.name) ?? []);
+  });
+}

--- a/config/packages.npm.txt
+++ b/config/packages.npm.txt
@@ -8,7 +8,7 @@
 command-code
 
 # Claude Code token usage analytics (local JSONL parser)
-ccusage
+ccusage@20.0.17
 
 # Review-first terminal diff viewer for agent-authored changesets (hunk binary)
 hunkdiff

--- a/docs/ai-agents/claude/ccusage.md
+++ b/docs/ai-agents/claude/ccusage.md
@@ -1,0 +1,72 @@
+# ccusage
+
+`ccusage` は各 AI コーディング CLI がローカルに保存する利用記録を集計するツール。Claude Code、Codex、pi、Gemini などを日別・週別・月別に確認できる。請求額ではなくローカル記録と価格表に基づく**推定値**として扱う。
+
+## 導入
+
+`config/packages.npm.txt` で `ccusage@20.0.17` を固定している。通常は `install.sh` を再実行する。導入確認:
+
+```bash
+ccusage --version
+# 20.x を確認
+```
+
+`~/.claude/ccusage.json` は Stow 管理され、日付境界を `Asia/Tokyo`、価格取得を offline に固定する。更新時は npm 最新版を確認し、`config/packages.npm.txt` のバージョンを更新してから `scripts/test-ccusage-snapshot.sh` を実行する。
+
+## 日常の確認
+
+```bash
+ccusage daily --all
+ccusage weekly --all --breakdown
+ccusage monthly --all --breakdown
+ccusage claude daily --instances
+ccusage blocks
+```
+
+- `--all`: 検出した agent の統合集計
+- `--instances`: Claude Code のプロジェクト別集計。プロジェクト名を含むため共有しない
+- `blocks`: Claude Code の5時間 block の利用傾向。tmux の現在クォータ表示とは別の履歴分析
+
+既存の `tmux-claude-usage.sh` は OAuth API の現在の5時間/週クォータを表示する。ccusage は履歴統計なので置換しない。
+
+## 月次証跡
+
+```bash
+ccusage-snapshot          # 前月
+ccusage-snapshot 2026-06 # 指定月
+```
+
+出力先は `${XDG_STATE_HOME:-~/.local/state}/ccusage/snapshots/YYYY/MM/`。
+
+| ファイル | 内容 |
+| --- | --- |
+| `all-daily.json` | 全 agent の日別集計 |
+| `claude-projects.json` | Claude Code のプロジェクト別日次集計 |
+| `manifest.json` | 期間、timezone、ccusage版、設定・レポートの SHA-256 |
+
+snapshot は既存月を上書きしない。`cs --clean` などで原本 JSONL を消す前に作成する。原本 (`~/.claude/projects/`、`~/.pi/agent/sessions/` 等) と snapshot 内のプロジェクト名は Git、dotfiles、スクリーンショット、非暗号化クラウド同期へ入れない。
+
+## 月次スケジュール
+
+スケジュールは opt-in。毎月1日 00:10 に前月の未作成 snapshot を保存する。
+
+```bash
+ccusage-schedule enable
+ccusage-schedule status
+ccusage-schedule disable
+```
+
+- macOS: user LaunchAgent (`com.user.ccusage-snapshot`)
+- Linux: user systemd timer (`ccusage-snapshot.timer`, `Persistent=true`)
+- ログ: `${XDG_STATE_HOME:-~/.local/state}/ccusage/log/`
+
+`enable` は実行中の dotfiles checkout を参照するジョブを作成する。dotfiles のパスを移動したら一度 `disable` してから `enable` し直す。
+
+## 検証
+
+```bash
+scripts/test-ccusage-snapshot.sh
+shellcheck scripts/ccusage-snapshot scripts/ccusage-schedule scripts/test-ccusage-snapshot.sh
+```
+
+テストは fake ccusage を使い、実際の会話ログを読み込まない。

--- a/docs/ai-agents/claude/claude-development.md
+++ b/docs/ai-agents/claude/claude-development.md
@@ -468,3 +468,4 @@ cs
 - [Ralph Pattern](ralph.md) - 自律開発ループ
 - [Claude Neovim](claude-neovim.md) - Neovim 連携
 - [Claude Fallback](claude-fallback.md) - API フォールバック
+- [ccusage](ccusage.md) - ローカル利用統計・月次証跡

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -136,6 +136,7 @@ dotfiles の拡張により Web Research Layer が利用可能。SearXNG + Jina 
 - `Ctrl+O`: ツール出力を展開/折り畳み
 - `Esc` を2回: `/tree` を開く。tree 内の `Ctrl+T` でツール結果を表示/非表示
 - `/statusline compact`: フッターを1行表示に切り替え
+- 入力中の既知 skill 名はアクセント色でハイライトされる（`/reload` または再起動で skill 一覧を再読込）。
 
 ### 拡張機能
 

--- a/scripts/ccusage-schedule
+++ b/scripts/ccusage-schedule
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ccusage-snapshot の月次スケジュールを明示的に管理する。
+set -euo pipefail
+
+LABEL="com.user.ccusage-snapshot"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNAPSHOT_SCRIPT="$SCRIPT_DIR/ccusage-snapshot"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ccusage"
+
+usage() {
+  echo "Usage: ccusage-schedule {enable|disable|status}" >&2
+}
+
+mac_enable() {
+  local destination="$HOME/Library/LaunchAgents/$LABEL.plist"
+  mkdir -p "$HOME/Library/LaunchAgents" "$STATE_DIR/log"
+  cat > "$destination" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key><array><string>$SNAPSHOT_SCRIPT</string></array>
+  <key>EnvironmentVariables</key><dict>
+    <key>HOME</key><string>$HOME</string>
+    <key>PATH</key><string>$HOME/.local/share/mise/shims:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StartCalendarInterval</key><dict>
+    <key>Day</key><integer>1</integer><key>Hour</key><integer>0</integer><key>Minute</key><integer>10</integer>
+  </dict>
+  <key>StandardOutPath</key><string>$STATE_DIR/log/snapshot.out</string>
+  <key>StandardErrorPath</key><string>$STATE_DIR/log/snapshot.err</string>
+</dict></plist>
+EOF
+  plutil -lint "$destination" >/dev/null
+  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$destination"
+  echo "Enabled launchd job: $LABEL"
+}
+
+mac_disable() {
+  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+  rm -f "$HOME/Library/LaunchAgents/$LABEL.plist"
+  echo "Disabled launchd job: $LABEL"
+}
+
+linux_unit_dir() {
+  printf '%s' "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+}
+
+linux_enable() {
+  local unit_dir
+  unit_dir="$(linux_unit_dir)"
+  mkdir -p "$unit_dir" "$STATE_DIR/log"
+  cat > "$unit_dir/ccusage-snapshot.service" <<EOF
+[Unit]
+Description=Save monthly ccusage snapshot
+
+[Service]
+Type=oneshot
+Environment=PATH=$HOME/.local/share/mise/shims:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=append:$STATE_DIR/log/snapshot.out
+StandardError=append:$STATE_DIR/log/snapshot.err
+ExecStart=$SNAPSHOT_SCRIPT
+EOF
+  cat > "$unit_dir/ccusage-snapshot.timer" <<'EOF'
+[Unit]
+Description=Run ccusage monthly snapshot
+
+[Timer]
+OnCalendar=*-*-01 00:10:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+  systemctl --user daemon-reload
+  systemctl --user enable --now ccusage-snapshot.timer
+  echo "Enabled systemd user timer: ccusage-snapshot.timer"
+}
+
+linux_disable() {
+  systemctl --user disable --now ccusage-snapshot.timer 2>/dev/null || true
+  rm -f "$(linux_unit_dir)/ccusage-snapshot.service" "$(linux_unit_dir)/ccusage-snapshot.timer"
+  systemctl --user daemon-reload
+  echo "Disabled systemd user timer: ccusage-snapshot.timer"
+}
+
+[[ $# -eq 1 ]] || { usage; exit 2; }
+case "$(uname -s):$1" in
+  Darwin:enable) mac_enable ;;
+  Darwin:disable) mac_disable ;;
+  Darwin:status) launchctl print "gui/$(id -u)/$LABEL" 2>&1 ;;
+  Linux:enable) linux_enable ;;
+  Linux:disable) linux_disable ;;
+  Linux:status) systemctl --user status ccusage-snapshot.timer ;;
+  Darwin:*|Linux:*) usage; exit 2 ;;
+  *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac

--- a/scripts/ccusage-snapshot
+++ b/scripts/ccusage-snapshot
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# ccusage の終了済み月を、原本 JSONL を含まない不変集計として保存する。
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: ccusage-snapshot [YYYY-MM]
+
+Save all-agent daily usage and Claude project usage for a completed calendar month.
+Without an argument, saves the previous month.
+EOF
+}
+
+[[ $# -le 1 ]] || { usage; exit 2; }
+MONTH="${1:-}"
+
+read -r YEAR MONTH_NUMBER START_DATE END_DATE <<EOF
+$(python3 - "$MONTH" <<'PY'
+import calendar
+import sys
+from datetime import date
+
+value = sys.argv[1]
+if value:
+    try:
+        year, month = map(int, value.split("-"))
+        if not 1 <= month <= 12 or f"{year:04d}-{month:02d}" != value:
+            raise ValueError
+    except ValueError:
+        raise SystemExit("month must be YYYY-MM")
+else:
+    today = date.today()
+    year, month = (today.year - 1, 12) if today.month == 1 else (today.year, today.month - 1)
+
+print(year, f"{month:02d}", f"{year:04d}{month:02d}01", f"{year:04d}{month:02d}{calendar.monthrange(year, month)[1]:02d}")
+PY
+)
+EOF
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/ccusage"
+SNAPSHOT_PARENT="$STATE_DIR/snapshots/$YEAR"
+SNAPSHOT_DIR="$SNAPSHOT_PARENT/$MONTH_NUMBER"
+TIMEZONE="${CCUSAGE_TIMEZONE:-Asia/Tokyo}"
+CONFIG_PATH="${CCUSAGE_CONFIG:-$HOME/.claude/ccusage.json}"
+
+if [[ -e "$SNAPSHOT_DIR" ]]; then
+  printf 'Snapshot already exists: %s\n' "$SNAPSHOT_DIR"
+  exit 0
+fi
+
+if [[ -n "${CCUSAGE_BIN:-}" ]]; then
+  [[ -x "$CCUSAGE_BIN" ]] || { printf 'CCUSAGE_BIN is not executable: %s\n' "$CCUSAGE_BIN" >&2; exit 1; }
+  CCUSAGE=("$CCUSAGE_BIN")
+elif command -v ccusage >/dev/null 2>&1; then
+  CCUSAGE=(ccusage)
+elif command -v mise >/dev/null 2>&1; then
+  CCUSAGE=(mise exec node -- ccusage)
+else
+  printf 'ccusage is not installed; run install.sh first.\n' >&2
+  exit 1
+fi
+
+VERSION_OUTPUT="$("${CCUSAGE[@]}" --version)"
+if [[ "$VERSION_OUTPUT" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+  VERSION="${BASH_REMATCH[0]}"
+  MAJOR="${BASH_REMATCH[1]}"
+else
+  printf 'Could not determine ccusage version: %s\n' "$VERSION_OUTPUT" >&2
+  exit 1
+fi
+if (( MAJOR < 20 )); then
+  printf 'ccusage 20 or newer is required (found: %s).\n' "$VERSION" >&2
+  exit 1
+fi
+
+mkdir -p "$SNAPSHOT_PARENT"
+TMP_DIR="$(mktemp -d "$SNAPSHOT_PARENT/.${MONTH_NUMBER}.tmp.XXXXXX")"
+cleanup() {
+  if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+run_report() {
+  local output="$1"
+  shift
+  "${CCUSAGE[@]}" "$@" --json --offline --mode auto --timezone "$TIMEZONE" \
+    --since "$START_DATE" --until "$END_DATE" > "$TMP_DIR/$output"
+  python3 -m json.tool "$TMP_DIR/$output" >/dev/null
+}
+
+run_report all-daily.json daily --all
+run_report claude-projects.json claude daily --instances
+
+python3 - "$TMP_DIR" "$YEAR-$MONTH_NUMBER" "$START_DATE" "$END_DATE" "$TIMEZONE" "$VERSION" "$CONFIG_PATH" <<'PY'
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+root, month, start, end, timezone_name, version, config_path = sys.argv[1:]
+root = Path(root)
+config = Path(config_path)
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+reports = {
+    "allDaily": {
+        "file": "all-daily.json",
+        "command": ["daily", "--all"],
+    },
+    "claudeProjects": {
+        "file": "claude-projects.json",
+        "command": ["claude", "daily", "--instances"],
+    },
+}
+for report in reports.values():
+    report["sha256"] = digest(root / report["file"])
+
+manifest = {
+    "schemaVersion": 1,
+    "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "period": {"month": month, "since": start, "until": end, "timezone": timezone_name},
+    "ccusage": {
+        "version": version,
+        "offline": True,
+        "costMode": "auto",
+        "configSha256": digest(config) if config.is_file() else None,
+    },
+    "reports": reports,
+}
+(root / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+PY
+
+mv "$TMP_DIR" "$SNAPSHOT_DIR"
+TMP_DIR=""
+printf 'Saved snapshot: %s\n' "$SNAPSHOT_DIR"

--- a/scripts/test-ccusage-snapshot.sh
+++ b/scripts/test-ccusage-snapshot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/home/.claude" "$TMP_DIR/bin"
+cat > "$TMP_DIR/home/.claude/ccusage.json" <<'EOF'
+{"defaults":{"timezone":"Asia/Tokyo","offline":true,"mode":"auto"}}
+EOF
+cat > "$TMP_DIR/bin/ccusage" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo 20.0.17
+  exit 0
+fi
+python3 - "$@" <<'PY'
+import json
+import sys
+print(json.dumps({"args": sys.argv[1:]}))
+PY
+EOF
+chmod +x "$TMP_DIR/bin/ccusage"
+
+HOME="$TMP_DIR/home" XDG_STATE_HOME="$TMP_DIR/state" CCUSAGE_BIN="$TMP_DIR/bin/ccusage" \
+  "$ROOT_DIR/scripts/ccusage-snapshot" 2026-06 >/dev/null
+
+python3 - "$TMP_DIR/state/ccusage/snapshots/2026/06" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+manifest = json.loads((root / "manifest.json").read_text())
+assert manifest["period"] == {
+    "month": "2026-06", "since": "20260601", "until": "20260630", "timezone": "Asia/Tokyo"
+}
+assert manifest["ccusage"]["version"] == "20.0.17"
+assert manifest["reports"]["allDaily"]["sha256"] == hashlib.sha256((root / "all-daily.json").read_bytes()).hexdigest()
+assert manifest["reports"]["claudeProjects"]["sha256"] == hashlib.sha256((root / "claude-projects.json").read_bytes()).hexdigest()
+assert "--all" in json.loads((root / "all-daily.json").read_text())["args"]
+assert "--instances" in json.loads((root / "claude-projects.json").read_text())["args"]
+PY
+
+echo "ccusage snapshot test passed"


### PR DESCRIPTION
## Summary
- pin ccusage 20.0.17 and add shared offline/Tokyo defaults
- add immutable monthly usage snapshots with integrity manifests
- add opt-in macOS launchd and Linux systemd scheduling

## Test plan
- [x] `scripts/test-ccusage-snapshot.sh`
- [x] `shellcheck scripts/ccusage-snapshot scripts/ccusage-schedule scripts/test-ccusage-snapshot.sh`
- [x] verified a real June 2026 snapshot manifest and LaunchAgent
