### PR TITLE
imprv(tmux): centralize custom keybindings with -N descriptions and lint

### DIFF
--- a/common/tmux/.config/tmux/custom-keys.conf
+++ b/common/tmux/.config/tmux/custom-keys.conf
@@ -1,0 +1,166 @@
+# ============================================================================
+# Custom Keybindings — canonical source for all user-defined tmux key bindings.
+#
+# Every bind uses `bind-key -N "description"` so `list-keys -N` (prefix+?)
+# shows the human-readable purpose alongside the raw command.
+#
+# Duplicate keys are catchable by: scripts/tmux-lint-keys.sh
+# ============================================================================
+
+# --- Prefix Key ---
+unbind C-b
+bind-key -N "Send prefix" C-Space send-prefix
+
+# ============================================================================
+# Copy Mode (vi-style)
+# ============================================================================
+
+# Enter copy mode
+unbind -n C-u
+bind-key -N "Copy mode + halfpage up" u copy-mode \; send-keys -X halfpage-up
+bind-key -N "Copy mode + halfpage up (C-u)" C-u copy-mode \; send-keys -X halfpage-up
+bind-key -N "Copy mode" v copy-mode
+
+# Copy mode keybindings
+bind-key -N "Begin selection" -T copy-mode-vi v send -X begin-selection
+bind-key -N "Rectangle selection" -T copy-mode-vi C-v send -X rectangle-toggle
+bind-key -N "Copy selection" -T copy-mode-vi y send -X copy-pipe "~/dotfiles/scripts/clipboard-copy"
+bind-key -N "Cancel" -T copy-mode-vi Enter send-keys -X cancel
+bind-key -N "Clear selection / exit" -T copy-mode-vi Escape if-shell -F '#{selection_present}' 'send-keys -X clear-selection' 'send-keys -X cancel'
+bind-key -N "Scroll up ×4" -T copy-mode-vi C-u send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up
+bind-key -N "Scroll down ×4" -T copy-mode-vi C-d send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down
+bind-key -N "Halfpage up" -T copy-mode-vi u send-keys -X halfpage-up
+bind-key -N "Halfpage down" -T copy-mode-vi d send-keys -X halfpage-down
+bind-key -N "Copy mouse selection" -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe "~/dotfiles/scripts/clipboard-copy"
+
+# ============================================================================
+# Pane Management
+# ============================================================================
+
+# Split
+unbind '"'
+unbind '%'
+bind-key -N "Split right" \| split-window -h -c "#{pane_current_path}"
+bind-key -N "Split down" - split-window -v -c "#{pane_current_path}"
+
+# Resize
+bind-key -N "Resize ←" -r H resize-pane -L 2
+bind-key -N "Resize ↓" -r J resize-pane -D 2
+bind-key -N "Resize ↑" -r K resize-pane -U 2
+bind-key -N "Resize →" -r L resize-pane -R 2
+
+# Zoom
+bind-key -N "Zoom" z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh normal"
+bind-key -N "Sticky zoom" Z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh sticky"
+bind-key -N "Zoom (no prefix)" -n C-z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh normal"
+
+# Swap
+bind-key -N "Swap pane (by number)" W command-prompt -p "Swap pane:","with pane:" "swap-pane -s '%%.%1' -t '%%.%2'"
+bind-key -N "Swap pane (fzf)" m display-popup -E -w 80% -h 40% "~/dotfiles/scripts/tmux-swap-picker"
+bind-key -N "Mark/unmark pane" M select-pane -m
+
+# Kill
+unbind "&"
+bind-key -N "Kill window" X confirm-before -p "kill-window #W? (y/n)" kill-window
+
+# Pane title
+bind-key -N "Set pane title" t command-prompt -p "Pane title:" "select-pane -T '%%'"
+
+# ============================================================================
+# Window Management
+# ============================================================================
+
+# New window (inherit cwd)
+bind-key -N "New window" c new-window -c "#{pane_current_path}"
+
+# Navigate
+bind-key -N "Prev window" -r p select-window -t :-
+bind-key -N "Next window" -r n select-window -t :+
+bind-key -N "Prev client" -r ( switch-client -p
+bind-key -N "Next client" -r ) switch-client -n
+bind-key -N "Last window" Tab switch-client -l
+
+# Title
+bind-key -N "Rename window" T command-prompt -p "Window name:" "rename-window '%%'"
+
+# ============================================================================
+# Config & Help
+# ============================================================================
+
+bind-key -N "Reload config" r set -g @reload_mode 1 \; \
+       refresh-client -S \; \
+       source-file ~/.config/tmux/tmux.conf \; \
+       set -gu @reload_mode \; \
+       refresh-client -S
+bind-key -N "Keybindings help" ? display-popup -E -w 50% -h 60% "~/dotfiles/scripts/tmux-list-keys.sh all | less -R"
+
+# ============================================================================
+# Session Navigation
+# ============================================================================
+
+# Session picker (group-aware, falls back to flat choose-tree)
+bind-key -N "Session picker" s run-shell -b "~/dotfiles/scripts/tmux-session-group.sh picker '#{client_name}' '#{pane_id}'"
+
+# Session group config (fzf popup)
+bind-key -N "Session group" C-g run-shell -b "~/dotfiles/scripts/tmux-session-group.sh menu-popup '#{client_name}' '#{client_session}'"
+
+# Session group: prev/next within group
+bind-key -N "Prev session" -n M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{client_name}' '#{client_session}'"
+bind-key -N "Next session" -n M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
+bind-key -N "Next group" -n M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
+bind-key -N "Prev group" -n M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
+
+# C-M-hjkl: Alt-hjkl alternatives for macOS (aerospace grabs Alt alone)
+bind-key -N "Prev session (C-M)" -n C-M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{client_name}' '#{client_session}'"
+bind-key -N "Next session (C-M)" -n C-M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
+bind-key -N "Next group (C-M)" -n C-M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
+bind-key -N "Prev group (C-M)" -n C-M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
+
+bind-key -N "Project root session" 9 run-shell "sesh connect --root '#{pane_current_path}'"
+bind-key -N "Sesh picker" C-f run-shell -b "~/dotfiles/scripts/tmux-sesh-picker.sh"
+
+# ============================================================================
+# AI Agent
+# ============================================================================
+
+bind-key -N "Agent status" a run-shell "tmux set-option -g @agent_cur_pane '#{pane_id}'" \; display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
+bind-key -N "Reload agent watchers" R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
+bind-key -N "Agent sidebar" A run-shell "TMUX_PANE=#{pane_id} ~/dotfiles/scripts/tmux-agent-sidebar.sh toggle"
+
+# ============================================================================
+# Tools & Popups
+# ============================================================================
+
+# Sync mode
+bind-key -N "Sync mode" S run-shell "~/dotfiles/scripts/tmux-sync-toggle.sh"
+
+# Theme picker
+bind-key -N "Theme" y display-menu -T "Theme" -x C -y C \
+    "tokyonight"  t "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh tokyonight'" \
+    "catppuccin"  c "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh catppuccin'" \
+    "gruvbox"     g "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh gruvbox'" \
+    "rosepine"    r "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh rosepine'" \
+    "myproject"    s "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh myproject'"
+
+# Paste buffer as keystrokes (bypasses bracketed paste)
+bind-key -N "Paste buffer (raw)" V run-shell 'tmux send-keys -l -- "$(tmux show-buffer)"'
+
+# Thumbs (Vimium-style hint selection)
+bind-key -N "Thumbs" e run-shell "~/dotfiles/scripts/tmux-thumbs-wrapper.sh"
+
+# ============================================================================
+# Nested Session Toggle (F12)
+# ============================================================================
+
+# F12: nested mode — pass keys through to inner tmux
+bind-key -N "Enter nested mode" -T root F12 run-shell "~/dotfiles/scripts/tmux-nested-toggle.sh on"
+bind-key -N "Exit nested mode" -T off F12 run-shell "~/dotfiles/scripts/tmux-nested-toggle.sh off"
+
+# ============================================================================
+# Plugin Overrides (after TPM, keep at bottom)
+# ============================================================================
+
+# Override default C-l (clear screen → window next)
+unbind C-l
+bind-key -N "Prev window (C-h)" -r C-h select-window -t :-
+bind-key -N "Next window (C-l)" -r C-l select-window -t :+

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -1,7 +1,8 @@
 # --- Prefix Key ---
 set -g prefix C-Space
