### PR TITLE
imprv(pi): statuslineの情報階層と可読性を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ linux/zsh/.zshrc.local
 # Pi extension runtime state
 .pi-subagents/
 .pi-loop/
+.pi/loops/
 
 # Python
 __pycache__/

--- a/common/pi/.pi/agent/extensions/prompt-stash.ts
+++ b/common/pi/.pi/agent/extensions/prompt-stash.ts
@@ -1,12 +1,12 @@
 // Prompt Stash Extension for pi
 //
 // Claude Code-like prompt stash: Ctrl+S saves the current editor draft,
-// handles an interruption, then auto-restores when the agent finishes.
+// handles an interruption, then auto-restores when the agent settles.
 //
 // Flow:
 //   1. Ctrl+S  → stash current draft + clear editor
 //   2. Send a different prompt (handle interruption)
-//   3. Agent finishes → draft auto-restores into editor
+//   3. Agent settles → draft auto-restores into editor
 //   4. Continue where you left off
 //
 // Single-slot stash. Ctrl+S on empty editor toggles restore.
@@ -29,7 +29,7 @@ export default function (pi: ExtensionAPI) {
         // Stash the current draft (replace any previous stash)
         stashed = current;
         ctx.ui.setEditorText("");
-        ctx.ui.setStatus("stash", "📝 stashed");
+        ctx.ui.setStatus("stash", ctx.ui.theme.fg("warning", "📝 stashed"));
         ctx.ui.notify("📝 Prompt stashed (send interruption, draft auto-restores)", "info");
       } else if (stashed) {
         // Toggle: restore the stash
@@ -42,14 +42,10 @@ export default function (pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Auto-restore when agent finishes and editor is empty
+  // Auto-restore when agent settles and editor is empty
   // -----------------------------------------------------------------------
-  pi.on("agent_end", async (_event, ctx) => {
+  pi.on("agent_settled", async (_event, ctx) => {
     if (!stashed) return;
-
-    // Give the TUI a moment to settle — editor may not be immediately empty
-    // when agent_end fires if there are queued follow-up messages.
-    await new Promise((r) => setTimeout(r, 50));
 
     const current = ctx.ui.getEditorText();
     if (!current || current.trim().length === 0) {
@@ -94,7 +90,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   // -----------------------------------------------------------------------
-  // Persist stash state across extension reloads
+  // Clear transient stash on session shutdown
   // -----------------------------------------------------------------------
   pi.on("session_shutdown", (_event) => {
     // Stash is cleared on shutdown — it's a transient UI state,

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -1,18 +1,16 @@
 // Statusline Extension for pi
 //
-// Multi-line footer with:
-//   Line 1: token stats + context gauge + cost + branch + model
-//   Line 2: web stats + MCP stats
+// Balanced telemetry footer with:
+//   Focus rail: goal + extension status
+//   Core rail: branch + model | context gauge
+//   Telemetry rail: tokens | cost | agents | web | MCP
 //   3 modes: detailed / compact / off (toggle via /statusline)
-//
-// The gauge is a plain-character progress bar: ████░░░░░░  29%
-// No ANSI codes inside compound strings to avoid truncation issues.
 
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -130,14 +128,43 @@ function refreshAgents(): void {
   agentStatus = { running, queued };
 }
 
-/**
- * Plain-character progress gauge. Safe to use inside theme.fg() because the
- * characters have no ANSI codes. Returns something like "████░░░░  29%".
- */
-function gauge(pct: number, barChars: number): string {
-  const clamped = Math.max(0, Math.min(100, pct));
-  const filled = Math.max(0, Math.min(barChars, Math.round((clamped / 100) * barChars)));
-  return "█".repeat(filled) + "░".repeat(barChars - filled) + ` ${pct.toFixed(0)}%`;
+function balanceLine(left: string, right: string, width: number): string {
+  if (!left) return truncateToWidth(right, width);
+  if (!right) return truncateToWidth(left, width);
+
+  const gap = 3;
+  const rightWidth = visibleWidth(right);
+  if (rightWidth >= width - gap) return truncateToWidth(right, width);
+
+  const fittedLeft = truncateToWidth(left, width - rightWidth - gap);
+  const padding = " ".repeat(Math.max(gap, width - visibleWidth(fittedLeft) - rightWidth));
+  return truncateToWidth(fittedLeft + padding + right, width);
+}
+
+function wrapGroups(groups: string[], width: number, separator = " │ "): string[] {
+  const lines: string[] = [];
+  let line = "";
+
+  for (const group of groups.filter(Boolean)) {
+    const candidate = line ? line + separator + group : group;
+    if (line && visibleWidth(candidate) > width) {
+      lines.push(truncateToWidth(line, width));
+      line = group;
+    } else {
+      line = candidate;
+    }
+  }
+  if (line) lines.push(truncateToWidth(line, width));
+  return lines;
+}
+
+function packCompact(groups: string[], width: number, separator = " · "): string {
+  let line = "";
+  for (const group of groups.filter(Boolean)) {
+    const candidate = line ? line + separator + group : group;
+    if (visibleWidth(candidate) <= width) line = candidate;
+  }
+  return truncateToWidth(line || groups.find(Boolean) || "", width);
 }
 
 // ---------------------------------------------------------------------------
@@ -151,11 +178,12 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand("statusline", {
     description: "Toggle statusline mode: detailed, compact, or off",
     getArgumentCompletions: () => [
-      { value: "detailed", label: "Two-line layout with gauge and all stats" },
+      { value: "detailed", label: "Balanced rich telemetry rails" },
       { value: "compact", label: "Single line, minimal" },
       { value: "off", label: "Disable custom statusline" },
     ],
     handler: async (args, ctx) => {
+      const previousMode = mode;
       if (args === "detailed" || args === "compact" || args === "off") {
         mode = args;
       } else {
@@ -166,6 +194,9 @@ export default function (pi: ExtensionAPI) {
       if (mode === "off") {
         ctx.ui.setFooter(undefined);
         ctx.ui.notify("Statusline: off", "info");
+      } else if (previousMode === "off") {
+        await ctx.reload();
+        return;
       } else {
         ctx.ui.notify(`Statusline: ${mode}`, "info");
       }
@@ -195,6 +226,10 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     recomputeTokens(ctx.sessionManager.getBranch());
     refreshAgents();
+    if (mode === "off") {
+      ctx.ui.setFooter(undefined);
+      return;
+    }
     ctx.ui.setFooter((tui, theme, footerData) => {
       const unsub = footerData.onBranchChange(() => tui.requestRender());
       return {
@@ -208,66 +243,84 @@ export default function (pi: ExtensionAPI) {
 
           // ---- Context ----
           const usage = ctx.getContextUsage();
-          const capacity = ctx.model?.contextWindow ?? 0;
-          const used = usage?.tokens ?? 0;
-          const pct = capacity > 0 ? (used / capacity) * 100 : 0;
+          const rawUsedPct = usage?.percent;
+          const usedPct = rawUsedPct === null || rawUsedPct === undefined
+            ? null
+            : Math.max(0, Math.min(100, rawUsedPct));
+          const gaugeChars = width >= 100 ? 10 : width >= 70 ? 8 : 6;
+          const ctxColor = usedPct === null
+            ? "muted"
+            : usedPct >= 85
+              ? "error"
+              : usedPct >= 70
+                ? "warning"
+                : "success";
+          const filled = usedPct === null ? 0 : Math.round((usedPct / 100) * gaugeChars);
+          const pctText = usedPct === null ? "?" : `${usedPct.toFixed(0)}%`;
+          const gaugeStr = [
+            theme.fg("muted", "CTX"),
+            theme.fg(ctxColor, "█".repeat(filled)) + theme.fg("dim", "░".repeat(gaugeChars - filled)),
+            theme.fg(ctxColor, pctText),
+          ].join(" ");
 
           // ---- Stats ----
           const stats = readStats();
 
-          // ---- Git / Model ----
+          // ---- Visual grammar ----
+          const minor = theme.fg("dim", " · ");
+          const major = theme.fg("dim", " │ ");
+          const label = (text: string) => theme.fg("muted", text);
+
+          // ---- Focus rail ----
+          const goal = readGoal();
+          const goalStr = goal
+            ? `${theme.fg("accent", "▌")} ${label("Goal:")} ${theme.fg("text", goal)}`
+            : "";
+          const extensionStatuses = [...footerData.getExtensionStatuses().values()];
+          const statusStr = extensionStatuses.join(minor);
+
+          // ---- Core rail ----
           const branch = footerData.getGitBranch();
           const branchStr = branch
-            ? `${theme.fg(dirtyState ? "warning" : "accent", branch)}${dirtyState ? theme.fg("warning", "*") : ""}`
+            ? theme.fg(dirtyState ? "warning" : "border", `${branch}${dirtyState ? "*" : ""}`)
             : "";
-          const modelStr = theme.fg("muted", ctx.model?.id || "no-model");
+          const modelStr = theme.fg("customMessageLabel", ctx.model?.id || "no-model");
+          const projectStr = [branchStr, modelStr].filter(Boolean).join(minor);
 
-          // ---- Tokens (left side) ----
+          // ---- Telemetry rail ----
           const tokIn = theme.fg("text", `↑${formatTokens(input)}`);
           const tokOut = theme.fg("accent", `↓${formatTokens(output)}`);
-          const costColor = cost > 1 ? "warning" : cost > 0.1 ? "text" : "dim";
-          const tokCost = theme.fg(costColor, `$${cost.toFixed(3)}`);
-
-          // ---- Gauge ----
-          const ctxColor = pct > 80 ? "error" : pct > 60 ? "warning" : "success";
-          const gaugeStr = capacity > 0
-            ? theme.fg(ctxColor, gauge(pct, 10))
+          const tokenStr = `${label("TOK")} ${tokIn}${minor}${tokOut}`;
+          const costStr = `${label("COST")} ${theme.fg("syntaxNumber", `$${cost.toFixed(3)}`)}`;
+          const agentStr = agentStatus.running > 0 || agentStatus.queued > 0
+            ? `${label("AGT")} ${theme.fg("customMessageLabel", `R${agentStatus.running}`)}${minor}${theme.fg("customMessageLabel", `Q${agentStatus.queued}`)}`
+            : "";
+          const webStr = stats.webSearch > 0 || stats.webFetch > 0
+            ? `${label("WEB")} ${theme.fg("syntaxType", `S${stats.webSearch}`)}${minor}${theme.fg("syntaxType", `F${stats.webFetch}`)}${minor}${theme.fg("syntaxType", `C${stats.webCache}`)}`
+            : "";
+          const mcpError = stats.mcpErrors > 0
+            ? minor + theme.fg("error", `E${stats.mcpErrors}`)
+            : "";
+          const mcpStr = stats.mcpCalls > 0 || stats.mcpErrors > 0
+            ? `${label("MCP")} ${theme.fg("border", `Q${stats.mcpCalls}`)}${mcpError}`
             : "";
 
-          // ---- Layout: 3-line, all left-aligned ----
-          // Line 1: tokens + gauge
-          // Line 2: branch + model
-          // Line 3: cost + web stats + mcp stats
-
           if (mode === "compact") {
-            return [truncateToWidth(`${tokIn} ${tokOut} ${tokCost}  ${modelStr}`, width)];
+            const compactFocus = truncateToWidth(
+              [statusStr, goalStr].filter(Boolean).join(minor),
+              width >= 100 ? 36 : width >= 70 ? 24 : 14,
+            );
+            return [packCompact(
+              [compactFocus, gaugeStr, branchStr, modelStr, tokenStr, costStr],
+              width,
+              minor,
+            )];
           }
 
           const lines: string[] = [];
-
-          // Pinned session note (top, most visible)
-          const goal = readGoal();
-          if (goal) lines.push(truncateToWidth(theme.fg("warning", `🎯 ${goal}`), width));
-
-          const l1 = [tokIn, tokOut, gaugeStr].filter(Boolean).join(" │ ");
-          lines.push(truncateToWidth(l1, width));
-
-          const l2 = [branchStr, modelStr].filter(Boolean).join(" · ");
-          if (l2) lines.push(truncateToWidth(l2, width));
-
-          const l3: string[] = [];
-          l3.push(tokCost);
-          if (agentStatus.running > 0 || agentStatus.queued > 0) {
-            l3.push(theme.fg("accent", `agents r:${agentStatus.running} q:${agentStatus.queued}`));
-          }
-          if (stats.webSearch > 0 || stats.webFetch > 0) {
-            l3.push(theme.fg("dim", `web s:${stats.webSearch} f:${stats.webFetch} c:${stats.webCache}`));
-          }
-          if (stats.mcpCalls > 0) {
-            l3.push(theme.fg("accent", `mcp q:${stats.mcpCalls}${stats.mcpErrors > 0 ? ` e:${stats.mcpErrors}` : ""}`));
-          }
-          lines.push(truncateToWidth(l3.join(" · "), width));
-
+          if (goalStr || statusStr) lines.push(balanceLine(goalStr, statusStr, width));
+          lines.push(balanceLine(projectStr, gaugeStr, width));
+          lines.push(...wrapGroups([tokenStr, costStr, agentStr, webStr, mcpStr], width, major));
           return lines;
         },
       };

--- a/scripts/test-pi-prompt-stash.sh
+++ b/scripts/test-pi-prompt-stash.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+node --input-type=module - "$root" <<'JS'
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+
+const root = process.argv[2];
+const { default: registerPromptStash } = await import(
+  pathToFileURL(`${root}/common/pi/.pi/agent/extensions/prompt-stash.ts`).href
+);
+
+const shortcuts = new Map();
+const handlers = new Map();
+registerPromptStash({
+  registerShortcut: (key, options) => shortcuts.set(key, options),
+  registerCommand: () => {},
+  on: (event, handler) => handlers.set(event, handler),
+});
+
+assert(handlers.has("agent_settled"));
+assert(!handlers.has("agent_end"));
+
+let editor = "draft";
+const statuses = new Map();
+const ctx = {
+  ui: {
+    theme: { fg: (_color, text) => text },
+    getEditorText: () => editor,
+    setEditorText: (text) => { editor = text; },
+    setStatus: (key, value) => value === undefined ? statuses.delete(key) : statuses.set(key, value),
+    notify: () => {},
+  },
+};
+
+await shortcuts.get("ctrl+s").handler(ctx);
+assert.equal(editor, "");
+assert.equal(statuses.get("stash"), "📝 stashed");
+
+await handlers.get("agent_settled")({}, ctx);
+assert.equal(editor, "draft");
+assert(!statuses.has("stash"));
+
+editor = "second draft";
+await shortcuts.get("ctrl+s").handler(ctx);
+editor = "interruption";
+await handlers.get("agent_settled")({}, ctx);
+assert.equal(editor, "interruption");
+assert.equal(statuses.get("stash"), "📝 stashed");
+
+editor = "";
+await shortcuts.get("ctrl+s").handler(ctx);
+assert.equal(editor, "second draft");
+assert(!statuses.has("stash"));
+
+console.log("OK: prompt stash restores only after agent_settled or manual toggle");
+JS

--- a/scripts/test-pi-statusline.sh
+++ b/scripts/test-pi-statusline.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+pi_bin=$(realpath "$(command -v pi)")
+pi_package=$(cd "$(dirname "$pi_bin")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/home/.pi/research" "$tmp/home/.pi/agent" "$tmp/bin"
+ln -s "$pi_package/node_modules" "$tmp/node_modules"
+ln -s "$root/common/pi/.pi/agent/extensions/statusline.ts" "$tmp/statusline.ts"
+printf '%s' '{"searchCount":3,"fetchCount":5,"cacheHits":2}' >"$tmp/home/.pi/research/stats.json"
+printf '%s' '{"demo":{"calls":8,"errors":1}}' >"$tmp/home/.pi/research/mcp-stats.json"
+printf '%s' 'Refine the pi statusline' >"$tmp/home/.pi/agent/goal"
+printf '%s\n' '#!/bin/sh' \
+  'printf '\''%s'\'' '\''{"tasks":{"1":{"label":"pi-delegate","status":"Running"},"2":{"label":"pi-delegate","status":"Queued"}}}'\''' \
+  >"$tmp/bin/pueue"
+chmod +x "$tmp/bin/pueue"
+
+cd "$tmp"
+HOME="$tmp/home" PATH="$tmp/bin:$PATH" node --experimental-strip-types --preserve-symlinks --input-type=module - "$tmp" <<'JS'
+import assert from "node:assert/strict";
+import { visibleWidth } from "@earendil-works/pi-tui";
+
+const tmp = process.argv[2];
+const { default: registerStatusline } = await import(`file://${tmp}/statusline.ts`);
+const handlers = new Map();
+const commands = new Map();
+let footerFactory;
+let contextPercent = 42;
+let reloaded = false;
+
+registerStatusline({
+  registerCommand: (name, options) => commands.set(name, options),
+  on(event, handler) {
+    const list = handlers.get(event) ?? [];
+    list.push(handler);
+    handlers.set(event, list);
+  },
+});
+
+const ctx = {
+  sessionManager: {
+    getBranch: () => [{
+      type: "message",
+      message: {
+        role: "assistant",
+        usage: { input: 12400, output: 3100, cost: { total: 0.38 } },
+      },
+    }],
+  },
+  getContextUsage: () => ({ tokens: contextPercent === null ? null : 42000, contextWindow: 100000, percent: contextPercent }),
+  model: { id: "gpt-5.6-sol", contextWindow: 100000 },
+  ui: {
+    setFooter: (factory) => { footerFactory = factory; },
+    notify: () => {},
+  },
+  reload: async () => { reloaded = true; },
+};
+
+for (const handler of handlers.get("session_start")) await handler({}, ctx);
+
+const ansi = { success: 32, warning: 33, error: 31, muted: 37, dim: 90 };
+const theme = {
+  fg: (color, text) => `\x1b[${ansi[color] ?? 36}m${text}\x1b[0m`,
+  bg: (_color, text) => text,
+};
+const footerData = {
+  getGitBranch: () => "main",
+  getExtensionStatuses: () => new Map([["stash", "📝 STASHED"]]),
+  onBranchChange: () => () => {},
+};
+const component = footerFactory({ requestRender() {} }, theme, footerData);
+
+for (const [width, maxLines] of [[100, 3], [80, 3], [60, 4], [40, 5]]) {
+  const lines = component.render(width);
+  assert(lines.length <= maxLines, `${width} columns rendered ${lines.length} lines`);
+  assert(lines.every((line) => visibleWidth(line) <= width), `${width} column render overflowed`);
+  const text = lines.join("\n");
+  for (const expected of ["Goal:", "STASHED", "main", "gpt-5.6-sol", "CTX", "TOK", "COST", "AGT", "WEB", "MCP"]) {
+    assert(text.includes(expected), `${width} column render omitted ${expected}`);
+  }
+}
+
+assert(component.render(80).join("\n").includes("\x1b[32m42%\x1b[0m"));
+contextPercent = 75;
+assert(component.render(80).join("\n").includes("\x1b[33m75%\x1b[0m"));
+contextPercent = 90;
+assert(component.render(80).join("\n").includes("\x1b[31m90%\x1b[0m"));
+contextPercent = null;
+assert(component.render(80).join("\n").includes("?"));
+
+await commands.get("statusline").handler("compact", ctx);
+const compact = component.render(60);
+assert.equal(compact.length, 1);
+assert(visibleWidth(compact[0]) <= 60);
+assert(compact[0].includes("STASHED"));
+assert(compact[0].includes("CTX"));
+
+await commands.get("statusline").handler("off", ctx);
+assert.equal(footerFactory, undefined);
+await commands.get("statusline").handler("detailed", ctx);
+assert(reloaded);
+
+console.log("OK: statusline fits 100/80/60/40 columns and colors context usage thresholds");
+JS


### PR DESCRIPTION
## Summary

Pi statuslineをFocus / Core / Telemetryの3層へ再構成し、既存の表示項目を維持したまま視認性と狭幅時のレイアウトを改善します。

## Changes

- goal・extension status、branch・model・context、tokens・cost・agent・web・MCPを意味単位で配置
- ANSI表示幅を考慮して100/80/60/40 columnsでgroup単位に折り返し
- context使用率をgreen / yellow / redの閾値で色分けし、unknownを`?`表示
- detailed / compact / offの切替を整合させ、offからの復帰時にextensionをreload
- prompt stashを`agent_settled`後に復元し、stash状態をfooterへ強調表示
- pi-loopのproject runtime stateをGit管理対象外へ追加

## Test plan

- [x] `scripts/test-pi-statusline.sh`
- [x] `scripts/test-pi-prompt-stash.sh`
- [x] `pi --list-models`
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`
- [x] TypeScript / shell syntax checks and `git diff --check`