### PR TITLE
fix(tmux): コピー後にスクロール位置を維持する

### DIFF
--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -57,17 +57,18 @@ bind v copy-mode
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'C-v' send -X rectangle-toggle
 # y: pipe to OS-aware clipboard wrapper (popup OSC52 を回避するため pbcopy/lemonade/wl-copy/xclip 直接呼出)
-bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel "~/dotfiles/scripts/clipboard-copy"
+bind-key -T copy-mode-vi 'y' send -X copy-pipe "~/dotfiles/scripts/clipboard-copy"
 bind-key -T copy-mode-vi Enter send-keys -X cancel
-bind-key -T copy-mode-vi Escape send-keys -X cancel
+# Escape: 選択中は解除のみ、非選択時は copy-mode を抜ける
+bind-key -T copy-mode-vi Escape if-shell -F '#{selection_present}' 'send-keys -X clear-selection' 'send-keys -X cancel'
 # スクロール量を4行に変更（デフォルトは半ページ）
 bind-key -T copy-mode-vi C-u send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up
 bind-key -T copy-mode-vi C-d send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down
 # u/d で半ページスクロール（倍速移動）
 bind-key -T copy-mode-vi u send-keys -X halfpage-up
 bind-key -T copy-mode-vi d send-keys -X halfpage-down
-# Mouse drag: auto-copy to clipboard, exit copy-mode and scroll to bottom
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "~/dotfiles/scripts/clipboard-copy"
+# Mouse drag: auto-copy to clipboard, keep copy-mode & scroll position (q/Enter で抜ける)
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe "~/dotfiles/scripts/clipboard-copy"
 set -g base-index 1
 setw -g pane-base-index 1
 set -s escape-time 0


### PR DESCRIPTION
## Summary
tmux でスクロールバック中にテキストをコピーすると最下部へジャンプしてしまう挙動を修正。コピー後も copy-mode に留まりスクロール位置を維持する。

## Changes
- `MouseDragEnd1Pane` / `y`: `copy-pipe-and-cancel` → `copy-pipe`（コピー後も copy-mode を維持）
- `Escape`: 選択中は `clear-selection`（選択解除のみ）、非選択時は `cancel`（copy-mode を抜ける）を `#{selection_present}` で分岐

## Test plan
- [ ] スクロールバック中にマウスドラッグでコピー → 位置が維持される
- [ ] v で選択 → y でコピー → 位置が維持される
- [ ] 選択中に Escape → 選択解除のみ、copy-mode に留まる
- [ ] 非選択で Escape → copy-mode を抜ける
- [ ] q で copy-mode を抜けられる