### PR TITLE
fix(install): installer が mise 管理ツールを見失う / 1Password 未 signin で中断する / dotfiles repo を汚す問題を修正

### DIFF
--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -27,7 +27,10 @@ NERD_FONT_URL="https://github.com/yuru7/udev-gothic/releases/download/${NERD_FON
 
 TOOL_bun_check_cmd="bun"
 TOOL_bun_method="curl_pipe"
-TOOL_bun_curl_cmd='curl -fsSL https://bun.sh/install | bash'
+# SHELL=/bin/sh: installer の rc 追記分岐 (case $(basename "$SHELL")) を `*` fallback へ
+# 逃がし、~/.zshrc = stow symlink 経由での dotfiles repo 書き換えを防ぐ。
+# PATH は zshrc.common が ~/.bun/bin を担当済み。scripts/linux.sh の install_bun も同様。
+TOOL_bun_curl_cmd='curl -fsSL https://bun.sh/install | SHELL=/bin/sh bash'
 
 TOOL_starship_check_cmd="starship"
 TOOL_starship_method="curl_pipe"

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -378,7 +378,12 @@ install_bun() {
 
   log_info "Installing bun (tmux-palette runtime)..."
   # Installs into ~/.bun; PATH is exported in zshrc.common (~/.bun/bin).
-  curl -fsSL https://bun.sh/install | bash
+  # bun の installer は `basename "$SHELL"` で分岐して rc に PATH を追記するが、
+  # ~/.zshrc は stow symlink なので dotfiles repo 本体が書き換わり、次回 install の
+  # link_dotfiles が "Uncommitted changes ... stow --adopt" で停止する (再実行の
+  # たびに重複追記もされる)。PATH は zshrc.common が担当済みなので、追記分岐に
+  # 入らない SHELL 名 (sh → case の `*` fallback) を渡して抑制する。
+  curl -fsSL https://bun.sh/install | SHELL=/bin/sh bash
   log_success "bun installed"
 }
 

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -352,13 +352,17 @@ install_modern_tools() {
   # Mise tools (special: depends on mise, activates it)
   if command_exists mise || [[ -f "$HOME/.local/bin/mise" ]]; then
     export PATH="$HOME/.local/bin:$PATH"
-    eval "$("$HOME/.local/bin/mise" activate bash 2>/dev/null || true)"
     # Linux-only tool set (github releases migrated off the eval/scrape engine).
     # conf.d is auto-loaded by mise and NOT stowed, so macOS never sees it.
     mkdir -p "$HOME/.config/mise/conf.d"
     cp "$CONFIG_DIR/mise-linux.toml" "$HOME/.config/mise/conf.d/dotfiles-linux.toml"
     log_info "Installing mise-managed tools..."
     "$HOME/.local/bin/mise" install -y 2>/dev/null || true
+    # `mise activate bash` は interactive shell 用 (PROMPT_COMMAND hook) で、
+    # installer のような非対話 script では PATH が一切書き換わらない。後続 step
+    # (install_npm_packages / install_compiled_tools の go) から mise 管理ツールを
+    # 見せるため、install 後に shims を直接 PATH へ載せる。
+    eval "$("$HOME/.local/bin/mise" activate bash --shims 2>/dev/null || true)"
   fi
 
   # Summary

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -100,24 +100,22 @@ check_1password() {
     return 0
   fi
 
+  # op 未導入 / 未 signin でも abort しない (install.sh の check_1password_cli と同じ方針)。
+  # ここは run_step から直接呼ばれるので exit すると linux.sh 全体が落ち、後続の
+  # set_default_shell まで飛ばされる。secret 依存ステップは op read が no-op fallback
+  # するので継続して問題なく、signin 後に再実行すれば secret が反映される。
+  # 未 signin の最終案内は install.sh の summary が出す。
   if ! command_exists op; then
-    log_error "1Password CLI not installed."
-    log_error "Install: https://developer.1password.com/docs/cli/get-started/"
-    exit 1
+    log_warn "1Password CLI not installed. Secret-dependent steps will no-op."
+    log_warn "Install: https://developer.1password.com/docs/cli/get-started/"
+    return 0
   fi
 
   if op whoami &>/dev/null; then
     log_success "1Password CLI: signed in"
   else
-    log_error "1Password CLI: not signed in"
-    echo "  ----------------------------------------"
-    echo "  Run the following command to sign in:"
-    echo ""
-    echo "    eval \$(op signin)"
-    echo ""
-    echo "  Then re-run this script."
-    echo "  ----------------------------------------"
-    exit 1
+    log_warn "1Password CLI: not signed in. Secret-dependent steps will no-op this run."
+    log_warn "Sign in with 'eval \$(op signin)' and re-run to populate secrets."
   fi
 }
 # --- 2. Install Functions ---

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -138,8 +138,11 @@ install_mise_tools() {
   fi
 
   log_info "Installing tools via mise..."
-  eval "$(mise activate bash)"
   mise install -y 2>/dev/null || true
+  # `mise activate bash` は interactive shell 用 (PROMPT_COMMAND hook) で、
+  # installer のような非対話 script では PATH が一切書き換わらない。後続 step
+  # から mise 管理ツールを見せるため、install 後に shims を直接 PATH へ載せる。
+  eval "$(mise activate bash --shims 2>/dev/null || true)"
 }
 
 set_default_shell() {


### PR DESCRIPTION
久しぶりに起動した pi-500 (Raspberry Pi, Debian aarch64) の復旧作業中に見つかった installer の欠陥 3 件を修正する。いずれも「install.sh が最後まで走ったように見えて、実際には一部が無言でスキップされる / 次回実行が壊れる」類のもの。

## 1. mise 管理ツールが後続 step から見えない

`mise activate bash` は interactive shell 用に `PROMPT_COMMAND` hook を仕込むだけで、installer のような非対話 script では PATH が一切書き換わらない。そのため `mise install` 直後でも `npm` / `npx` / `go` が見つからず、以下が warning だけ出して無言でスキップされていた。

- `install_npm_packages` — npm パッケージ 7 個
- `install_claude_mem` — claude-mem
- `install_compiled_tools` — go 版 crew

`mise activate bash --shims` に変更し、実行位置も `mise install` の後へ移動して生成済み shims を PATH 先頭に載せる。`--shims` は `export PATH=".../shims:$PATH"` を吐くだけなので非対話でも効く。linux / mac 双方の経路を同時に更新。

## 2. 1Password 未 signin で linux.sh 全体が落ちる

`check_1password` は `run_step` から subshell 無しで直接呼ばれるため、`exit 1` が `scripts/linux.sh` 全体を終了させ、後続の `set_default_shell` まで飛ばしていた。一方 `install.sh` 側は「未 signin でも exit せず継続する (これが根本治療)」と明示設計されており、二重チェックで方針が食い違っていた。

未導入 / 未 signin とも `log_warn` + `return 0` に変更して `install.sh` と揃える。secret 依存ステップは `op read` が no-op fallback するため継続して問題なく、signin 後の再実行で反映される。未 signin の最終案内は `install.sh` の summary が出すので、重複していた案内ボックスは削除。

## 3. bun installer が dotfiles repo 本体を書き換える

bun の installer は `case $(basename "$SHELL")` で分岐し、zsh なら `~/.zshrc` へ PATH を追記する。`~/.zshrc` は stow symlink なので `common/zsh/.zshrc` が書き換わり、**次回 install.sh の `link_dotfiles` が `Uncommitted changes in dotfiles repo would be lost by stow --adopt` で停止する**。再実行のたびに同じブロックが重複追記されていた。

`~/.bun/bin` の PATH は `zshrc.common` が既に担当しているので追記は不要。rc 追記分岐に入らない `SHELL=/bin/sh` (case の `*` fallback) を渡して抑制する。bun は `config/tools.linux.bash` の tool table と `scripts/linux.sh` の `install_bun` の 2 箇所から入るため両方を修正。

## Test plan

pi-500 実機で、元の失敗形である非対話 shell (`ssh pi-500 'cd ~/dotfiles && ./install.sh -y'`) から実行して確認。

- [x] `npm not found, skipping npm packages` / `npx not found` / `go not found, skipping crew` が消失
- [x] go 版 crew がビルドされる (`~/.local/bin/crew` 生成、4.9MB)
- [x] 1Password 未 signin でも `ERROR` / abort せず `WARN` のみ、`set_default_shell` まで到達
- [x] `Some Linux setup steps failed` / `Installation finished with package setup failures` が消え `=== Installation Complete! ===` になる
- [x] bun 再インストール後も `common/zsh/.zshrc` が dirty にならず (`Manually add the directory to ~/.bashrc (or similar):` の fallback 分岐に入る)、`Dotfiles linked successfully` まで到達
- [x] `bash -n scripts/linux.sh scripts/mac.sh config/tools.linux.bash`
- [x] `shellcheck -S warning -x scripts/linux.sh scripts/mac.sh` クリーン
- [x] `scripts/check-markdown-links.py` / `scripts/check-package-duplication.sh` 通過

## 未対応 (別途)

- bun が tool table と `install_bun` の 2 箇所から入る重複自体は残している (今回は追記抑制のみ)
- `~/.codex/config.toml` の生成が stow 経由で `common/codex/.codex/config.toml` を dirty にする。bun と同じ「installer が repo 本体に書く」クラスだが、生成が `link_dotfiles` より後なので stow は止まらない