-unbind C-b
-bind C-Space send-prefix
+
+# Custom keybindings (centralized: descriptions feed prefix+? popup)
+source-file ~/.config/tmux/custom-keys.conf
 
 # --- General ---
 # default-command: do NOT bake $SHELL at config-load time. rcon's ssh-t
@@ -45,30 +46,7 @@ set -g set-titles-string "#{b:pane_current_path}"
 
 # --- Copy Mode (vi-style) ---
 setw -g mode-keys vi
-
-# prefix+u / prefix+C-u でcopy-modeに入りスクロールアップ
-unbind -n C-u
-bind u copy-mode \; send-keys -X halfpage-up
-bind C-u copy-mode \; send-keys -X halfpage-up
-
-# prefix+v でcopy-modeに入る
-bind v copy-mode
-
-bind-key -T copy-mode-vi 'v' send -X begin-selection
-bind-key -T copy-mode-vi 'C-v' send -X rectangle-toggle
-# y: pipe to OS-aware clipboard wrapper (popup OSC52 を回避するため pbcopy/lemonade/wl-copy/xclip 直接呼出)
-bind-key -T copy-mode-vi 'y' send -X copy-pipe "~/dotfiles/scripts/clipboard-copy"
-bind-key -T copy-mode-vi Enter send-keys -X cancel
-# Escape: 選択中は解除のみ、非選択時は copy-mode を抜ける
-bind-key -T copy-mode-vi Escape if-shell -F '#{selection_present}' 'send-keys -X clear-selection' 'send-keys -X cancel'
-# スクロール量を4行に変更（デフォルトは半ページ）
-bind-key -T copy-mode-vi C-u send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up \; send-keys -X scroll-up
-bind-key -T copy-mode-vi C-d send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down \; send-keys -X scroll-down
-# u/d で半ページスクロール（倍速移動）
-bind-key -T copy-mode-vi u send-keys -X halfpage-up
-bind-key -T copy-mode-vi d send-keys -X halfpage-down
-# Mouse drag: auto-copy to clipboard, keep copy-mode & scroll position (q/Enter で抜ける)
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe "~/dotfiles/scripts/clipboard-copy"
+# (copy-mode keybindings are in custom-keys.conf)
 set -g base-index 1
 setw -g pane-base-index 1
 set -s escape-time 0
