### PR TITLE
feat(claude): hunk 単位の解説つき差分ビュー生成スキル d-diff-explain

### DIFF
--- a/common/claude/.claude/skills/d-diff-explain/SKILL.md
+++ b/common/claude/.claude/skills/d-diff-explain/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: d-diff-explain
+description: git diff の各 hunk に解説を書き、リッチな差分ビュー HTML を生成してブラウザで開きます。実装理解・レビュー準備・引き継ぎ資料に使います。
+user-invocable: true
+arguments: "[<rev-range>] [-- <path>...]"
+argument-hint: "[<rev-range>] [-- <path>...]"
+when_to_use: "Use when the user wants to understand what a change does — 'この差分を解説して', '実装を理解したい', 'PR の内容を説明する HTML が欲しい'. Do NOT use for reviewing code quality (that is /d-hunk-review) or for writing PR descriptions (/d-pr)."
+---
+
+# Diff Explain - 解説つき差分ビュー生成
+
+`scripts/diff-explain` (PATH 上の `diff-explain`) と組み合わせ、diff の hunk 単位に解説を添えた HTML を生成する。
+
+## 手順
+
+1. **範囲の決定**: 引数をそのまま `git diff` の引数として使う。引数なしの場合は `main...HEAD`（デフォルトブランチとの差分）。差分が空ならその旨を伝えて終了。
+
+2. **差分の取得**: `diff-explain hunks <引数>` を実行する。出力は hunk ID (`<path>#<連番>`) 付きの unified diff。
+
+3. **文脈の把握**: diff だけで意図が読めない箇所は、Read/Grep で周辺の実装や呼び出し元を確認する。推測で解説を書かない。
+
+4. **解説の作成**: `$TMPDIR/diff-explain-<任意名>.json` に以下を書く。
+
+   ```json
+   {
+     "title": "この変更の見出し",
+     "overview": "変更全体の目的と設計の要約",
+     "files": {"path/to/file.ts": "このファイルが担う役割と変更の位置づけ"},
+     "hunks": {"path/to/file.ts#1": "この hunk の解説"}
+   }
+   ```
+
+   - `hunks` の ID は手順 2 の出力そのまま。存在しない ID は render 時に warning が出る
+   - `files` と `overview` は任意。`hunks` は原則すべての hunk を埋める
+   - 書式は素のテキスト。`` `code` `` のみインラインコードとして描画される
+
+5. **解説の書き方**: 読者は「その実装を理解したい人」。
+   - diff を日本語に訳すだけの解説は書かない（`x を y に変更` は見れば分かる）
+   - なぜその変更が必要か、どういう仕組みで動くか、どこと繋がっているかを書く
+   - 前提知識（API の挙動、フレームワークの制約など）は補って書く
+   - 意図が読み切れない箇所は断定せず「〜と思われる」と明示する
+   - 機械的な変更（lockfile、フォーマット、リネーム）はまとめて 1 行で済ませる
+
+6. **生成と確認**: `diff-explain render -e <json> --open <引数>` を実行し、出力パスを報告する。warning が出たら hunk ID を直して再実行する。
+
+## remote で実行する場合
+
+`SSH_CONNECTION` が設定されている環境では `--open` を付けてもブラウザは開かない（開けない）。生成後、ユーザーにローカル側で以下を実行するよう伝える。
+
+```bash
+diff-explain-open <host>[:<container>]      # 最新の HTML を取得して開く
+```
+
+`<host>[:<container>]` は rcon の targets と同じ形式。remote 側のパスを明示したい場合は第 2 引数に渡す。
+
+## 注意
+
+- 大量の hunk がある場合は `-- <path>` で範囲を絞るか、対象を分けて複数回生成することをユーザーに提案する
+- lockfile など機械生成物は `-- . ':(exclude)*lock*'` のようなパススペックで除外してよい
+- HTML の出力先は `$XDG_CACHE_HOME/diff-explain/`（`-o` で変更可）

--- a/common/tmux/.config/tmux/tmux.conf
+++ b/common/tmux/.config/tmux/tmux.conf
@@ -202,6 +202,9 @@ run-shell "~/.config/tmux/plugins/tmux-popup-manager/popup-manager.tmux"
 set -g status-bg default
 set -g status-style bg=default
 
+# ステータスバーは画面上部に置く (テーマ再生成後も維持されるようここで上書き)
+set -g status-position top
+
 # Visual settings (pane borders, window styles) are set by the theme file
 
 # サイドバー幅の即時補正: window-size latest 再適用後の比例リサイズ丸めで幅がドリフトするため、

