### PR TITLE
feat(cli): gum を導入し確認プロンプトを gum confirm に統一

### DIFF
--- a/common/bin/.local/bin/conflict-review
+++ b/common/bin/.local/bin/conflict-review
@@ -121,9 +121,7 @@ case "$action" in
       echo "Warning: REVIEW: comments remain:"
       echo "$REVIEW_REMAINING"
       echo ""
-      read -rp "Continue anyway? [y/N]: " -n 1 yn || true
-      echo ""
-      [[ "$yn" =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
+      gum confirm --default=false "Continue anyway?" || { echo "Cancelled."; exit 0; }
     fi
     case "$OP_TYPE" in
       rebase)      git rebase --continue ;;
@@ -140,9 +138,7 @@ case "$action" in
       cherry-pick) abort_cmd="git cherry-pick --abort" ;;
       *)           abort_cmd="git merge --abort" ;;
     esac
-    read -rp "Run '${abort_cmd}'? [y/N]: " -n 1 confirm || true
-    echo ""
-    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+    if gum confirm --default=false "Run '${abort_cmd}'?"; then
       $abort_cmd
       echo "Aborted."
     else

--- a/common/bin/.local/bin/rebase-review
+++ b/common/bin/.local/bin/rebase-review
@@ -316,9 +316,7 @@ while true; do
     m|M)
       REVIEW_REMAINING=$(collect_review_comments)
       if [[ -n "$REVIEW_REMAINING" ]]; then
-        read -rp "REVIEW: comments remain. Continue with amend? [y/N]: " -n 1 yn || true
-        echo ""
-        [[ "$yn" =~ ^[Yy]$ ]] || continue
+        gum confirm --default=false "REVIEW: comments remain. Continue with amend?" || continue
       fi
       git commit --amend
       break

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -77,6 +77,7 @@ brew "git"
 brew "git-absorb"
 brew "ouch"
 brew "glow"
+brew "gum"          # 対話シェルスクリプト用 UI (confirm/choose/input)
 brew "viddy"
 brew "doggo"
 brew "topgrade"

--- a/config/mise-linux.toml
+++ b/config/mise-linux.toml
@@ -36,6 +36,7 @@
 "aqua:gitleaks/gitleaks" = "latest"
 "aqua:ducaale/xh" = "latest"
 "aqua:charmbracelet/glow" = "latest"
+"aqua:charmbracelet/gum" = "latest"
 "aqua:sachaos/viddy" = "latest"
 "github:mr-karan/doggo" = "latest"  # aqua registry が doggo 1.2.0 の asset 命名に未追随のため github へ
 "aqua:topgrade-rs/topgrade" = "latest"

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -172,7 +172,7 @@ LINUX_TOOL_ORDER=(
   pgcli
 )
 # GitHub-release tools (fzf, fastfetch, delta, lazygit, ghq, smug, dops, yazi,
-# rainfrog, typst, just, watchexec, hyperfine, gitleaks, xh, ouch, glow, viddy,
+# rainfrog, typst, just, watchexec, hyperfine, gitleaks, xh, ouch, glow, gum, viddy,
 # doggo, topgrade, grex, sesh, lemonade, neovim, direnv, sd, dust,
 # bottom, rip2, lsd, tealdeer) are installed via mise — see config/mise-linux.toml
 # and the mise block in scripts/linux.sh. They no longer use the eval/scrape engine.

--- a/scripts/cs
+++ b/scripts/cs
@@ -173,10 +173,7 @@ clean_old_sessions() {
     fi
 
     echo ""
-    read -p "Delete these $count sessions? [y/N] " -n 1 -r
-    echo
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if gum confirm --default=false "Delete these $count sessions?"; then
         while IFS= read -r session_file; do
             local age_days
             age_days=$(( ($(date +%s) - $(stat -f "%m" "$session_file" 2>/dev/null || stat -c "%Y" "$session_file")) / 86400 ))

--- a/scripts/tmux-layout-menu.sh
+++ b/scripts/tmux-layout-menu.sh
@@ -52,13 +52,9 @@ while true; do
     if [ "$picked_name" = "$SAVE_TAG" ]; then
       continue
     fi
-    printf 'delete preset %q? [y/N]: ' "$picked_name"
-    read -r answer
-    case "${answer:-}" in
-      y|Y|yes|YES)
-        "$TMUX_LAYOUT" delete "$picked_name" || true
-        ;;
-    esac
+    if gum confirm --default=false "delete preset $picked_name?"; then
+      "$TMUX_LAYOUT" delete "$picked_name" || true
+    fi
     continue
   fi
 


### PR DESCRIPTION
## Summary
対話シェルスクリプト用 UI ツール gum を導入し、各所の `read -p "[y/N]"` + 正規表現判定という定型の確認プロンプトを `gum confirm` に統一した。

## Changes
- 登録（mac / linux 両経路）
  - `config/Brewfile` — `brew "gum"`
  - `config/mise-linux.toml` — `"aqua:charmbracelet/gum" = "latest"`（glow と同じ aqua backend）
  - `config/tools.linux.bash` — mise 管理 tool 列挙コメントに gum を追記
- 確認プロンプト置換（`read -p "[y/N]" -n 1` + `[[ =~ ^[Yy]$ ]]` → `gum confirm --default=false`）
  - `scripts/cs` セッション一括削除
  - `scripts/tmux-layout-menu.sh` プリセット削除
  - `common/bin/.local/bin/rebase-review` amend 続行
  - `common/bin/.local/bin/conflict-review` 続行 / abort 実行（2箇所）
- 破壊的操作のためデフォルト選択は No（`--default=false`）
- フォールバック（gum 不在時の read 復帰）は付けない。gum は fzf 同様の宣言済み依存として扱う

正味 -21 / +10 行。

## Test plan
- [x] tmux 実 TTY で E2E: `y` → exit 0（実行パス）/ `n` → exit 1（キャンセルパス）を確認
- [x] `bash -n` 構文チェック（4スクリプト）
- [x] `scripts/check-markdown-links.py` / `scripts/check-package-duplication.sh` OK
- [ ] `install.sh` で gum が両 OS に入ること（レビュア環境で任意確認）