### PR TITLE
fix(tmux): agent 横断ビューを既定で軽量 preview 版に戻す

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -182,14 +182,18 @@ bind -n C-M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group 
 bind -n C-M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
 bind Tab switch-client -l
 
-# AI Agent 横断ビュー: popup 内にセレクタ + 選択エージェントの実ペインを swap-pane で表示。
-# open が scratch session(_agentpop)でセレクタを起動し、display-popup がそれを attach。
-# j/k 選択で該当エージェント実ペインを blank と swap して右に live 表示(元 window は構造保持・
-# 該当スロットが一時 blank になるだけ)、Tab で右の実ペインへフォーカスして操作、Enter で元 client
-# を該当ペインへジャンプ、q で閉じる(swap 中の実ペインは selector 終了時に元へ戻す)。
-# 末尾の run-shell jump: popup client では switch-client できないため、popup を閉じた後に
-# 元 client コンテキストで selector が記録した target へ飛ぶ。
-bind a run-shell "~/dotfiles/scripts/tmux-agent-status.sh open" \; display-popup -E -w 85% -h 75% 'sock="${TMUX%%,*}"; TMUX= exec tmux -S "$sock" attach -t _agentpop 2>/dev/null' \; run-shell "~/dotfiles/scripts/tmux-agent-status.sh jump"
+# AI Agent 横断ビュー: 既定は軽量な preview 版(capture-pane で右にプレビュー)。重い reflect 版
+# (選択エージェントの実ペインを swap-pane で右に live 表示)は popup 内で Shift-Tab を押した時だけ、
+# その回に限り起動する(prefix 不要・既定は常に軽量版)。Shift-Tab は @agent_escalate を立てて popup を
+# 閉じ、下の if-shell が reflect 版を開き直す。
+# reflect 版: open が scratch session(_agentpop)でセレクタを起動し display-popup が attach。
+# j/k で該当実ペインを blank と swap して右に live 表示、Tab で操作、Enter でジャンプ、q で閉じる。
+# 末尾の run-shell jump: popup client では switch-client できないため popup を閉じた後に飛ぶ。
+bind a run-shell "tmux set-option -g @agent_cur_pane '#{pane_id}'; tmux set-option -gu @agent_escalate" \; display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup" \; if-shell -F '#{@agent_escalate}' {
+  run-shell "~/dotfiles/scripts/tmux-agent-status.sh open"
+  display-popup -E -w 85% -h 75% 'sock="${TMUX%%,*}"; TMUX= exec tmux -S "$sock" attach -t _agentpop 2>/dev/null'
+  run-shell "~/dotfiles/scripts/tmux-agent-status.sh jump"
+}
 # AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
 # (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
 bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -378,7 +378,8 @@ case "${1:-popup}" in
             --preview "bash '$SELF' preview {1} {2}" \
             --preview-window 'right,58%,border-left,wrap' \
             --prompt 'agent> ' \
-            --header 'j/k:移動  g/G:端  r:再走査  s:stash  /:検索  Enter:ジャンプ  q:閉じる' \
+            --header 'j/k:移動  g/G:端  r:再走査  s:stash  S-Tab:実ペイン表示  Enter:ジャンプ  q:閉じる' \
+            --bind "shift-tab:execute-silent(tmux set-option -g @agent_escalate 1)+abort" \
             --bind 'g:first,G:last' \
             --bind 'j:down+transform:[ {2} = divider ] && echo down' \
             --bind 'k:up+transform:[ {2} = divider ] && echo up' \


### PR DESCRIPTION
## Summary

prefix a の AI Agent 横断ビューは #242 で「選択エージェントの実ペインを swap-pane で右に live 表示する reflect 版」に変わったが、多pane 環境ではこの swap 処理が重い。既定を元の軽量な capture-pane preview 版に戻し、重い reflect 版は使いたい時だけ起動できるようにした。

## Changes

- `prefix a` の既定挙動を軽量な preview 版(`tmux-agent-status.sh popup`)に戻した
- reflect 実ペイン版は popup 内で `Shift-Tab`(prefix 不要)を押した回のみ起動。`@agent_escalate` を立てて popup を閉じ、後続の `if-shell` が reflect 版を開き直す
- 永続化しないため次回の `prefix a` は常に軽量版
- `popup` case の fzf に `shift-tab:execute-silent(...)+abort` バインドと header ヒントを追加

## Test plan

- [ ] `prefix + r` で設定リロード後、`prefix a` で軽量 preview 版が開くこと
- [ ] popup 内で `Shift-Tab` を押すと reflect 実ペイン版に切り替わること
- [ ] 切り替え後に再度 `prefix a` を押すと軽量版に戻ること(永続化しない)