--- a/docs/ai-agents/claude/claude-skills.md
+++ b/docs/ai-agents/claude/claude-skills.md
@@ -8,6 +8,7 @@ Claude Code で使用可能なカスタムスキルのリファレンス。
 |--------|------|
 | `/d-beacon` | AeroSpace ワークスペースに環境を紐付け |
 | `/d-commit` | セッション内の変更を分析してコミット作成 |
+| `/d-diff-explain` | hunk 単位の解説つき差分ビュー HTML を生成 |
 | `/d-news` | プロファイルベースのパーソナライズドニュース収集 |
 | `/d-setup-rcon-target` | rcon ターゲットの登録 + 接続検証 + docker mount スニペット生成 |
 | `/d-update-md` | セッション内の変更に関連するドキュメント更新 |
@@ -91,6 +92,61 @@ Ralph系スキルは[Ralph概要](../ralph/overview.md)を参照。
 
 - `.env`, `credentials.json` 等のシークレットファイルは自動で除外
 - `git push` は実行しない（手動で push が必要）
+
+## /d-diff-explain
+
+git diff の hunk ごとに Claude が解説を書き、解説つきの差分ビュー HTML を生成してブラウザで開きます。実装理解、レビュー準備、引き継ぎ資料に使います。
+
+### 使い方
+
+```bash
+/d-diff-explain                          # main...HEAD
+/d-diff-explain HEAD~3                   # 直近 3 コミット
+/d-diff-explain main...feature -- src/   # 範囲とパスを指定
+```
+
+### 動作
+
+1. `diff-explain hunks <引数>` で hunk ID (`<path>#<連番>`) 付きの diff を取得
+2. 必要に応じて周辺コードを読み、hunk ごとの解説 JSON を `$TMPDIR` に書く
+3. `diff-explain render -e <json> --open <引数>` で HTML を生成してブラウザで開く
+
+### diff-explain コマンド
+
+スキルを介さず単体でも使えます（解説なしの差分ビューとして）。
+
+```bash
+diff-explain hunks [--split N] [<git diff の引数>...]
+diff-explain render -e explain.json [-o out.html] [--open] [--split N] [<git diff の引数>...]
+```
+
+`--split`（既定 40 行）は長い hunk をトップレベル定義の直前で擬似 hunk に分割し、新規ファイルでも解説を細かく付けられるようにします。`hunks` と `render` は同じ値で分割する必要があります（hunk ID がずれるため）。`0` で無効。
+
+`explain.json` の形式:
+
+```json
+{
+  "title": "見出し",
+  "overview": "全体の解説",
+  "files": {"path/to/file.ts": "ファイル単位の解説"},
+  "hunks": {"path/to/file.ts#1": "hunk の解説"}
+}
+```
+
+### remote での利用
+
+remote（rcon 接続先のホストやコンテナ）でも dotfiles を stow していればそのまま動きますが、ブラウザが無いため `--open` は無効化され、代わりにローカルでの取得方法が案内されます。ローカル側から取りに行きます。
+
+```bash
+diff-explain-open <host>[:<container>]              # 最新の HTML を取得して開く
+diff-explain-open ailab:myproject-dev ~/.cache/diff-explain/x.html   # パス明示
+```
+
+`ssh`（コンテナ指定時は `docker exec` 経由）で HTML を吸い出し、ローカルの一時ディレクトリに置いて `open` / `xdg-open` します。ターゲット指定は rcon の `~/.config/rcon/targets` と同じ `host` / `host:container` 形式。単一 HTML なので転送はこれだけで完結します（`diff-explain render -o -` で stdout に出せるため、別の転送手段に差し替えることもできます）。
+
+差分は左右 2 カラム（左が変更前、右が変更後）で表示します。連続する削除行と追加行を順に突き合わせるだけの対応付けなので、片側しかない行は反対側が空欄になります。
+
+出力先の既定は `$XDG_CACHE_HOME/diff-explain/<repo>-<timestamp>.html`。シンタックスハイライトは highlight.js を CDN から読むため、オフラインでは色が付かないだけで表示自体は保たれます（行単位で解析するため、複数行文字列やブロックコメントの色は正確ではありません）。
 
 ## /d-news
 

