### PR TITLE
fix(pi): prevent finite work from using cron loops

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -106,9 +106,12 @@ guarantees, prefer adopting it over maintaining the custom one.
 
 ## Loop Automation
 
-- `@trevonistrevon/pi-loop` provides cron/event-based agent re-wake loops and background monitors.
-- Use `/loop [interval] [prompt]` for interactive loop creation.
-- Tools: `LoopCreate`, `LoopList`, `LoopDelete`, `MonitorCreate`, `MonitorList`, `MonitorStop`.
+- `@trevonistrevon/pi-loop` provides dynamic goal loops, cron/event re-wake loops, and background monitors.
+- Finite implementation goals, especially "continue until everything is done", must use `/goal <goal>`, not a cron `LoopCreate`. Do not translate the user's word "loop" into timer polling when the requested stop condition is work completion.
+- `/loop <goal>` creates a dynamic loop for explicitly bounded iterative work. It waits for `LoopUpdate`, so timer ticks cannot exhaust `maxFires` while the agent is still working, but it still stops after its iteration cap.
+- Use `/loop [interval] [prompt]` and `LoopCreate` only for genuinely periodic observation or polling. `maxFires` counts scheduled trigger firings, including coalesced wakes while the agent is busy; it is not a completed-work counter.
+- Tools: `LoopCreate`, `LoopUpdate`, `LoopList`, `LoopDelete`, `MonitorCreate`, `MonitorList`, `MonitorStop`.
+- Before reporting that a loop remains active or finished, call `LoopList`; never infer scheduler state from the prompt or from work status.
 - Prefer session-scoped loops unless a project explicitly needs shared automation.
 
 ## Session Management

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -11,10 +11,18 @@
 | pi CLI | エージェント本体 | `config/packages.npm.txt` の `@earendil-works/pi-coding-agent` (npm global) |
 | pi-cursor-agent | Cursor サブスク → pi プロバイダ | `settings.json` の `packages` → `pi install npm:pi-cursor-agent` |
 | pi-dynamic-workflows | Claude Code-style workflow / fan-out orchestration | `settings.json` の `packages` → `pi install npm:@quintinshaw/pi-dynamic-workflows` |
-| pi-loop | cron/event-based agent re-wake loops と background monitor | `settings.json` の `packages` → `pi install npm:@trevonistrevon/pi-loop` |
+| pi-loop | dynamic goal loop、cron/event re-wake loop、background monitor | `settings.json` の `packages` → `pi install npm:@trevonistrevon/pi-loop` |
 | pi-goal | `/goal` で完了まで継続する goal mode | `settings.json` の `packages` → `pi install npm:@narumitw/pi-goal` |
 | AGENTS.md | グローバル指示書 | `common/pi/.pi/agent/AGENTS.md` → `~/.pi/agent/AGENTS.md` |
 | pueue | バックグラウンドタスク・並列 delegation 用キュー | `config/Brewfile` (mac), `packages.linux.{apt,alpine}.txt` (linux) |
+
+## LoopとGoalの使い分け
+
+「全件完了まで継続」のように作業完了を停止条件とする実装には`/goal <goal>`を使う。利用者が「loop」と表現しても、時間間隔に意味がなければcron loopへ変換しない。
+
+`/loop <goal>`のdynamic loopは、iteration上限内の反復作業に使う。各iterationの完了後に`LoopUpdate`で次回wakeを設定するため、agent実行中のtimer tickでは`maxFires`を消費しないが、iteration上限に達すると終了する。
+
+`LoopCreate`によるcron loopはCI監視など、時間間隔そのものに意味がある観測・polling専用とする。cron loopの`maxFires`は実作業の完了回数ではなくschedule発火回数を数え、agent実行中に通知がcoalesceされても増加する。
 
 ## セットアップ
 


### PR DESCRIPTION
## 背景

完了条件を持つ実装作業をcron loopとして起動すると、agent実行中もschedule発火ごとに`fireCount`が増えます。通知は同じloop IDでcoalesceされる一方、`maxFires`は消費されるため、実作業のiteration数より先にloopが自動削除されていました。

実際にSession Phase BのLoop #51は5分間隔・`maxFires: 50`で作成され、約250分後に未完了項目を残したまま消失しました。

## 変更内容

- 「全件完了まで」の有限作業はcron loopではなく`/goal <goal>`へ振り分けるルールを追加
- `/loop <goal>`のdynamic loopはiteration上限内の反復作業に限定
- `LoopCreate`を時間間隔に意味がある観測・polling用途に限定
- `maxFires`は完了作業数ではなくschedule発火数であることを明記
- loopの継続・終了を報告する前に`LoopList`で実測するルールを追加
- pi-loop 0.6.1で追加されたdynamic loopと`LoopUpdate`を構成ドキュメントへ反映

## 検証

- `git diff --check origin/main...HEAD`: 成功
- 変更は`common/pi/.pi/agent/AGENTS.md`と`docs/ai-agents/pi/overview.md`のみ
- ローカル環境の`@trevonistrevon/pi-loop`を0.6.1へ更新し、`LoopUpdate`の登録を確認

## 補足

`common/pi/.pi/agent/settings.json`に存在する別作業の未commit差分は、このPRに含めていません。
