### PR TITLE
fix(pi): git 配下の rm -rf / force push を permission-gate に一元化

### DIFF
--- a/common/pi/.pi/agent/pi-permissions.jsonc
+++ b/common/pi/.pi/agent/pi-permissions.jsonc
@@ -44,7 +44,7 @@
     // デストラクティブなコマンドは確認
     "rm *": "ask",
     "rmdir *": "ask",
-    "rm -rf *": "ask",
+    // rm -rf は permission-gate.ts が git 判定付きで一元管理（git 配下は免除、非 git は confirm）
     "rm -r *": "ask",
     "mv *": "ask",
     "cp *": "ask",
@@ -63,7 +63,7 @@
     "pnpm add *": "ask",
     "pip install *": "ask",
     "pip uninstall *": "ask",
-    "git push *": "ask",
+    // git push は permission-gate.ts が force push を git 判定付きで管理（plain push は allow に委譲）
     "git commit *": "allow",
     "git add *": "allow",
     "git checkout *": "ask",


### PR DESCRIPTION
## Summary

pi の権限機構が二重ゲート（`pi-permission-system` の `pi-permissions.jsonc` と自作 `permission-gate.ts`）になっており、git 配下を免除するロジックが `permission-gate.ts` 側にしか無かった。実際に `rm -rf` / `git push` を ask にしているのは jsonc 側で、こちらは git 判定を持たないため、git 配下でも確認プロンプトが出続けていた。

両者は独立した `tool_call` ハンドラで、jsonc の `ask` は必ずプロンプトを出すため、拡張側の免除では打ち消せない（permission-gate は確認を追加できても除去できない）。

## Changes

- `pi-permissions.jsonc` から `"rm -rf *": "ask"` を削除（git 判定を持つ `permission-gate.ts` に一元化）
- `pi-permissions.jsonc` から `"git push *": "ask"` を削除（force push は permission-gate、plain push は allow に委譲）
- `rm -r` / `rm` / `rmdir` は permission-gate の対象外のため jsonc に残置

### 変更後の挙動

| コマンド | git 配下 | 非 git |
|---|---|---|
| `rm -rf` | 無確認 | permission-gate が confirm |
| force push (`--force-with-lease`) | 無確認 | permission-gate が confirm |
| plain `git push` | 無確認 | 無確認 |
| `rm -r` / `rm` / `rmdir` | ask | ask |

## Test plan

- [ ] pi を再起動し設定を再読込
- [ ] git 配下で `rm -rf <repo内ファイル>` が無確認で通ること
- [ ] git 配下で `git push --force-with-lease` が無確認で通ること
- [ ] 非 git ディレクトリで `rm -rf` が permission-gate の confirm を出すこと
- [ ] `rm -r foo` が従来通り ask になること