### PR TITLE
fix(pi): keep implementation in session working tree

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -18,7 +18,8 @@
 - secret、credential、`.env`、private key、production dumpを読まない。
 - 生成物とruntime fileを直接編集しない。
 - root causeを確認し、既存実装・stdlib・native機能を優先する。
-- agentは既存pooled worktreeだけを再利用し、`git worktree add`や`pnpm wt provision`でworktree capacityを追加しない。追加が必要なら利用者がterminalから実行する。
+- agentはセッション開始時のworking tree（main repositoryまたは既存worktree）で実装し、利用者の明示なしに別worktreeへ移動しない。
+- agentは`git worktree add`や`pnpm wt provision`でworktree capacityを追加しない。追加が必要なら利用者がterminalから実行する。
 
 ## Memory
 

--- a/common/pi/.pi/agent/extensions/permission-gate.ts
+++ b/common/pi/.pi/agent/extensions/permission-gate.ts
@@ -18,7 +18,7 @@ const HARD_DENY_PATTERNS = [
   {
     pattern:
       /(?:^|[;&|]\s*)(?:sudo\s+)?(?:\S*\/)?git\b(?:(?:\s+-C\s+(?:"[^"]*"|'[^']*'|[^\s;&|]+))*)\s+worktree\s+add\b/i,
-    reason: "Agents may only reuse existing pooled worktrees; run git worktree add manually if required",
+    reason: "Agents may not create worktrees; use the session working tree or an explicitly selected existing worktree",
   },
   {
     pattern:

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -147,7 +147,7 @@ dotfiles の拡張により Web Research Layer が利用可能。SearXNG + Jina 
 
 ### Permission gate
 
-`common/pi/.pi/agent/extensions/permission-gate.ts`はdangerous shell commandを実行前に確認する。agentによるworktree capacity追加は確認対象ではなくhard denyし、`git worktree add`と`pnpm wt provision`は実行しない。既存pooled slotのclaim/listは許可する。capacity追加が必要な場合は利用者がpi外のterminalから実行する。
+`common/pi/.pi/agent/extensions/permission-gate.ts`はdangerous shell commandを実行前に確認する。agentはセッション開始時のmain repositoryまたは既存worktreeで実装し、利用者の明示なしに別worktreeへ移動しない。worktree capacity追加は確認対象ではなくhard denyし、`git worktree add`と`pnpm wt provision`は実行しない。利用者が明示した既存pooled slotのclaim/listは許可する。capacity追加が必要な場合は利用者がpi外のterminalから実行する。
 
 ### 拡張機能
 


### PR DESCRIPTION
Closes #305

## 背景

global AGENTS.mdの「既存pooled worktreeだけを再利用する」という記述により、main repositoryで開始したセッションがslot不足を理由に実装を停止していました。また、指定slotで開始したセッションが別slotへ移動する余地があり、利用者が開いている環境と変更先が一致しませんでした。

## 変更内容

- agentの実装場所をセッション開始時のmain repositoryまたは既存worktreeに固定しました。
- 利用者の明示なしに別worktreeへ移動しない規則を追加しました。
- `git worktree add`と`pnpm wt provision`のhard denyは維持し、拒否理由からpooled worktree限定という誤解を除きました。
- Pi overviewを同じ境界へ更新しました。

## 検証

- `scripts/check-markdown-links.py`: 109 Markdown files、success。
- `scripts/check-package-duplication.sh`: 既存apt分類warning、apt/pixi同期はsuccess。
- `pi -e common/pi/.pi/agent/extensions/permission-gate.ts --list-models`: extension load成功。
- `git diff --check`: success。
