### PR TITLE
feat(pi): trust repository-local cleanup commands

### DIFF
--- a/common/pi/.pi/agent/extensions/permission-gate.ts
+++ b/common/pi/.pi/agent/extensions/permission-gate.ts
@@ -2,7 +2,11 @@
 // Blocks dangerous bash commands pending user confirmation.
 // Install: place in ~/.pi/agent/extensions/permission-gate.ts
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const execFileAsync = promisify(execFile);
 
 // Defense-in-depth only. This is a denylist and is inherently bypassable
 // (e.g. `rm -r -f`, base64-encoded commands, obscure flag spellings); it is not
@@ -35,6 +39,55 @@ const DANGEROUS_PATTERNS = [
 // are matched defensively (harmless if they don't exist — the gate never fires).
 const SHELL_TOOLS = new Set(["bash", "shell", "sh", "exec", "run"]);
 
+// The exemption deliberately accepts a tiny shell grammar: a standalone `rm`
+// with relative, non-traversing arguments, or a standalone force-push from the
+// current repository. Everything else retains the confirmation dialog.
+function isRepoLocalRm(command: string): boolean {
+  const parts = command.trim().split(/\s+/);
+  if (parts.shift() !== "rm") return false;
+
+  let recursive = false;
+  let force = false;
+  let options = true;
+  const targets: string[] = [];
+  for (const part of parts) {
+    if (options && part === "--") {
+      options = false;
+    } else if (options && /^-[A-Za-z]+$/.test(part)) {
+      recursive ||= part.includes("r") || part.includes("R");
+      force ||= part.includes("f");
+    } else if (options && part === "--recursive") {
+      recursive = true;
+    } else if (options && part === "--force") {
+      force = true;
+    } else {
+      targets.push(part);
+    }
+  }
+
+  return recursive && force && targets.length > 0 && targets.every(
+    (target) => !target.startsWith("/") && !target.split("/").includes("..") && !/["'`$;&|()\\]/.test(target),
+  );
+}
+
+function isRepoLocalForceWithLease(command: string): boolean {
+  return /^git\s+push\b(?=[\s\S]*--force-with-lease)[^;&|`$()\n]*$/.test(command.trim());
+}
+
+async function isGitWorktree(cwd: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", cwd, "rev-parse", "--is-inside-work-tree"]);
+    return stdout.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+export async function isTrustedGitProjectCommand(command: string, cwd: string): Promise<boolean> {
+  if (!isRepoLocalRm(command) && !isRepoLocalForceWithLease(command)) return false;
+  return isGitWorktree(cwd);
+}
+
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, ctx) => {
     if (!SHELL_TOOLS.has(event.toolName)) return;
@@ -44,6 +97,8 @@ export default function (pi: ExtensionAPI) {
 
     const matched = DANGEROUS_PATTERNS.find((p) => p.test(command));
     if (!matched) return;
+
+    if (await isTrustedGitProjectCommand(command, ctx.cwd)) return;
 
     const ok = await ctx.ui.confirm(
       "🛡️ Dangerous command detected",

--- a/docs/specs/agent-infrastructure.md
+++ b/docs/specs/agent-infrastructure.md
@@ -20,7 +20,7 @@
 | **Triggers** | `rm -rf`, `sudo`, `chmod 777`, `chown`, `docker system prune`, `kubectl delete`, `terraform apply`, `npm publish`, `git push --force`, `git reset --hard`, `DROP`, `DELETE FROM`, `TRUNCATE TABLE` |
 | **Pi impl** | `extensions/permission-gate.ts` — `tool_call` event + `ctx.ui.confirm` |
 | **Claude impl** | 検討中（`hooks/` で実装可能） |
-| **Behavior** | ユーザーに確認ダイアログを表示。拒否時は理由をログに記録 |
+| **Behavior** | ユーザーに確認ダイアログを表示。拒否時は理由をログに記録。Git worktree 内では、相対パスのみの単独 `rm -rf` と単独 `git push --force-with-lease` は自動許可（それ以外の危険操作は確認） |
 
 ### 2. Protected Paths
 


### PR DESCRIPTION
## Summary
- Allow guarded repository-local cleanup commands without a prompt.
- Keep absolute/traversing deletes and plain force-pushes gated.

## Test plan
- [x] Run repository-exemption assertions for allowed and rejected command forms.
- [x] Verify `git push --force` and `git push -f` remain rejected.