@@ -95,152 +73,23 @@ set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
 
 # --- Keybindings (Vim-like) ---
-# Pane split
-bind | split-window -h -c "#{pane_current_path}"
-bind - split-window -v -c "#{pane_current_path}"
-unbind '"'
-unbind %
-
-# New window inherits current pane's cwd (consistency with split-window)
-bind c new-window -c "#{pane_current_path}"
-
 # Pane navigation: vim-tmux-navigator (C-h/j/k/l) を使用
-
-# Pane resize
-bind -r H resize-pane -L 2
-bind -r J resize-pane -D 2
-bind -r K resize-pane -U 2
-bind -r L resize-pane -R 2
-
-# Zoom toggle
-#   z: normal zoom — tmux auto-unzooms on pane switch and does not restore on return
-#   Z: pane-sticky zoom — after-select-pane hook re-zooms when returning to the pane
-#   Pressing either again while sticky unzooms and clears the sticky flag
-bind z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh normal"
-bind Z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh sticky"
-bind -n C-z run-shell "~/dotfiles/scripts/tmux-zoom-toggle.sh normal"
-
-# Reload config (shows RELOAD mode during reload)
-bind r set -g @reload_mode 1 \; \
-       refresh-client -S \; \
-       source-file ~/.config/tmux/tmux.conf \; \
-       set -gu @reload_mode \; \
-       refresh-client -S
-
-# Window kill (X = bigger than x for pane)
-unbind &
-bind X confirm-before -p "kill-window #W? (y/n)" kill-window
-
-# Pane swap (by display number shown with prefix+q)
-bind W command-prompt -p "Swap pane:","with pane:" "swap-pane -s '%%.%1' -t '%%.%2'"
-
-# Visual pane swap: pick two panes via fzf popup; slot sizes preserved,
-# only contents swap. Uses fzf rather than display-panes so small panes
-# (below tmux's big-digit render threshold) remain selectable.
-# Overrides default prefix+m (select-pane -m).
-bind m display-popup -E -w 80% -h 40% "~/dotfiles/scripts/tmux-swap-picker"
-# Mark / unmark current pane (toggle). Replaces default mark role freed by
-# prefix+m above; keeps `{marked}` referenceable for cross-window swap-pane etc.
-bind M select-pane -m
-
-# Pane title
-bind t command-prompt -p "Pane title:" "select-pane -T '%%'"
-
-# Window title
-bind T command-prompt -p "Window name:" "rename-window '%%'"
+# (all custom keybindings are in custom-keys.conf)
 
 # Window navigation
 set -g repeat-time 1000  # リピート可能時間を1秒に
