### PR TITLE
fix(install): atuin が install.sh 経由で入らない / dotfiles repo の .zshrc を汚す問題を修正

### DIFF
--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -50,7 +50,11 @@ TOOL_zoxide_curl_cmd='curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/z
 
 TOOL_atuin_check_cmd="atuin"
 TOOL_atuin_method="curl_pipe"
-TOOL_atuin_curl_cmd='curl --proto =https --tlsv1.2 -LsSf https://setup.atuin.sh | sh -s -- --yes'
+# ATUIN_NO_MODIFY_PATH / ZDOTDIR: installer による ~/.zshrc への追記を抑止する。
+# ~/.zshrc は stow symlink なので追記されると dotfiles repo 本体が汚れる。
+# PATH は zshrc.common、init は linux/zsh/.zshrc.local が担当済み。
+# 詳細は scripts/linux.sh の _atuin_rc_guard_dir を参照。
+TOOL_atuin_curl_cmd='curl --proto =https --tlsv1.2 -LsSf https://setup.atuin.sh | ATUIN_NO_MODIFY_PATH=1 ZDOTDIR="$(_atuin_rc_guard_dir)" sh -s -- --yes'
 
 TOOL_dotenvx_check_cmd="dotenvx"
 TOOL_dotenvx_method="curl_pipe"

--- a/config/tools.linux.bash
+++ b/config/tools.linux.bash
@@ -54,7 +54,10 @@ TOOL_atuin_method="curl_pipe"
 # ~/.zshrc は stow symlink なので追記されると dotfiles repo 本体が汚れる。
 # PATH は zshrc.common、init は linux/zsh/.zshrc.local が担当済み。
 # 詳細は scripts/linux.sh の _atuin_rc_guard_dir を参照。
-TOOL_atuin_curl_cmd='curl --proto =https --tlsv1.2 -LsSf https://setup.atuin.sh | ATUIN_NO_MODIFY_PATH=1 ZDOTDIR="$(_atuin_rc_guard_dir)" sh -s -- --yes'
+# --non-interactive: setup script は `--yes` を解釈しない。未指定だと TTY 判定へ進み、
+# TTY の無い installer 実行では `exec 3</dev/tty` の失敗が (POSIX sh の特殊組込み
+# エラーとして) shell を即終了させる。stderr は握り潰されるため無言で入らない。
+TOOL_atuin_curl_cmd='curl --proto =https --tlsv1.2 -LsSf https://setup.atuin.sh | ATUIN_NO_MODIFY_PATH=1 ZDOTDIR="$(_atuin_rc_guard_dir)" sh -s -- --non-interactive'
 
 TOOL_dotenvx_check_cmd="dotenvx"
 TOOL_dotenvx_method="curl_pipe"

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -256,6 +256,19 @@ install_postgresql_apt() {
   $SUDO apt install -y postgresql-client
 }
 