--- a/scripts/diff-explain
+++ b/scripts/diff-explain
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""git diff を LLM 解説つきの HTML 差分ビューに変換する。
+
+  diff-explain hunks  [<git diff の引数>...]            # hunk ID 付き diff を出力
+  diff-explain render -e explain.json [-o out.html] [--open] [<git diff の引数>...]
+
+長い hunk (新規ファイルなど) は --split 行数で擬似 hunk に分割され、解説を細かく
+付けられる。hunks と render は同じ既定値で分割するため hunk ID は一致する。
+
+hunk ID は `<path>#<1始まりの連番>`。explain.json の形式:
+
+  {
+    "title":    "見出し",
+    "overview": "全体の解説",
+    "files":    {"path/to/file.ts": "ファイル単位の解説"},
+    "hunks":    {"path/to/file.ts#1": "この hunk の解説"}
+  }
+"""
+
+import argparse
+import html
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+HUNK_RE = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$")
+
+
+def git_diff(args):
+    result = subprocess.run(
+        # prefix はユーザー設定 (diff.mnemonicPrefix 等) に左右されるため固定する
+        ["git", "diff", "--no-color", "--no-ext-diff", "--src-prefix=a/", "--dst-prefix=b/", *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(result.stderr.strip() or "git diff failed")
+    return result.stdout
+
+
+def strip_prefix(path):
+    """"a/foo" -> "foo"、"/dev/null" -> None。"""
+    if path == "/dev/null":
+        return None
+    return path[2:] if path[:2] in ("a/", "b/") else path
+
+
+def parse_diff(text):
+    """unified diff を [{path, binary, hunks:[{header, old, new, lines}]}] に変換する。"""
+    files = []
+    current = None
+    hunk = None
+    old_no = new_no = 0
+
+    for line in text.splitlines():
+        if line.startswith("diff --git "):
+            current = {"path": line.split(" b/", 1)[-1], "binary": False, "hunks": []}
+            hunk = None
+            files.append(current)
+        elif current is None:
+            continue
+        elif line.startswith("--- ") or line.startswith("+++ "):
+            path = strip_prefix(line[4:])
+            if path:  # /dev/null 側は無視し、追加・削除どちらでも実体のパスを採る
+                current["path"] = path
+        elif line.startswith("Binary files "):
+            current["binary"] = True
+        elif line.startswith("@@"):
+            match = HUNK_RE.match(line)
+            if not match:
+                continue
+            old_no, new_no = int(match.group(1)), int(match.group(2))
+            hunk = {"header": line, "context": match.group(3).strip(), "lines": []}
+            current["hunks"].append(hunk)
+        elif hunk is not None and line[:1] in (" ", "+", "-", "\\"):
+            kind = {" ": "ctx", "+": "add", "-": "del", "\\": "meta"}[line[0]]
+            body = line[1:]
+            old = new = None
+            if kind in ("ctx", "del"):
+                old = old_no
+                old_no += 1
+            if kind in ("ctx", "add"):
+                new = new_no
+                new_no += 1
+            hunk["lines"].append((kind, old, new, body))
+
+    return files
+
+
+def hunk_header(lines, context=""):
+    """分割後の行から `@@ -x,y +a,b @@` を再構成する。"""
+    olds = [old for _, old, _, _ in lines if old]
+    news = [new for _, _, new, _ in lines if new]
+    old_part = f"-{olds[0]},{len(olds)}" if olds else "-0,0"
+    new_part = f"+{news[0]},{len(news)}" if news else "+0,0"
+    return f"@@ {old_part} {new_part} @@{context}"
+
+
+def split_hunk(hunk, limit):
+    """長い hunk をトップレベル定義の直前で分割する。新規ファイルの巨大 hunk 対策。"""
+    lines = hunk["lines"]
+    if limit <= 0 or len(lines) <= limit:
+        return [hunk]
+
+    chunks, current = [], []
+    for index, line in enumerate(lines):
+        current.append(line)
+        if len(current) < limit:
+            continue
+        # 次行がインデントなしで始まる = 関数/クラス/見出しの切れ目。無ければ 2 倍で強制分割
+        following = lines[index + 1][3] if index + 1 < len(lines) else ""
+        if following[:1].strip() or len(current) >= limit * 2:
+            chunks.append(current)
+            current = []
+    if current:
+        if chunks and len(current) < limit // 4:
+            chunks[-1].extend(current)  # 半端な末尾は直前にまとめる
+        else:
+            chunks.append(current)
+
+    return [
+        {
+            "header": hunk_header(chunk, hunk["context"] and f" {hunk['context']}" if i == 0 else ""),
+            "context": hunk["context"] if i == 0 else "",
+            "lines": chunk,
+        }
+        for i, chunk in enumerate(chunks)
+    ]
+
+
+EXT_LANG = {
+    "py": "python", "js": "javascript", "mjs": "javascript", "cjs": "javascript",
+    "jsx": "javascript", "ts": "typescript", "tsx": "typescript", "rb": "ruby",
+    "go": "go", "rs": "rust", "c": "c", "h": "c", "cpp": "cpp", "hpp": "cpp",
+    "java": "java", "kt": "kotlin", "swift": "swift", "php": "php", "lua": "lua",
+    "sh": "bash", "bash": "bash", "zsh": "bash", "fish": "bash", "vim": "vim",
+    "json": "json", "yml": "yaml", "yaml": "yaml", "toml": "ini", "ini": "ini",
+    "css": "css", "scss": "scss", "html": "xml", "xml": "xml", "sql": "sql",
+    "md": "markdown", "tf": "hcl", "hcl": "hcl", "dockerfile": "dockerfile",
+    "makefile": "makefile", "conf": "ini", "tmux": "bash", "gitignore": "bash",
+}
+
+
+def guess_lang(path, hunks):
+    """拡張子、ファイル名、shebang の順に言語を推定する。"""
+    name = path.rsplit("/", 1)[-1].lower()
+    if "." in name and EXT_LANG.get(name.rsplit(".", 1)[1]):
+        return EXT_LANG[name.rsplit(".", 1)[1]]
+    if EXT_LANG.get(name):
+        return EXT_LANG[name]
+    for hunk in hunks:
+        for _kind, _old, _new, body in hunk["lines"][:1]:
+            if body.startswith("#!"):
+                if "python" in body:
+                    return "python"
+                if re.search(r"\b(bash|zsh|sh)\b", body):
+                    return "bash"
+    return ""
+
+
+def load_files(git_args, split):
+    files = parse_diff(git_diff(git_args))
+    for entry in files:
+        entry["hunks"] = [part for h in entry["hunks"] for part in split_hunk(h, split)]
+        entry["lang"] = guess_lang(entry["path"], entry["hunks"])
+    return files
+
+
+def cmd_hunks(files):
+    for entry in files:
+        if entry["binary"]:
+            print(f"{entry['path']}  (binary)")
+            continue
+        for index, hunk in enumerate(entry["hunks"], 1):
+            print(f"[{entry['path']}#{index}] {hunk['header']}")
+            for kind, _old, _new, body in hunk["lines"]:
+                prefix = {"ctx": " ", "add": "+", "del": "-", "meta": "\\"}[kind]
+                print(f"{prefix}{body}")
+            print()
+
+
+def side_by_side(lines):
+    """hunk の行を (左, 右) の組に畳む。左右どちらかが無い行は None。
+
+    連続する削除と追加を同じ位置で突き合わせるだけの素朴な対応付け。
+    """
+    rows, dels, adds = [], [], []
+
+    def flush():
+        for i in range(max(len(dels), len(adds))):
+            rows.append((dels[i] if i < len(dels) else None, adds[i] if i < len(adds) else None))
+        dels.clear()
+        adds.clear()
+
+    for kind, old, new, body in lines:
+        if kind == "del":
+            dels.append(("del", old, body))
+        elif kind == "add":
+            adds.append(("add", new, body))
+        else:
+            flush()
+            if kind == "ctx":
+                rows.append((("ctx", old, body), ("ctx", new, body)))
+            else:
+                rows.append((("meta", None, body), None))  # "\ No newline at end of file"
+    flush()
+    return rows
+
+
+def rich_text(text):
+    """解説テキストを最小限だけ HTML 化する（`code` と改行のみ）。"""
+    # ponytail: full markdown は使わない。必要になったら markdown-it 等に差し替える
+    escaped = html.escape(text or "")
+    return re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
+
+
+CSS = """
+:root { color-scheme: dark; --bg:#0d1117; --panel:#161b22; --line:#30363d;
+        --fg:#e6edf3; --dim:#8b949e; --add:#12281b; --del:#2d181c; --hl:#58a6ff; }
+* { box-sizing: border-box; }
+body { margin:0; background:var(--bg); color:var(--fg); font-family:-apple-system,"Hiragino Sans",sans-serif; }
+.layout { display:flex; align-items:flex-start; }
+nav { position:sticky; top:0; width:270px; flex:none; max-height:100vh; overflow:auto;
+      padding:24px 16px; border-right:1px solid var(--line); font-size:13px; }
+nav a { display:block; color:var(--dim); text-decoration:none; padding:4px 6px;
+        border-radius:6px; word-break:break-all; }
+nav a:hover { background:var(--panel); color:var(--fg); }
+main { flex:1; min-width:0; padding:24px 32px 96px; max-width:1200px; }
+h1 { font-size:22px; margin:0 0 8px; }
+.meta { color:var(--dim); font-size:13px; margin-bottom:24px; }
+.note { background:var(--panel); border:1px solid var(--line); border-left:3px solid var(--hl);
+        border-radius:8px; padding:12px 16px; margin:12px 0; line-height:1.7; white-space:pre-wrap; }
+.file { border:1px solid var(--line); border-radius:10px; margin:28px 0; overflow:hidden; }
+.file > h2 { position:sticky; top:0; z-index:1; margin:0; padding:10px 16px; font-size:14px;
+             background:var(--panel); border-bottom:1px solid var(--line); font-family:ui-monospace,monospace; }
+.file .note { margin:12px 16px; }
+.hunk { border-top:1px solid var(--line); }
+.hunk-header { padding:6px 16px; color:var(--dim); font-size:12px; font-family:ui-monospace,monospace;
+               background:#11161d; }
+table { width:100%; table-layout:fixed; border-collapse:collapse;
+        font-family:ui-monospace,SFMono-Regular,monospace; font-size:12.5px; }
+col.c-ln { width:3.4em; } col.c-sign { width:1.4em; } col.c-code { width:calc(50% - 4.8em); }
+td { padding:0 4px; vertical-align:top; }
+td.ln { text-align:right; color:var(--dim); user-select:none; }
+td.sign { padding:0; text-align:center; user-select:none; color:var(--dim); }
+td.code { white-space:pre-wrap; word-break:break-all; tab-size:4; padding-right:8px; }
+td.right { border-left:1px solid var(--line); }
+td.add { background:var(--add); } td.add.sign { color:#3fb950; }
+td.del { background:var(--del); } td.del.sign { color:#f85149; }
+td.nil { background:#0b0e13; }
+td.meta { color:var(--dim); text-align:center; }
+.hljs-comment,.hljs-quote { color:#8b949e; font-style:italic; }
+.hljs-keyword,.hljs-selector-tag,.hljs-literal,.hljs-section,.hljs-doctag,.hljs-type,.hljs-name,.hljs-strong { color:#ff7b72; }
+.hljs-string,.hljs-regexp,.hljs-addition,.hljs-attribute,.hljs-meta .hljs-string { color:#a5d6ff; }
+.hljs-number,.hljs-symbol,.hljs-bullet,.hljs-variable,.hljs-template-variable,.hljs-attr { color:#79c0ff; }
+.hljs-title,.hljs-title.function_,.hljs-built_in { color:#d2a8ff; }
+.hljs-meta,.hljs-params { color:#ffa657; }
+"""
+
+# ponytail: ハイライトは CDN 頼み。オフラインでは色が付かないだけで表示は壊れない
+HLJS = "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/highlight.min.js"
+HIGHLIGHT_JS = """
+document.querySelectorAll('table[data-lang]').forEach(function (table) {
+  var lang = table.dataset.lang;
+  if (!window.hljs || !hljs.getLanguage(lang)) return;
+  table.querySelectorAll('td.code').forEach(function (cell) {
+    // ponytail: 行単位でハイライトするため複数行文字列/コメントは正確でない
+    cell.innerHTML = hljs.highlight(cell.textContent, {language: lang, ignoreIllegals: true}).value;
+  });
+});
+"""
+
+
+def half(cell, side):
+    """左右いずれかの 3 セル (行番号 / 記号 / コード) を組み立てる。"""
+    if cell is None:
+        return f'<td class="ln nil{side}"></td><td class="sign nil"></td><td class="code nil"></td>'
+    kind, number, body = cell
+    mark = {"add": "+", "del": "-"}.get(kind, "")
+    style = "" if kind == "ctx" else f" {kind}"
+    return (
+        f'<td class="ln{style}{side}">{number or ""}</td>'
+        f'<td class="sign{style}">{mark}</td>'
+        f'<td class="code{style}">{html.escape(body)}</td>'
+    )
+
+
+def render_html(files, explain, title, subtitle):
+    hunk_notes = explain.get("hunks", {})
+    file_notes = explain.get("files", {})
+    out = [
+        f"<h1>{html.escape(title)}</h1>",
+        f'<div class="meta">{html.escape(subtitle)}</div>',
+    ]
+    if explain.get("overview"):
+        out.append(f'<div class="note">{rich_text(explain["overview"])}</div>')
+
+    nav = []
+    for position, entry in enumerate(files):
+        path = entry["path"]
+        anchor = f"f{position}"
+        changes = sum(
+            1 for h in entry["hunks"] for kind, *_ in h["lines"] if kind in ("add", "del")
+        )
+        nav.append(
+            f'<a href="#{anchor}">{html.escape(path)}'
+            f'<span style="color:var(--hl)"> {changes}</span></a>'
+        )
+        out.append(f'<section class="file" id="{anchor}"><h2>{html.escape(path)}</h2>')
+        if file_notes.get(path):
+            out.append(f'<div class="note">{rich_text(file_notes[path])}</div>')
+        if entry["binary"]:
+            out.append('<div class="hunk-header">binary file</div>')
+        for index, hunk in enumerate(entry["hunks"], 1):
+            out.append('<div class="hunk">')
+            out.append(
+                f'<div class="hunk-header">{html.escape(hunk["header"])}'
+                f"  ({path}#{index})</div>"
+            )
+            note = hunk_notes.get(f"{path}#{index}")
+            if note:
+                out.append(f'<div class="note">{rich_text(note)}</div>')
+            out.append(
+                f'<table data-lang="{entry.get("lang", "")}"><colgroup>'
+                '<col class="c-ln"><col class="c-sign"><col class="c-code">'
+                '<col class="c-ln"><col class="c-sign"><col class="c-code"></colgroup>'
+            )
+            for left, right in side_by_side(hunk["lines"]):
+                if left and left[0] == "meta":
+                    out.append(f'<tr><td class="meta" colspan="6">{html.escape(left[2])}</td></tr>')
+                    continue
+                out.append("<tr>" + half(left, "") + half(right, " right") + "</tr>")
+            out.append("</table></div>")
+        out.append("</section>")
+
+    return (
+        "<!DOCTYPE html><html lang='ja'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        f"<title>{html.escape(title)}</title><style>{CSS}</style></head>"
+        f"<body><div class='layout'><nav>{''.join(nav)}</nav>"
+        f"<main>{''.join(out)}</main></div>"
+        f'<script src="{HLJS}"></script><script>{HIGHLIGHT_JS}</script>'
+        "</body></html>"
+    )
+
+
+def default_output():
+    cache = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "diff-explain"
+    cache.mkdir(parents=True, exist_ok=True)
+    repo = Path.cwd().name
+    return cache / f"{repo}-{time.strftime('%Y%m%d-%H%M%S')}.html"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("command", choices=["hunks", "render"])
+    parser.add_argument("-e", "--explain", help="解説 JSON のパス (render)")
+    parser.add_argument("-o", "--output", help="出力 HTML のパス (render, `-` で stdout)")
+    parser.add_argument("--title", help="HTML の見出し")
+    parser.add_argument("--open", action="store_true", help="生成後にブラウザで開く")
+    parser.add_argument(
+        "--split",
+        type=int,
+        default=40,
+        help="この行数を超える hunk を擬似 hunk に分割する (0 で無効, 既定 40)",
+    )
+    parser.add_argument("git_args", nargs="*", help="git diff にそのまま渡す引数")
+    args = parser.parse_args()
+
+    files = load_files(args.git_args, args.split)
+    if not files:
+        sys.exit("差分がありません")
+
+    if args.command == "hunks":
+        cmd_hunks(files)
+        return
+
+    explain = json.loads(Path(args.explain).read_text()) if args.explain else {}
+    known = {
+        f"{entry['path']}#{i}" for entry in files for i in range(1, len(entry["hunks"]) + 1)
+    }
+    for key in explain.get("hunks", {}):
+        if key not in known:
+            print(f"warning: 存在しない hunk ID: {key}", file=sys.stderr)
+
+    subtitle = " ".join(args.git_args) or "working tree"
+    page = render_html(
+        files, explain, args.title or explain.get("title") or "Diff Explained", subtitle
+    )
+    if args.output == "-":
+        sys.stdout.write(page)
+        return
+
+    output = Path(args.output) if args.output else default_output()
+    output.write_text(page)
+    print(output)
+    if not args.open:
+        return
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"):
+        # remote にはブラウザが無い。ローカル側から取りに行ってもらう
+        print(
+            "remote 環境のためブラウザは開かない。"
+            "ローカルで: diff-explain-open <host>[:<container>]",
+            file=sys.stderr,
+        )
+        return
+    webbrowser.open(output.as_uri())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diff-explain-open
+++ b/scripts/diff-explain-open
@@ -36,6 +36,7 @@ runner="echo ${payload} | base64 -d | sh"
 out_dir=$(mktemp -d)
 out="$out_dir/diff-explain.html"
 
+# shellcheck disable=SC2029  # payload をローカルで展開して送るのが意図
 if [[ -n $container ]]; then
   ssh "$host" "docker exec ${container} sh -c '${runner}'" >"$out"
 else

--- a/scripts/diff-explain-open
+++ b/scripts/diff-explain-open
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# diff-explain-open — remote で生成した diff-explain の HTML をローカルに取得して開く。
+#
+#   diff-explain-open <host>[:<container>] [<remote path>]
+#
+# path 省略時は remote の $XDG_CACHE_HOME/diff-explain/ にある最新の HTML を取る。
+# ターゲット指定は rcon の targets と同じ `host` / `host:container` 形式。
+
+set -euo pipefail
+
+target=${1:-}
+remote_path=${2:-}
+
+if [[ -z $target || $target == -h || $target == --help ]]; then
+  sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
+  [[ -z $target ]] && exit 1
+  exit 0
+fi
+
+host=${target%%:*}
+container=""
+[[ $target == *:* ]] && container=${target#*:}
+
+# remote 側で実行するスクリプト。base64 で包んで ssh / docker exec の引用を通す
+remote_script="
+dir=\"\${XDG_CACHE_HOME:-\$HOME/.cache}/diff-explain\"
+file='${remote_path}'
+[ -n \"\$file\" ] || file=\$(ls -t \"\$dir\"/*.html 2>/dev/null | head -1)
+[ -n \"\$file\" ] || { echo 'diff-explain の HTML が見つからない: '\"\$dir\" >&2; exit 1; }
+cat \"\$file\"
+"
+# base64 -d は GNU / busybox / macOS のいずれでも通る
+payload=$(printf '%s' "$remote_script" | base64 | tr -d '\n')
+runner="echo ${payload} | base64 -d | sh"
+
+out_dir=$(mktemp -d)
+out="$out_dir/diff-explain.html"
+
+if [[ -n $container ]]; then
+  ssh "$host" "docker exec ${container} sh -c '${runner}'" >"$out"
+else
+  ssh "$host" "${runner}" >"$out"
+fi
+
+[[ -s $out ]] || { echo "取得できなかった: ${target}" >&2; exit 1; }
+
+echo "$out"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  open "$out"
+else
+  xdg-open "$out" >/dev/null 2>&1 &
+fi

--- a/scripts/test_diff_explain.py
+++ b/scripts/test_diff_explain.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+from importlib.machinery import SourceFileLoader
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).with_name("diff-explain")
+SPEC = importlib.util.spec_from_loader(
+    "diff_explain", SourceFileLoader("diff_explain", str(SCRIPT))
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+DIFF = """diff --git a/app/main.py b/app/main.py
+index 1111111..2222222 100644
+--- a/app/main.py
++++ b/app/main.py
+@@ -1,4 +1,5 @@ def run():
+ import os
+-import sys
++import json
++import time
+     return None
+@@ -20,2 +21,2 @@
+-old = 1
++new = 1
+diff --git a/logo.png b/logo.png
+index 3333333..4444444 100644
+Binary files a/logo.png and b/logo.png differ
+"""
+
+
+class ParseDiffTest(unittest.TestCase):
+    def setUp(self):
+        self.files = MODULE.parse_diff(DIFF)
+
+    def test_files_and_hunks(self):
+        self.assertEqual([f["path"] for f in self.files], ["app/main.py", "logo.png"])
+        self.assertEqual(len(self.files[0]["hunks"]), 2)
+        self.assertTrue(self.files[1]["binary"])
+        self.assertEqual(self.files[1]["hunks"], [])
+
+    def test_line_numbering(self):
+        lines = self.files[0]["hunks"][0]["lines"]
+        self.assertEqual(
+            [(kind, old, new) for kind, old, new, _ in lines],
+            [
+                ("ctx", 1, 1),
+                ("del", 2, None),
+                ("add", None, 2),
+                ("add", None, 3),
+                ("ctx", 3, 4),
+            ],
+        )
+        self.assertEqual(self.files[0]["hunks"][1]["lines"][0][1], 20)
+
+    def test_side_by_side_pairs_del_with_add(self):
+        rows = MODULE.side_by_side(self.files[0]["hunks"][0]["lines"])
+        self.assertEqual(
+            [(left and left[2], right and right[2]) for left, right in rows],
+            [
+                ("import os", "import os"),
+                ("import sys", "import json"),
+                (None, "import time"),  # 追加が余る行は左が空
+                ("    return None", "    return None"),
+            ],
+        )
+
+    def test_render_places_note_with_matching_hunk(self):
+        explain = {"hunks": {"app/main.py#2": "2番目の hunk の解説"}, "files": {}}
+        page = MODULE.render_html(self.files, explain, "T", "range")
+        self.assertIn("2番目の hunk の解説", page)
+        self.assertLess(page.index("app/main.py#2"), page.index("2番目の hunk の解説"))
+        self.assertIn("&lt;", MODULE.rich_text("<script>"))
+
+
+class SplitHunkTest(unittest.TestCase):
+    def hunk(self, bodies):
+        lines = [("add", None, i, body) for i, body in enumerate(bodies, 1)]
+        return {"header": "@@ -0,0 +1,%d @@" % len(lines), "context": "", "lines": lines}
+
+    def test_splits_before_top_level_definition(self):
+        # def の直前 (空行を挟んでも) で切れ、関数の途中では切れないこと
+        body = lambda i: ["def f%d():" % i, "    a = 1", "    b = 2", "    return a", ""]
+        parts = MODULE.split_hunk(self.hunk(body(1) + body(2) + body(3)), 4)
+        self.assertEqual([p["lines"][0][3] for p in parts], ["def f1():", "def f2():", "def f3():"])
+        self.assertEqual(parts[1]["header"], "@@ -0,0 +6,5 @@")
+
+    def test_forces_split_without_top_level_lines(self):
+        parts = MODULE.split_hunk(self.hunk(["    x"] * 25), 4)
+        self.assertTrue(all(len(p["lines"]) <= 8 for p in parts))
+        self.assertEqual(sum(len(p["lines"]) for p in parts), 25)
+
+    def test_short_hunk_and_disabled_split_are_untouched(self):
+        hunk = self.hunk(["x"] * 10)
+        self.assertEqual(MODULE.split_hunk(hunk, 40), [hunk])
+        self.assertEqual(MODULE.split_hunk(hunk, 0), [hunk])
+
+
+class GuessLangTest(unittest.TestCase):
+    def test_extension_filename_and_shebang(self):
+        self.assertEqual(MODULE.guess_lang("a/b/main.py", []), "python")
+        self.assertEqual(MODULE.guess_lang("Dockerfile", []), "dockerfile")
+        shebang = [{"lines": [("add", None, 1, "#!/usr/bin/env python3")]}]
+        self.assertEqual(MODULE.guess_lang("scripts/diff-explain", shebang), "python")
+        self.assertEqual(MODULE.guess_lang("scripts/unknown-thing", []), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

git diff の hunk ごとに LLM の解説を添えた HTML を生成するスキルとコマンドを追加する。実装理解、レビュー準備、引き継ぎ資料での利用を想定している。

差分の取得・パース・分割・描画は Python スクリプトが決定的に行い、Claude は解説テキストだけを書く。両者を繋ぐ契約が hunk ID (`<path>#<連番>`) で、これにより Claude は巨大な diff 本文を書き戻す必要がなく、短い JSON を書くだけで済む。

## Changes

- `scripts/diff-explain` — diff を左右 2 カラムの HTML に描画する。stdlib のみ
  - `hunks` サブコマンドで hunk ID 付きの diff を出力、`render` で解説 JSON をマージ
  - 新規ファイルが 1 hunk になる問題への対処として、トップレベル定義の直前で擬似 hunk に分割 (`--split`, 既定 40 行)
  - シンタックスハイライトは highlight.js を CDN から読む。オフラインでは色が付かないだけで表示は保たれる
  - 解説 JSON に存在しない hunk ID があれば stderr に warning を出す
- `scripts/diff-explain-open` — remote (rcon の `host` / `host:container`) で生成した HTML をローカルに取得して開く。ssh → docker exec → sh の 3 層を通すため、実行スクリプトは base64 で包む
- `common/claude/.claude/skills/d-diff-explain/SKILL.md` — Claude 側の手順。解説の書き方 (diff の直訳を書かない、周辺コードを読む) に重点を置く
- `scripts/test_diff_explain.py` — パーサ、擬似 hunk 分割、左右対応付け、言語推定のテスト
- `docs/ai-agents/claude/claude-skills.md` — スキル一覧とリファレンスに追記

## Test plan

- [x] `python3 scripts/test_diff_explain.py` (8 件)
- [x] `scripts/check-markdown-links.py`
- [x] 新規ファイル中心の差分・既存ファイル中心の差分の双方で hunks → 解説 JSON → render を実行し、ブラウザで表示を確認
- [x] `diff-explain-open` は ssh をスタブ化して 4 経路 (最新ファイル解決 / `host:container` / パス明示 / HTML 不在時のエラー) を確認
- [ ] 実 remote に対する `diff-explain-open` の疎通確認 (この端末から到達できる接続先が無いため未実施)

## 既知の制約

- ハイライトは行単位で解析するため、複数行文字列やブロックコメントの色は途中で切れる
- 左右の対応付けは連続する削除行と追加行を順に突き合わせるだけなので、数が合わない塊では並びがずれて見える