-bind -r p select-window -t :-
-bind -r n select-window -t :+
 
-# Session navigation
+# Session navigation (see custom-keys.conf for keybindings)
 # Session groups: 各 session の @group user option でグループ化 (名前規約に非依存)。
 # state file 永続化・再適用は tmux-session-group.sh が担当。
-#   prefix+s   : 二段 picker (グループ一覧 menu → グループ内 choose-tree)。
-#                グループ未使用なら従来のフラットな choose-tree にフォールバック。
-#   prefix+C-g : 現 session のグループ設定/解除 (fzf popup。prefix+G は gh-dash が使用済み)
-#   M-h / M-l  : 同グループ内の前/次 session へ (名前順・循環)
-#   M-j / M-k  : 次/前のグループで最後に見ていた session へ (ungrouped は末尾の 1 バケツ扱い)
 # run-shell は -b 必須: display-menu は menu が閉じるまで CLI を返さないため、
 # フォアグラウンド run-shell だと client のコマンドキューを保持してしまう。
 # nav 系も -b でキュー保持を避ける (cb98ccd の fork レイテンシ対策と同方針)。
 # '#{client_name}' 等の引数渡しも必須: run-shell -b の子プロセスは key を押した
 # client/pane の文脈を持たない (tmux が任意の session/pane へ解決し誤動作する) ため、
 # bind 時の format 展開で明示的に渡す。
-bind s run-shell -b "~/dotfiles/scripts/tmux-session-group.sh picker '#{client_name}' '#{pane_id}'"
-bind C-g run-shell -b "~/dotfiles/scripts/tmux-session-group.sh menu-popup '#{client_name}' '#{client_session}'"
-bind -n M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{client_name}' '#{client_session}'"
-bind -n M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
-bind -n M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
-bind -n M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
-# C-M-hjkl は M-hjkl の別名。ローカル macOS では aerospace が alt-hjkl / alt-shift-hjkl を
-# グローバルに掴んでいて terminal まで届かないため、Ctrl 併用で回避する。
-# aerospace のいない環境 (リモート Linux 等) では M-hjkl がそのまま使える。
-bind -n C-M-h run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev '#{client_name}' '#{client_session}'"
-bind -n C-M-l run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next '#{client_name}' '#{client_session}'"
-bind -n C-M-j run-shell -b "~/dotfiles/scripts/tmux-session-group.sh next-group '#{client_name}' '#{client_session}'"
-bind -n C-M-k run-shell -b "~/dotfiles/scripts/tmux-session-group.sh prev-group '#{client_name}' '#{client_session}'"
-bind Tab switch-client -l
 
