### PR TITLE
feat(nvim): markdown レンダリングを強化

### DIFF
--- a/common/nvim/.config/nvim/lua/config/autocmds.lua
+++ b/common/nvim/.config/nvim/lua/config/autocmds.lua
@@ -440,3 +440,20 @@ vim.api.nvim_create_user_command("CleanupCache", function()
   )
 end, { desc = "Clean up Neovim cache, logs, and old files" })
 
+
+-- Markdown の折り返し・gutter 設定
+-- lazyvim_wrap_spell augroup は spell 誤検知のため削除済み (先頭参照)。
+-- render-markdown の描画に必要な折り返し関連だけをここで補う。
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "markdown", "markdown.mdx" },
+  callback = function()
+    -- 単語途中で折り返さない / 折り返し行をインデントに揃える
+    vim.opt_local.linebreak = true
+    vim.opt_local.breakindent = true
+    -- リスト項目は本文位置に揃えて折り返す
+    vim.opt_local.breakindentopt = "list:-1"
+    vim.opt_local.showbreak = "↪ "
+    -- gitsigns と render-markdown の見出し sign を同時に表示する
+    vim.opt_local.signcolumn = "yes:2"
+  end,
+})

--- a/common/nvim/.config/nvim/lua/plugins/render-markdown.lua
+++ b/common/nvim/.config/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,166 @@
+-- Markdown をエディタ内でリッチにレンダリングする。
+-- LazyVim の lang.markdown extra は意図的に地味なプリセット
+-- (見出しアイコンなし / sign なし / checkbox 無効) を渡すため、ここで全面的に上書きする。
+-- <leader>um でトグル (LazyVim 側の config が Snacks.toggle を登録済み)。
+
+local ft = {
+  "markdown",
+  "markdown.mdx",
+  "norg",
+  "rmd",
+  "org",
+  "codecompanion",
+  -- AI チャットバッファも markdown として描画する
+  "Avante",
+  "AvanteInput",
+  "copilot-chat",
+}
+
+return {
+  {
+    "MeanderingProgrammer/render-markdown.nvim",
+    ft = ft,
+    opts = {
+      file_types = ft,
+
+      -- 挿入・ビジュアルモードでも描画したまま編集する (Obsidian 的な体験)。
+      -- カーソル行だけは anti_conceal で生テキストに戻る。
+      render_modes = true,
+      anti_conceal = {
+        enabled = true,
+        -- 背景系はカーソル行でも消さない (ちらつき防止)
+        ignore = {
+          code_background = true,
+          head_background = true,
+          indent = true,
+          sign = true,
+          virtual_lines = true,
+        },
+      },
+
+      -- callout / checkbox の補完を blink.cmp と LSP に出す
+      completions = {
+        blink = { enabled = true },
+        lsp = { enabled = true },
+      },
+
+      heading = {
+        sign = true,
+        signs = { "󰫎 " },
+        icons = { "󰲡 ", "󰲣 ", "󰲥 ", "󰲧 ", "󰲩 ", "󰲫 " },
+        -- inline: '#' を隠してアイコンを差し込む (本文が左端に揃う)
+        position = "inline",
+        -- H1/H2 はウィンドウ幅のバナー、H3 以降は文字幅のバッジ
+        width = { "full", "full", "block", "block", "block", "block" },
+        left_pad = 1,
+        right_pad = 2,
+        -- 見出しの上下に背景色の帯を追加。border_virtual = false なので
+        -- 前後が空行のときだけ描画され、行数はずれない。
+        border = true,
+        border_virtual = false,
+      },
+
+      code = {
+        -- 見出し側で sign を使うのでコードブロックは言語ラベルのみ
+        sign = false,
+        width = "block",
+        min_width = 45,
+        left_pad = 2,
+        right_pad = 2,
+        language_pad = 1,
+        language_icon = true,
+        language_name = true,
+        -- hide: ``` の行は言語ラベルがある行以外を隠す
+        border = "hide",
+        inline_pad = 1,
+        -- diff はハイライトが潰れるので背景を付けない
+        disable_background = { "diff" },
+      },
+
+      bullet = {
+        icons = { "●", "○", "◆", "◇" },
+        right_pad = 1,
+      },
+
+      checkbox = {
+        enabled = true,
+        right_pad = 1,
+        unchecked = { icon = "󰄱 ", highlight = "RenderMarkdownUnchecked" },
+        checked = {
+          icon = "󰱒 ",
+          highlight = "RenderMarkdownChecked",
+          scope_highlight = "@markup.strikethrough",
+        },
+        -- markdown 文法外の拡張状態 (Obsidian 互換)
+        custom = {
+          todo = { raw = "[-]", rendered = "󰥔 ", highlight = "RenderMarkdownTodo" },
+          important = { raw = "[!]", rendered = "󰀦 ", highlight = "DiagnosticWarn" },
+          question = { raw = "[?]", rendered = "󰘥 ", highlight = "DiagnosticInfo" },
+          star = { raw = "[*]", rendered = "󰓎 ", highlight = "DiagnosticWarn" },
+          cancelled = {
+            raw = "[~]",
+            rendered = "󰰱 ",
+            highlight = "Comment",
+            scope_highlight = "@markup.strikethrough",
+          },
+        },
+      },
+
+      quote = {
+        icon = "▋",
+        -- 折り返した行にも引用マーカーを継続表示する (wrap 前提)
+        repeat_linebreak = true,
+      },
+
+      pipe_table = {
+        preset = "round",
+        cell = "padded",
+        alignment_indicator = "━",
+      },
+
+      link = {
+        custom = {
+          notion = { icon = "󰈙 ", pattern = "notion%.so", kind = "url" },
+          claude = { icon = "󰚩 ", pattern = "claude%.ai", kind = "url" },
+          anthropic = { icon = "󰚩 ", pattern = "anthropic%.com", kind = "url" },
+        },
+      },
+
+      -- 見出しレベルに応じて本文をインデントし、階層を可視化する。
+      -- 二重線を避けるため hlchunk 側で markdown を除外している。
+      indent = {
+        enabled = true,
+        per_level = 2,
+        skip_level = 1,
+        skip_heading = false,
+        icon = "▏",
+      },
+
+      html = {
+        comment = {
+          -- コメントは畳むが、存在は小さなアイコンで示す
+          conceal = true,
+          text = "󰅺 ",
+        },
+        -- 開始/終了タグを隠してアイコンに置き換える
+        tag = {
+          details = { icon = "󰅀 ", highlight = "RenderMarkdownHtmlComment" },
+          summary = { icon = "󰅂 ", highlight = "RenderMarkdownHtmlComment" },
+          kbd = { icon = "󰌌 ", highlight = "RenderMarkdownCodeInline" },
+        },
+      },
+
+      -- utftex / latex2text が未導入のため無効化 (有効のままだとエラーログが出る)
+      latex = { enabled = false },
+    },
+  },
+
+  -- markdown では render-markdown の indent を使うので hlchunk のガイドを止める
+  {
+    "shellRaining/hlchunk.nvim",
+    opts = {
+      indent = { exclude_filetypes = { markdown = true } },
+      chunk = { exclude_filetypes = { markdown = true } },
+    },
+  },
+}

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -24,6 +24,7 @@ brew "qrencode"
 
 # --- Development ---
 brew "neovim"
+brew "tree-sitter-cli"  # nvim-treesitter (main branch) がパーサーの generate/build に必須
 brew "typst"
 brew "fancy-cat"    # ターミナル内PDFビューア（Kitty graphics protocol）
 brew "lazygit"

--- a/config/mise-linux.toml
+++ b/config/mise-linux.toml
@@ -18,13 +18,14 @@
 #                 (crate の bin 名 = tldr。install.sh では rust の post_install で cargo が PATH に乗る)。
 
 [tools]
-# --- aqua registry (25) ---
+# --- aqua registry (26) ---
 "aqua:junegunn/fzf" = "latest"
 "aqua:fastfetch-cli/fastfetch" = "latest"
 "aqua:dandavison/delta" = "latest"
 "aqua:jesseduffield/lazygit" = "latest"
 "aqua:x-motemen/ghq" = "latest"
 "aqua:neovim/neovim" = "latest"
+"aqua:tree-sitter/tree-sitter" = "latest"  # nvim-treesitter (main) のパーサー generate/build に必須
 "aqua:chmln/sd" = "latest"
 "aqua:bootandy/dust" = "latest"
 "aqua:ClementTsang/bottom" = "latest"

--- a/docs/tools/neovim/overview.md
+++ b/docs/tools/neovim/overview.md
@@ -142,6 +142,27 @@ LazyVim ベースの Neovim 設定。lazy.nvim によるプラグイン管理。
 | markdown-preview.nvim | ブラウザプレビュー               |
 | render-markdown.nvim  | バッファ内 Markdown レンダリング |
 
+`render-markdown.nvim` は LazyVim の控えめなプリセットを `lua/plugins/render-markdown.lua` で上書きしている。
+
+| 要素            | 設定                                                                  |
+| --------------- | --------------------------------------------------------------------- |
+| 見出し          | レベル別アイコン + sign、H1/H2 は全幅バー、上下に境界帯                |
+| コードブロック   | block 幅、言語アイコン + 名前、` ``` ` 行は非表示                       |
+| リスト・タスク   | 階層別ブレット、checkbox は todo/important/question/star/cancelled を追加 |
+| 引用・callout    | GitHub / Obsidian 記法のアイコン化、折り返し時もマーカー継続            |
+| テーブル        | 角丸ボーダー + 寄せインジケーター                                      |
+| リンク          | ドメイン別アイコン (github / notion / claude 等)                       |
+| インデント      | 見出しレベルに応じた本文インデント (hlchunk は markdown で無効化)       |
+| HTML            | コメントを畳み、`<details>` `<summary>` `<kbd>` をアイコン化            |
+
+描画モードは insert を含む全モード。カーソル行だけ anti_conceal で生テキストに戻る。
+折り返し関連の window option (`linebreak` / `breakindent` / `showbreak` / `signcolumn=yes:2`) は
+`lua/config/autocmds.lua` の FileType autocmd で設定する。
+
+LaTeX 描画は変換コマンド (`utftex` / `latex2text`) 未導入のため無効化している。
+HTML の描画には tree-sitter の `html` パーサーが必要で、その build には `tree-sitter-cli` が要る
+(macOS は `config/Brewfile`、Linux は `config/mise-linux.toml` で導入)。
+
 ### メディア
 
 | プラグイン         | 役割                                                    |
@@ -308,6 +329,7 @@ common/nvim/.config/nvim/lua/plugins/
 ├── pdf.lua                # PDF ビューア (fancy-cat, tmux detach trick)
 ├── python-tools.lua       # Python ツール (Ruff + Mypy + basedpyright extraPaths)
 ├── rainbow-delimiters.lua # ブラケットペアカラー化
+├── render-markdown.lua    # Markdown レンダリング強化 (LazyVim プリセットを上書き)
 ├── remote.lua             # リモート/コンテナ開発 (remote-nvim)
 ├── scrollbar.lua          # スクロールバー設定
 ├── session.lua            # セッション管理設定


### PR DESCRIPTION
## Summary

LazyVim の `lang.markdown` extra が render-markdown.nvim に渡す控えめなプリセット（見出しアイコンなし / sign なし / checkbox 無効）を全面的に上書きし、バッファ内 Markdown の視認性を大幅に強化した。

あわせて、パーサーの build に必要だが未導入だった `tree-sitter-cli` をパッケージ宣言に追加した。

## Changes

### render-markdown.nvim の設定 (`lua/plugins/render-markdown.lua`)

| 要素 | 内容 |
| --- | --- |
| 見出し | レベル別アイコン + gutter sign、H1/H2 は全幅バー、上下に境界帯、`position=inline` で本文左揃え |
| コードブロック | block 幅、言語アイコン + 名前、` ``` ` 行は非表示 |
| リスト・タスク | 階層別ブレット、checkbox 有効化 + `[-] [!] [?] [*] [~]` の拡張状態（完了/中止は打ち消し線） |
| 引用・callout | GitHub / Obsidian 記法のアイコン化、折り返し時もマーカー継続 |
| テーブル | 角丸ボーダー + 寄せインジケーター |
| リンク | ドメイン別アイコン（github / notion / claude 等） |
| インデント | 見出しレベル連動の本文インデント |
| HTML | コメントの畳み込み、`<details>` `<summary>` `<kbd>` のアイコン化 |

描画は insert を含む全モードで行い、カーソル行のみ anti_conceal で生テキストに戻る。

### 付随する調整

- インデントが hlchunk のガイドと二重になるため、markdown では hlchunk 側を無効化
- 折り返し関連の window option（`linebreak` / `breakindent` / `breakindentopt=list:-1` / `showbreak` / `signcolumn=yes:2`）を FileType autocmd で設定。`lazyvim_wrap_spell` augroup は spell 誤検知のため削除済みで、折り返し設定が失われていた
- LaTeX は変換コマンド（`utftex` / `latex2text`）未導入のため無効化

### tree-sitter-cli の追加

nvim-treesitter (main branch) はパーサーの generate/build に tree-sitter CLI を必須とするが未導入で、`:TSInstall` が全言語で無音失敗していた。これが原因で `html` パーサーが入らず HTML レンダリングも効かなかった。macOS は `config/Brewfile`、Linux は `config/mise-linux.toml` (aqua backend) で導入する。

## Test plan

- [x] tmux 上の実 nvim で demo markdown を開き、見出し / コードブロック / checkbox / callout / 引用 / テーブル / 水平線 / リンク / インデント / HTML の全要素の描画を目視確認
- [x] `:checkhealth render-markdown` が全項目 OK（設定 valid、markdown / markdown_inline / html / yaml パーサー導入済み、競合プラグインなし）
- [x] 日本語テキストの折り返しと `showbreak` の表示を確認
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`