+# atuin の setup script は `grep -q "atuin init zsh" "${ZDOTDIR:-$HOME}/.zshrc"` が
+# 空振りすると ~/.zshrc へ init 行を追記する。~/.zshrc は stow symlink なので
+# dotfiles repo 本体 (common/zsh/.zshrc) が汚れ、次回 install の link_dotfiles が
+# stow --adopt 前チェックで停止する。init は linux/zsh/.zshrc.local が担当済みなので、
+# 「追記済み」に見えるダミー .zshrc を持つ ZDOTDIR を渡して guard を成立させ、
+# 追記そのものを起こさせない。PATH 側の追記は ATUIN_NO_MODIFY_PATH=1 が抑止する。
+_atuin_rc_guard_dir() {
+  local d="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/atuin-rc-guard"
+  mkdir -p "$d"
+  printf 'eval "$(atuin init zsh)"\n' > "$d/.zshrc"
+  printf '%s' "$d"
+}
+
 # --- Main Tool Dispatcher ---
 
 install_modern_tools() {


### PR DESCRIPTION
pi-500 で `atuin` が毎コマンド以下を吐くようになっていた件の調査で見つかった installer の欠陥 2 件を修正する。

```
Error: migration 20260224000100 was previously applied but is missing in the resolved migrations
```

直接の原因は atuin バイナリと履歴 DB のバージョン不整合 (2026-01-13 付の 18.11.0 が、新しい atuin で `20260224000100` まで進んだ DB を開けない) だが、**なぜ古いバイナリが残り続けたのか**を追うと installer 側に 2 つの問題があった。

## 1. setup script が非対話環境で無言で死ぬ (#316 の続き)

tool table は `--yes` を渡していたが `setup.atuin.sh` はこのフラグを解釈しない。未指定だと TTY 判定に進み `exec 3</dev/tty` を試みるが、TTY の無い installer 実行 (ssh 越し / バックグラウンド) では失敗する。POSIX sh では **exec のリダイレクト失敗が特殊組込みのエラーとして shell を即終了させる**うえ、`2>/dev/null` で stderr も消えるため、バナーすら出さずに atuin が入らないまま次の tool へ進んでいた。

対話端末から手で叩くと TTY があるので成功し、`install.sh` 経由でだけ失敗するため気付きにくい。正しいフラグ `--non-interactive` に修正する。

これが「install.sh を何度回しても古い atuin のままだった」理由。tool table の `command_exists atuin` はバージョンを見ないため、一度入った古いバイナリは以降スキップされ続ける。

## 2. atuin installer が dotfiles repo の .zshrc を書き換える

\#316 の bun と同じクラス。`setup.atuin.sh` は

```sh
grep -q "atuin init zsh" "${ZDOTDIR:-$HOME}/.zshrc"
```

が空振りすると `~/.zshrc` へ init 行を追記し、内包する dist installer も `. "$HOME/.atuin/bin/env"` を追記する。`~/.zshrc` は stow symlink なので `common/zsh/.zshrc` が dirty になり、次回 `install.sh` の `link_dotfiles` が `Uncommitted changes ... stow --adopt` で停止する。

PATH は `zshrc.common:43`、`atuin init zsh` は `linux/zsh/.zshrc.local:21` が既に担当しており追記は完全な重複。dist installer 側は `ATUIN_NO_MODIFY_PATH=1` で抑止でき、setup script 側は「追記済み」に見えるダミー `.zshrc` を持つ `ZDOTDIR` を渡して grep guard を成立させ、追記自体を起こさせない。

bun と違い `SHELL` を見ない無条件追記なので、guard を成立させる形でしか塞げない。

mac は brew 経由で入るため rc 追記の経路がなく、変更不要。

## Test plan

pi-500 実機で `~/.atuin` を削除した状態から、非対話 shell (`ssh pi-500 'cd ~/dotfiles && ./install.sh -y'`) で確認。

- [x] 修正前: `Installing atuin...` の直後に何も出力されず、`~/.atuin/bin/atuin` が生成されない (Tool Summary には `New: atuin` と出るため成功に見える)
- [x] 修正後: `Atuin installed successfully!` まで到達し `atuin 18.18.1` が入る
- [x] `common/zsh/.zshrc` が dirty にならない
- [x] 対照実験: ZDOTDIR guard 無しで同じ installer を叩くと `common/zsh/.zshrc` に 2 行追記される (guard が効いていることの確認)
- [x] 更新後の atuin で migration エラーが消え、既存履歴もそのまま読める
- [x] `bash -n scripts/linux.sh config/tools.linux.bash` / `shellcheck -S warning -x scripts/linux.sh` クリーン
- [x] `scripts/check-markdown-links.py` / `scripts/check-package-duplication.sh` 通過

## 未対応

tool table 全体にバージョン比較の仕組みが無く、`command_exists` を通った時点で以降スキップされる。今回の「古いバイナリが更新されない」根本はここだが、tool table の設計変更になるため分離した。