-# AI Agent 横断ビュー: capture-pane previewのみ。実paneをswapするreflect版は、複数clientで
-# agent paneを誤ってkillし得るため使わない。
-bind a run-shell "tmux set-option -g @agent_cur_pane '#{pane_id}'" \; display-popup -E -w 70% -h 60% "~/dotfiles/scripts/tmux-agent-status.sh popup"
-# AI Agent 通知リロード: watcher 再起動 + 即時スキャン(残留/シェル復帰の GC・ハング検出)
-# (prefix+r=tmux 設定リロード と対。prefix+A は tmux-layout menu が使用のため R)
-bind R run-shell "~/dotfiles/scripts/tmux-agent-status.sh reload"
-# AI Agent サイドバー: 全エージェントを常時表示する pane を開閉
-bind b run-shell "TMUX_PANE=#{pane_id} ~/dotfiles/scripts/tmux-agent-sidebar.sh toggle"
-bind -r ( switch-client -p
-bind -r ) switch-client -n
 
-# sesh last: 直前のセッションに戻る。switch-client -l と比べて sesh 側の履歴を
-# 参照するので fzf picker 経由で切り替えた履歴も拾える。セッション 1 つだけの
-# ときは黙らずメッセージを出す (コミュニティ標準のフォールバック)。
-bind L run-shell "sesh last || tmux display-message -d 1000 'Only one session'"
-
-# sesh root: 現在の session の "root" に相当する session にジャンプ。
-# worktree (`<main>--wt--<slug>`) 等のネストから親プロジェクトへ一撃で戻るとき便利。
-# #{pane_current_path} は tmux 側で invocation time に展開されるため、shell expansion ではなく
-# tmux format substitution を使う必要がある (shell expansion だと config load 時点で固定される)。
-bind 9 run-shell "sesh connect --root '#{pane_current_path}'"
-
-# sesh: fuzzy session picker (config + tmux + zoxide 横断) の多段フィルタ版。
-# 公式 README の配布レシピを採用。popup 内で Ctrl キーで ソース切替:
-#   ^a all / ^t tmux / ^g configs / ^x zoxide / ^f find (fd) / ^d kill session
-# prefix+f はローカル tmux session のみの色付き picker (軽量)、
-# prefix+C-f はプロジェクトディレクトリ横断で新規セッション作成含むスーパーセット。
-# 重要: display-popup でラップしない。内側の fzf-tmux -p が自前で popup を開くため、
-# 二重 popup になって入力が届かなくなる (旧実装のバグ)。run-shell に任せる。
-bind C-f run-shell "sesh connect \"\$(
-  sesh list --icons | fzf-tmux -p 80%,70% --no-sort --ansi \
-    --border-label ' sesh ' --prompt '⚡  ' \
-    --header '  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find' \
-    --bind 'tab:down,btab:up' \
-    --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)' \
-    --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)' \
-    --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)' \
-    --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)' \
-    --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
-    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)' \
-    --preview-window 'right:55%' \
-    --preview 'sesh preview {}'
-)\""
-
-# Sync mode toggle (with style change, reads @theme-* at runtime)
-bind S run-shell '\
-  off=$(tmux show-option -gqv @theme-border-inactive); \
-  on=$(tmux show-option -gqv @theme-border-success); \
-  off=${off:-"#3b4261"}; on=${on:-"#73daca"}; \
-  if [ "$(tmux show-window-options -v synchronize-panes)" = "on" ]; then \
-    tmux setw synchronize-panes off; \
-    tmux set -g window-style "fg=colour244,bg=default"; \
-    tmux set -g pane-border-style "fg=${off},bg=default"; \
-  else \
-    tmux setw synchronize-panes on; \
-    tmux set -g window-style "fg=colour255,bg=default"; \
-    tmux set -g pane-border-style "fg=${on},bg=default"; \
-  fi'
 
 # --- Popup Manager ---
 # Project / git / DB tools: route through tmux-popup-in-container so they run
