### PR TITLE
chore(pi): update default model and changelog version

### DIFF
--- a/common/pi/.pi/agent/settings.json
+++ b/common/pi/.pi/agent/settings.json
@@ -1,6 +1,6 @@
 {
   "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.5",
+  "defaultModel": "gpt-5.6-terra",
   "defaultThinkingLevel": "high",
   "hideThinkingBlock": true,
   "theme": "tokyonight-high-contrast",
@@ -82,5 +82,5 @@
     "npm:pi-permission-system",
     "git:github.com/DietrichGebert/ponytail"
   ],
-  "lastChangelogVersion": "0.80.3"
+  "lastChangelogVersion": "0.80.6"
 }


### PR DESCRIPTION
## Summary
- set Pi default model to gpt-5.6-terra
- record the current Pi changelog version

## Test plan
- [x] `jq empty common/pi/.pi/agent/settings.json`