### PR TITLE
fix(pi): hard-deny worktree capacity creation

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -18,6 +18,7 @@
 - secret、credential、`.env`、private key、production dumpを読まない。
 - 生成物とruntime fileを直接編集しない。
 - root causeを確認し、既存実装・stdlib・native機能を優先する。
+- agentは既存pooled worktreeだけを再利用し、`git worktree add`や`pnpm wt provision`でworktree capacityを追加しない。追加が必要なら利用者がterminalから実行する。
 
 ## Memory
 

--- a/common/pi/.pi/agent/extensions/permission-gate.ts
+++ b/common/pi/.pi/agent/extensions/permission-gate.ts
@@ -12,6 +12,21 @@ const execFileAsync = promisify(execFile);
 // (e.g. `rm -r -f`, base64-encoded commands, obscure flag spellings); it is not
 // a security boundary. Its job is to catch the obvious-footgun cases and force
 // a human decision, not to stop a determined adversary.
+// Capacity creation must originate outside the agent, so these commands do not
+// offer the confirmation escape hatch used by the general denylist.
+const HARD_DENY_PATTERNS = [
+  {
+    pattern:
+      /(?:^|[;&|]\s*)(?:sudo\s+)?(?:\S*\/)?git\b(?:(?:\s+-C\s+(?:"[^"]*"|'[^']*'|[^\s;&|]+))*)\s+worktree\s+add\b/i,
+    reason: "Agents may only reuse existing pooled worktrees; run git worktree add manually if required",
+  },
+  {
+    pattern:
+      /(?:^|[;&|]\s*)(?:sudo\s+)?(?:corepack\s+)?(?:\S*\/)?pnpm\b(?:\s+(?:(?:-C|--dir|--filter)\s+(?:"[^"]*"|'[^']*'|[^\s;&|]+)|(?:--dir|--filter)=(?:"[^"]*"|'[^']*'|[^\s;&|]+)|-w|--workspace-root|--silent))*\s+(?:run\s+)?wt\s+(?:--\s+)?provision\b/i,
+    reason: "Agents may not add pooled worktree capacity; run pnpm wt provision manually if required",
+  },
+];
+
 const DANGEROUS_PATTERNS = [
   /\brm\b(?=[^|;&\n]*\s-[a-z]*r)(?=[^|;&\n]*\s-[a-z]*f)/i, // rm with both -r and -f (rf/fr/-r -f)
   /\bsudo\b/,
@@ -83,6 +98,10 @@ async function isGitWorktree(cwd: string): Promise<boolean> {
   }
 }
 
+export function getHardDenyReason(command: string): string | undefined {
+  return HARD_DENY_PATTERNS.find(({ pattern }) => pattern.test(command))?.reason;
+}
+
 export async function isTrustedGitProjectCommand(command: string, cwd: string): Promise<boolean> {
   if (!isRepoLocalRm(command) && !isRepoLocalForceWithLease(command)) return false;
   return isGitWorktree(cwd);
@@ -94,6 +113,11 @@ export default function (pi: ExtensionAPI) {
 
     const command = String(event.input?.command ?? event.input?.cmd ?? "");
     if (!command) return;
+
+    const hardDenyReason = getHardDenyReason(command);
+    if (hardDenyReason) {
+      return { block: true, reason: hardDenyReason };
+    }
 
     const matched = DANGEROUS_PATTERNS.find((p) => p.test(command));
     if (!matched) return;

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -145,6 +145,10 @@ dotfiles の拡張により Web Research Layer が利用可能。SearXNG + Jina 
 - `/statusline compact`: フッターを1行表示に切り替え
 - 入力中の既知 skill 名はアクセント色でハイライトされる（`/reload` または再起動で skill 一覧を再読込）。
 
+### Permission gate
+
+`common/pi/.pi/agent/extensions/permission-gate.ts`はdangerous shell commandを実行前に確認する。agentによるworktree capacity追加は確認対象ではなくhard denyし、`git worktree add`と`pnpm wt provision`は実行しない。既存pooled slotのclaim/listは許可する。capacity追加が必要な場合は利用者がpi外のterminalから実行する。
+
 ### 拡張機能
 
 pi packages 経由で extensions / skills を追加:


### PR DESCRIPTION
Closes #302

## 背景

project-local guardrail追加前のstale worktreeでは、agentが`git worktree add`や`pnpm wt provision`を実行でき、既存poolだけを再利用する運用制約を回避できました。

## 変更内容

- global `permission-gate.ts`へworktree capacity追加専用のhard denyを追加しました。
- `git -C`、command separator、`pnpm -C` / `--dir` / `--filter`、`corepack pnpm`の一般的な形を検出します。
- hard denyは確認ダイアログを出さず、既存のdangerous command確認や`pnpm wt claim/list`は変更しません。
- global AGENTS.mdとPi overviewへ、agentは既存pooled slotだけを再利用しcapacity追加は利用者がterminalで行う境界を記載しました。

## 検証

- Node assert matrix: block 6 variants / allow 5 variantsが成功。
- Extension handler test: hard deny時に`ctx.ui.confirm`を呼ばずblockし、既存`sudo`はconfirmへ進むことを確認。
- `pi -e .../permission-gate.ts --list-models`: extension load成功。
- `scripts/check-markdown-links.py`: 109 Markdown files、success。
- `scripts/check-package-duplication.sh`: 既存apt分類warning、apt/pixi同期はsuccess。
- `git diff --check`: success。