@@ -251,39 +100,12 @@ set -g @popup-keifu     "k|80|80|~/dotfiles/scripts/tmux-popup-in-container zsh 
 set -g @popup-pgcli     "P|80|80|~/dotfiles/scripts/tmux-popup-in-container pgcli \${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres}"
 set -g @popup-quay      "Q|80|80|~/dotfiles/scripts/tmux-popup-in-container quay"
 set -g @popup-gh-dash   "G|85|85|~/dotfiles/scripts/tmux-popup-in-container gh dash|gh-dash"
-set -g @popup-scratch   "l|80|80|SCRATCH|Scratchpad"
+set -g @popup-scratch   "j|80|80|SCRATCH|Scratchpad"
 set -g @popup-sessions  "f|60|60|~/dotfiles/scripts/tmux-session-color.sh fzf-sessions"
 set -g @popup-projects  "F|60|60|~/dotfiles/scripts/tmux-popup-ghq.sh"
-set -g @popup-layout    "A|60|40|~/dotfiles/scripts/tmux-layout menu"
+set -g @popup-layout    "l|60|40|~/dotfiles/scripts/tmux-layout menu"
 set -g @popup-smug      "N|60|50|~/dotfiles/scripts/tmux-smug-menu.sh|smug"
 set -g @popup-manager-which-key-var "@wk_menu_popup"
-
-# --- Nested Session Toggle (F12) ---
-# F12で外側tmuxのキーバインドをOFFにし、内側tmuxにパススルー
-# OFFの間: prefix無効、ステータスバーがグレーアウト、[OFF]表示
-bind -T root F12 run-shell '\
-    fg=$(tmux show-option -gqv @theme-fg-subtle); \
-    bg=$(tmux show-option -gqv @theme-bg-dark); \
-    fg=${fg:-"#545c7e"}; bg=${bg:-"#1a1b26"}; \
-    tmux set prefix None \; \
-         set key-table off \; \
-         set status-style "fg=${fg},bg=${bg}" \; \
-         set window-status-current-format "#[fg=${fg},bg=${bg}] #I #W " \; \
-         set window-status-current-style "fg=${fg},bg=${bg}"; \
-    if [ "$(tmux display -p "#{pane_in_mode}")" = "1" ]; then \
-         tmux send-keys -X cancel; fi; \
-    tmux refresh-client -S'
-
-bind -T off F12 \
-    set -u prefix \;\
-    set -u key-table \;\
-    set -u status-style \;\
-    set -u window-status-current-format \;\
-    set -u window-status-current-style \;\
-    refresh-client -S
-
-# --- Status Bar ---
-set -g status-position top
 
 # Theme: tokyonight | myproject
 # Last selection is persisted in $XDG_STATE_HOME/tmux/current-theme by
@@ -292,13 +114,7 @@ run-shell 'state="${XDG_STATE_HOME:-$HOME/.local/state}/tmux/current-theme"; \
   theme=$( [ -f "$state" ] && cat "$state" || echo tokyonight ); \
   tmux source-file "$HOME/.config/tmux/${theme}.tmux"'
 
-# Theme picker: prefix + y opens a menu to select the tmux theme.
-bind y display-menu -T "Theme" -x C -y C \
-    "tokyonight"  t "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh tokyonight'" \
-    "catppuccin"  c "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh catppuccin'" \
-    "gruvbox"     g "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh gruvbox'" \
-    "rosepine"    r "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh rosepine'" \
-    "myproject"    s "run-shell '~/dotfiles/scripts/tmux-theme-toggle.sh myproject'"
+# (theme picker is in custom-keys.conf)
 
 # Claude Code 通知統合
 source-file ~/.config/tmux/claude-hooks.tmux
@@ -378,26 +194,7 @@ if "test -f ~/.config/tmux/plugins/tmux-which-key/config.yaml && test -d ~/.tmux
    "run 'ln -sf ~/.config/tmux/plugins/tmux-which-key/config.yaml ~/.tmux/plugins/tmux-which-key/config.yaml'"
 
 # Override plugins for prefix+C-h/C-l (window navigation)
-unbind C-l
-bind -r C-h select-window -t :-
-bind -r C-l select-window -t :+
-
-# Note: a previous version pinned C-h/j/k/l to plain select-pane to work
-# around vim-tmux-navigator's TTY detection failing inside docker exec
-# panes. That broke nvim's own split navigation in host-direct sessions.
-# Removed so vim-tmux-navigator's smart binding handles it:
-#   - inside nvim split with neighbour → move within nvim
-#   - at split edge → fall through to tmux select-pane
-
-# prefix + V : paste tmux buffer as literal keystrokes (bypasses bracketed
-# paste markers). For TUIs like `claude auth login` / `claude setup-token`
-# that read input in raw mode and reject pasted bracketed sequences.
-# Usage: copy the auth code (Cmd+C on Mac is mirrored into tmux buffer via
-# set-clipboard=on OSC52), then press prefix+V instead of Cmd+V.
-bind V run-shell 'tmux send-keys -l -- "$(tmux show-buffer)"'
-
-# tmux-thumbs: custom wrapper (overrides TPM binding)
-bind e run-shell "~/dotfiles/scripts/tmux-thumbs-wrapper.sh"
+# (moved to custom-keys.conf)
 
 # tmux-popup-manager: load after TPM (overwrites which-key's empty @wk_menu_popup)
 run-shell "~/.config/tmux/plugins/tmux-popup-manager/popup-manager.tmux"

--- a/scripts/tmux-lint-keys.sh
+++ b/scripts/tmux-lint-keys.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# tmux-lint-keys.sh — detect duplicate key bindings in custom-keys.conf
+#
+# Usage:
+#   scripts/tmux-lint-keys.sh              # check dotfiles source
+#   scripts/tmux-lint-keys.sh <file>       # check a specific file
+
+set -e
+
+DOTFILES="${DOTFILES:-$HOME/dotfiles}"
+CONF="${1:-$DOTFILES/common/tmux/.config/tmux/custom-keys.conf}"
+
+if [ ! -f "$CONF" ]; then
+  echo "File not found: $CONF" >&2
+  exit 1
+fi
+
+# Extract (table, key) pairs from bind/bind-key lines (skip unbinds).
+# Strategy: strip comments and quoted -N descriptions first, then parse.
+sed -E \
+  -e 's/#.*//' \
+  -e 's/-N "[^"]*"//g' \
+  -e "s/-N '[^']*'//g" \
+  "$CONF" | awk '
+/^(bind-key|bind)[[:space:]]/ {
+  table = "prefix"
+  for (i = 2; i <= NF; i++) {
+    if ($i == "-n")         { table = "root"; continue }
+    if ($i == "-r")         { continue }
+    if ($i == "-T" && (i+1) <= NF) { table = $(i+1); i++; continue }
+    if ($i ~ /^-/)          { continue }  # skip unknown flags
+    key = $(i)
+    break
+  }
+  if (key != "") printf "%s:%s\n", table, key
+}' | sort | uniq -d > /tmp/tmux-dup-keys.txt
+
+if [ -s /tmp/tmux-dup-keys.txt ]; then
+  echo "=== DUPLICATE KEYS ==="
+  cat /tmp/tmux-dup-keys.txt
+  echo ""
+  echo "FAIL: $(wc -l < /tmp/tmux-dup-keys.txt | tr -d ' ') duplicate(s)."
+  exit 1
+else
+  count=$(sed -E -e 's/#.*//' -e 's/-N "[^"]*"//g' -e "s/-N '[^']*'//g" "$CONF" | grep -cE '^(bind-key|bind|unbind)[[:space:]]')
+  echo "OK: $count bindings, no duplicates."
+fi

--- a/scripts/tmux-list-keys.sh
+++ b/scripts/tmux-list-keys.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# pretty-print tmux keybindings with ANSI colors
+# Usage: tmux-list-keys.sh [all]
+#   no args: prefix table only
+#   "all": all key tables (includes root, copy-mode, etc.)
+
+if [ "$1" = "all" ]; then
+  tmux list-keys -aN
+else
+  tmux list-keys -N
+fi | awk '
+/^[[:space:]]/ {
+  # root table (no table name column)
+  k=$1; $1=""
+  sub(/^[[:space:]]+/, "")
+  printf "\033[36m%-10s\033[0m \033[33m%-20s\033[0m %s\n", "root", k, $0
+  next
+}
+{
+  t=$1; k=$2; $1=""; $2=""
+  sub(/^[[:space:]][[:space:]]*/, "")
+  printf "\033[36m%-10s\033[0m \033[33m%-20s\033[0m %s\n", t, k, $0
+}'

--- a/scripts/tmux-nested-toggle.sh
+++ b/scripts/tmux-nested-toggle.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Toggle nested tmux mode (F12)
+# ON:  disable outer tmux bindings, pass keys through to inner tmux
+# OFF: restore outer tmux bindings
+
+case "${1:-toggle}" in
+on)
+  fg=$(tmux show-option -gqv @theme-fg-subtle)
+  bg=$(tmux show-option -gqv @theme-bg-dark)
+  fg=${fg:-"#545c7e"}
+  bg=${bg:-"#1a1b26"}
+  tmux set prefix None \; \
+       set key-table off \; \
+       set status-style "fg=${fg},bg=${bg}" \; \
+       set window-status-current-format "#[fg=${fg},bg=${bg}] #I #W " \; \
+       set window-status-current-style "fg=${fg},bg=${bg}"
+  if [ "$(tmux display -p "#{pane_in_mode}")" = "1" ]; then
+    tmux send-keys -X cancel
+  fi
+  tmux refresh-client -S
+  ;;
+off)
+  tmux set -u prefix \; \
+       set -u key-table \; \
+       set -u status-style \; \
+       set -u window-status-current-format \; \
+       set -u window-status-current-style \; \
+       refresh-client -S
+  ;;
+*)
+  echo "Usage: $0 {on|off}" >&2
+  exit 1
+  ;;
+esac

--- a/scripts/tmux-sesh-picker.sh
+++ b/scripts/tmux-sesh-picker.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# sesh fuzzy session picker (prefix + C-f)
+# Multi-source picker: tmux + configs + zoxide + find
+sesh connect "$(
+  sesh list --icons | fzf-tmux -p 80%,70% --no-sort --ansi \
+    --border-label ' sesh ' --prompt '⚡  ' \
+    --header '  ^a all ^t tmux ^g configs ^x zoxide ^d kill ^f find' \
+    --bind 'tab:down,btab:up' \
+    --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list --icons)' \
+    --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)' \
+    --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)' \
+    --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)' \
+    --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)' \
+    --preview-window 'right:55%' \
+    --preview 'sesh preview {}'
+)"


### PR DESCRIPTION
## Summary

カスタムキーバインドを1ファイル `custom-keys.conf` に集約し、すべてに `-N` 説明を付与。
`prefix+?` でポップアップ表示されるようになり、リントスクリプトで重複キーも検出可能に。

## Changes

- **`custom-keys.conf`** (new): 全66件のカスタムバインドを `bind-key -N "説明"` で一元管理
- **`tmux.conf`**: バインド行を全削除し `source-file custom-keys.conf` に置換。popup-manager のキー再配置 (scratch: l→j, layout: A→l)
- **`scripts/tmux-list-keys.sh`** (new): `prefix+?` で `list-keys -aN` を色付きポップアップ表示
- **`scripts/tmux-lint-keys.sh`** (new): 重複キーバインド検出
- **`scripts/tmux-nested-toggle.sh`** (new): F12 nested mode のインラインスクリプトを分離
- **`scripts/tmux-sesh-picker.sh`** (new): `prefix+C-f` sesh picker のインラインスクリプトを分離
- `prefix+S` sync toggle を既存 `tmux-sync-toggle.sh` に差し替え
- キー再割り当て: `prefix+A`→agent sidebar, `prefix+j`→scratch, `prefix+l`→layout

## Test plan

- [ ] `prefix+r` でリロード後、全キーバインドが正常に動作する
- [ ] `prefix+?` でポップアップが開き、説明付きで全キーが表示される
- [ ] `scripts/tmux-lint-keys.sh` が no duplicates を返す