### PR TITLE
feat(tmux): prefix + o で Claude Code transcript を Neovim popup で開く

### DIFF
--- a/common/tmux/.config/tmux/custom-keys.conf
+++ b/common/tmux/.config/tmux/custom-keys.conf
@@ -149,6 +149,10 @@ bind-key -N "Paste buffer (raw)" V run-shell 'tmux send-keys -l -- "$(tmux show-
 # Thumbs (Vimium-style hint selection)
 bind-key -N "Thumbs" e run-shell "~/dotfiles/scripts/tmux-thumbs-wrapper.sh"
 
+# Claude Code transcript (tool output omitted, arbitrary multi-page selection)
+bind-key -N "Claude transcript" o run-shell -b \
+    "~/dotfiles/scripts/tmux-claude-transcript --popup '#{pane_id}'"
+
 # ============================================================================
 # Nested Session Toggle (F12)
 # ============================================================================

--- a/docs/tools/tmux.md
+++ b/docs/tools/tmux.md
@@ -109,6 +109,20 @@ prefix 不要のグループ移動キー（root table）:
 | `u` / `d` | 半ページスクロール（倍速移動） |
 | マウスドラッグ | 自動コピー → OSC52（Copy Mode 終了） |
 
+### Claude Code transcript
+
+| キー | 動作 |
+|------|------|
+| `prefix + o` | 現在のClaude Code会話をtool出力抜きのMarkdownとしてNeovim popupで開く |
+
+Claude Code fullscreenは会話をtmux scrollbackに残さず、`Ctrl+o` → `[` は全tool出力を
+展開する。`prefix + o` はSessionStart hookでpaneに記録した正確なJSONLを
+`jq`でuser/assistant本文だけを直接Markdown化するため、同じcwdで複数sessionを動かしても
+取り違えない。popup内では通常のNeovim操作 (`/`, `v`/`V`, `y`) でページをまたいで
+検索・選択・system clipboardへのコピーができる。hook導入前から動いているpaneでは
+cwdに対応する最新sessionへフォールバックし、次回の起動・resume以降は記録済みpathを使う。
+USER PROMPTブロックは背景色付きで表示され、長いClaude回答の中でも発言境界を判別できる。
+
 ## ステータスバー
 
 位置: 上部（`status-position top`）、透過背景。
@@ -172,6 +186,7 @@ Prefix (`Ctrl+Space`) 押下時、ステータスバー右側全体がキーバ�
 | `l` | pane レイアウトプリセット menu（保存/適用） |
 | `N` | smug session テンプレート起動 |
 | `A` | AI agent sidebar |
+| `o` | Claude transcript（tool出力抜き、Neovim popup） |
 | `v` | Copy Mode |
 | `r` | 設定リロード |
 | `?` | キーバインド一覧 |

--- a/scripts/claude-transcript-highlight.lua
+++ b/scripts/claude-transcript-highlight.lua
@@ -1,0 +1,27 @@
+-- Make user prompts immediately distinguishable in the read-only transcript.
+-- Extmarks affect display only: yanked text remains the original Markdown.
+
+local buffer = vim.api.nvim_get_current_buf()
+local namespace = vim.api.nvim_create_namespace("claude-transcript-user")
+local lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, false)
+local in_user_prompt = false
+
+vim.api.nvim_set_hl(0, "ClaudeTranscriptUser", { link = "DiffAdd", default = true })
+vim.api.nvim_set_hl(0, "ClaudeTranscriptUserHeader", { link = "DiffText", default = true })
+
+for index, line in ipairs(lines) do
+  if line == "# USER PROMPT" then
+    in_user_prompt = true
+  elseif line == "# CLAUDE" then
+    in_user_prompt = false
+  end
+
+  if in_user_prompt then
+    vim.api.nvim_buf_set_extmark(buffer, namespace, index - 1, 0, {
+      line_hl_group = line == "# USER PROMPT"
+          and "ClaudeTranscriptUserHeader"
+        or "ClaudeTranscriptUser",
+      priority = 120,
+    })
+  end
+end

--- a/scripts/tmux-claude-pane.sh
+++ b/scripts/tmux-claude-pane.sh
@@ -17,6 +17,7 @@
 #   tmux-claude-pane.sh set <running|idle|permission|complete|hang|error> [provider]
 #   tmux-claude-pane.sh start [provider] [event|screen]
 #   tmux-claude-pane.sh heartbeat [provider] [event|screen]
+#   tmux-claude-pane.sh track [provider]  # hook stdin から transcript_path を記録
 #   tmux-claude-pane.sh clear       # 通知クリア(全 pane option を解除)
 #   tmux-claude-pane.sh hang-scan   # 全ペーン走査: running かつ無応答を hang 化 (watcher が定期実行)
 
@@ -81,7 +82,7 @@ apply_status() {
 clear_pane() {
   local pane="$1"
   local option
-  for option in status icon heartbeat state_since outhash heartbeat_source provider stashed; do
+  for option in status icon heartbeat state_since outhash heartbeat_source provider stashed transcript_path; do
     tmux set-option -p -t "$pane" -u "@agent_$option" 2>/dev/null || true
   done
 }
@@ -93,6 +94,21 @@ resolve_pane() {
   local p="${TMUX_PANE:-$(tmux display-message -p '#{pane_id}' 2>/dev/null)}"
   [[ -z "$p" ]] && exit 0
   echo "$p"
+}
+
+# Existing installations already invoke set/start/heartbeat from Claude hooks,
+# and every hook payload carries transcript_path. Capture it opportunistically
+# so pane/session association works before the newly added dedicated `track`
+# SessionStart hook has been deployed to ~/.claude/settings.json.
+track_from_hook_stdin() {
+  local pane="$1" provider="$2" hook_input transcript_path
+  [[ "$provider" == "claude" ]] || return 0
+  [[ ! -t 0 ]] || return 0
+  hook_input=$(cat)
+  [[ -n "$hook_input" ]] || return 0
+  transcript_path=$(printf '%s' "$hook_input" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+  [[ -n "$transcript_path" ]] || return 0
+  tmux set-option -p -t "$pane" @agent_transcript_path "$transcript_path"
 }
 
 scan_pane() {
@@ -135,10 +151,23 @@ scan_pane() {
 }
 
 case "${1:-}" in
+  track)
+    # Claude Code hook input contains the authoritative transcript path. Keep it
+    # on the originating pane so a popup never guesses the wrong JSONL when
+    # multiple Claude sessions run in the same working directory.
+    PANE_ID=$(resolve_pane)
+    PROVIDER="${2:-claude}"
+    hook_input=$(cat)
+    transcript_path=$(printf '%s' "$hook_input" | jq -r '.transcript_path // empty' 2>/dev/null || true)
+    [[ -n "$transcript_path" ]] || exit 0
+    tmux set-option -p -t "$PANE_ID" @agent_transcript_path "$transcript_path"
+    tmux set-option -p -t "$PANE_ID" @agent_provider "$PROVIDER"
+    ;;
   set)
     PANE_ID=$(resolve_pane)
     STATUS="${2:-idle}"
     PROVIDER="${3:-}"
+    track_from_hook_stdin "$PANE_ID" "$PROVIDER"
     lock_pane "$PANE_ID"
     apply_status "$PANE_ID" "$STATUS" "$PROVIDER" || { echo "Unknown status: $STATUS" >&2; exit 1; }
     unlock_pane
@@ -151,6 +180,7 @@ case "${1:-}" in
     PANE_ID=$(resolve_pane)
     PROVIDER="${2:-}"
     SOURCE="${3:-screen}"
+    track_from_hook_stdin "$PANE_ID" "$PROVIDER"
     [[ "$SOURCE" == event || "$SOURCE" == screen ]] || { echo "Unknown heartbeat source: $SOURCE" >&2; exit 1; }
     lock_pane "$PANE_ID"
     now=$(date +%s)
@@ -172,6 +202,7 @@ case "${1:-}" in
     PANE_ID=$(resolve_pane)
     PROVIDER="${2:-}"
     SOURCE="${3:-}"
+    track_from_hook_stdin "$PANE_ID" "$PROVIDER"
     lock_pane "$PANE_ID"
     now=$(date +%s)
     current=$(tmux show-options -pv -t "$PANE_ID" @agent_status 2>/dev/null || echo "")
@@ -221,7 +252,7 @@ case "${1:-}" in
     ;;
 
   *)
-    echo "Usage: $0 {set <status> [provider]|start [provider] [event|screen]|heartbeat [provider] [event|screen]|clear|hang-scan}" >&2
+    echo "Usage: $0 {track [provider]|set <status> [provider]|start [provider] [event|screen]|heartbeat [provider] [event|screen]|clear|hang-scan}" >&2
     exit 1
     ;;
 esac

--- a/scripts/tmux-claude-transcript
+++ b/scripts/tmux-claude-transcript
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Open the Claude Code transcript attached to a tmux pane as compact Markdown.
+# Tool calls/results are omitted so the result behaves like Claude's collapsed
+# fullscreen view, while Neovim provides keyboard-only, multi-page selection.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+die() {
+  printf 'Claude transcript: %s\n' "$*" >&2
+  printf '\nPress any key to close...'
+  IFS= read -r -n 1 _ || true
+  exit 1
+}
+
+render() {
+  local transcript="$1" tmp_dir output
+  [[ -r "$transcript" ]] || die "transcript is not readable: $transcript"
+  command -v nvim >/dev/null 2>&1 || die "nvim is required"
+  command -v jq >/dev/null 2>&1 || die "jq is required"
+
+  tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/claude-transcript.XXXXXX")
+  trap 'rm -rf "$tmp_dir"' EXIT
+  output="$tmp_dir/transcript.md"
+
+  # claude-code-log's minimal view distilled to the hot path: extracting only
+  # human prompts and assistant text with jq avoids Python/uvx startup on every
+  # popup. Tool results, tool calls, thinking and hook-injected meta messages
+  # never reach the Markdown buffer.
+  jq -r '
+    def text_content:
+      if type == "string" then .
+      elif type == "array" then
+        [ .[] | select((.type? // "text") == "text") | (.text // empty) ]
+        | join("\n")
+      else ""
+      end;
+    select(.type == "user" or .type == "assistant")
+    | (.message.content | text_content) as $body
+    | select($body != "")
+    | select((.isMeta // false) == false)
+    | select(($body | test("^<(system-reminder|local-command|command-name|command-message|ide_opened_file)")) | not)
+    | if .type == "user"
+      then "\n---\n\n# USER PROMPT\n\n" + $body + "\n"
+      else "\n# CLAUDE\n\n" + $body + "\n"
+      end
+  ' "$transcript" > "$output" || die "failed to parse Claude transcript"
+
+  if [[ ! -s "$output" ]]; then
+    die "transcript contained no user/assistant text"
+  fi
+
+  # TextYankPost sends every yank through the repository's clipboard bridge.
+  # This also works in tmux popups where OSC 52 is swallowed by tmux.
+  nvim -R \
+    --cmd "lua vim.api.nvim_create_autocmd('TextYankPost',{callback=function() if vim.v.event.operator == 'y' then vim.fn.system(vim.fn.expand('~/dotfiles/scripts/clipboard-copy'), vim.fn.getreg('\"')) end end})" \
+    -c "luafile $SCRIPT_DIR/claude-transcript-highlight.lua" \
+    -c 'normal! Gzb' \
+    "$output"
+}
+
+discover_and_render() {
+  local cwd="$1" project_key project_dir transcript candidate
+  local -a sessions
+  project_key=${cwd//\//-}
+  project_dir="$HOME/.claude/projects/$project_key"
+  # Prefer Claude's usual path-derived project directory, then fall back to
+  # inspecting .cwd in every top-level transcript. The latter avoids depending
+  # on Claude's private path-mangling rules (dots and other punctuation have
+  # changed encoding across releases).
+  shopt -s nullglob
+  sessions=("$project_dir"/*.jsonl)
+  shopt -u nullglob
+  if ((${#sessions[@]} > 0)); then
+    transcript=$(ls -t "${sessions[@]}" 2>/dev/null | head -1 || true)
+    [[ -n "$transcript" ]] && { render "$transcript"; return; }
+  fi
+
+  shopt -s nullglob
+  sessions=("$HOME"/.claude/projects/*/*.jsonl)
+  shopt -u nullglob
+  ((${#sessions[@]} > 0)) || die "no Claude session transcript found for: $cwd"
+
+  while IFS= read -r candidate; do
+    if jq -e --arg cwd "$cwd" 'select(.cwd == $cwd)' "$candidate" >/dev/null 2>&1; then
+      transcript="$candidate"
+      break
+    fi
+  done < <(ls -t "${sessions[@]}" 2>/dev/null | awk '!seen[$0]++')
+  [[ -n "$transcript" ]] || die "no Claude session transcript found for: $cwd"
+  render "$transcript"
+}
+
+if [[ "${1:-}" == "--render" ]]; then
+  [[ $# -eq 2 ]] || die "internal usage: --render TRANSCRIPT"
+  render "$2"
+  exit 0
+fi
+if [[ "${1:-}" == "--discover" ]]; then
+  [[ $# -eq 2 ]] || die "internal usage: --discover CWD"
+  discover_and_render "$2"
+  exit 0
+fi
+if [[ "${1:-}" == "--popup" ]]; then
+  [[ $# -eq 2 ]] || die "internal usage: --popup PANE_ID"
+  # display-popup does not expand formats embedded in its shell-command.
+  # This mode is entered through run-shell, where #{pane_id} has already been
+  # resolved, and passes the resulting literal pane ID into the popup command.
+  exec tmux display-popup -E -w 90% -h 90% \
+    "'$SCRIPT_DIR/tmux-claude-transcript' '$2'"
+fi
+
+pane_id="${1:-${TMUX_PANE:-}}"
+[[ -n "$pane_id" ]] || die "could not determine the source pane"
+
+transcript=$(tmux show-options -pv -t "$pane_id" @agent_transcript_path 2>/dev/null || true)
+
+# A remote rcon pane stores a container-local transcript path. Render inside
+# that container; local panes render directly on the host.
+eval "$("$SCRIPT_DIR/tmux-pane-context" "$pane_id")"
+if [[ -n "${CONTAINER:-}" ]]; then
+  # Do not execute the container's copy of this script: remote/container
+  # dotfiles may lag behind the host version. Fetch only the JSONL and render
+  # it with the host-side converter, editor, and clipboard bridge.
+  if [[ -z "$transcript" ]]; then
+    transcript=$(docker exec "$CONTAINER" bash -lc '
+      project_key=${1//\//-}
+      project_dir="$HOME/.claude/projects/$project_key"
+      shopt -s nullglob
+      sessions=("$project_dir"/*.jsonl)
+      if ((${#sessions[@]} > 0)); then
+        ls -t "${sessions[@]}" | head -1
+        exit 0
+      fi
+      sessions=("$HOME"/.claude/projects/*/*.jsonl)
+      ((${#sessions[@]} > 0)) || exit 1
+      while IFS= read -r candidate; do
+        if jq -e --arg cwd "$1" "select(.cwd == \$cwd)" "$candidate" >/dev/null 2>&1; then
+          printf "%s\n" "$candidate"
+          exit 0
+        fi
+      done < <(ls -t "${sessions[@]}" 2>/dev/null | awk "!seen[\$0]++")
+      exit 1
+    ' bash "$CWD" 2>/dev/null || true)
+  fi
+  [[ -n "$transcript" ]] || die "no Claude session transcript found in container for: $CWD"
+
+  fetched_dir=$(mktemp -d "${TMPDIR:-/tmp}/claude-transcript-fetch.XXXXXX")
+  fetched="$fetched_dir/session.jsonl"
+  trap 'rm -rf "$fetched_dir"' EXIT
+  docker exec "$CONTAINER" cat "$transcript" > "$fetched" \
+    || die "could not read transcript from container: $transcript"
+  render "$fetched"
+  exit 0
+fi
+
+if [[ -n "$transcript" ]]; then
+  render "$transcript"
+else
+  discover_and_render "$CWD"
+fi

--- a/templates/claude-settings.json
+++ b/templates/claude-settings.json
@@ -57,6 +57,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh track claude"
+          },
+          {
+            "type": "command",
             "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh set idle claude"
           }
         ]


### PR DESCRIPTION
## Summary

Claude Code fullscreen は会話を tmux scrollback に残さず、`Ctrl+o` → `[` は全 tool 出力を展開してしまうため、過去のやり取りを横断的に検索・コピーする手段がなかった。`prefix + o` で、tool 出力を除いた会話本文だけを read-only Neovim popup として開けるようにする。

## Changes

- `scripts/tmux-claude-transcript` (新規): pane option に記録された transcript path の JSONL を `jq` で user/assistant 本文のみ Markdown 化し、`display-popup` 内の read-only Neovim で開く。popup 内では `/`・`v`/`V`・`y` でページをまたいだ検索・選択・clipboard コピーが可能（yank は `clipboard-copy` bridge 経由。tmux popup では OSC 52 が握り潰されるため）。
- rcon の container pane では、container 側 dotfiles のバージョン差を避けるため JSONL のみ `docker exec` で取得し、描画・editor・clipboard は host 側で行う。
- `scripts/claude-transcript-highlight.lua` (新規): USER PROMPT ブロックを extmark で着色し、長い Claude 回答の中でも発言境界を判別できるようにする。表示のみの変更で、yank されるテキストは元の Markdown のまま。
- `scripts/tmux-claude-pane.sh`: SessionStart hook 用の `track` サブコマンドを追加し、hook payload の `transcript_path` を pane option に記録する。同一 cwd で複数 session を動かしても取り違えない。既存の `set`/`start`/`heartbeat` 経路でも stdin から日和見的に拾うため、hook 未再配布の環境でも動く。`clear` の解除対象にも `transcript_path` を追加。
- `templates/claude-settings.json`: SessionStart に `track` hook を登録。
- `docs/tools/tmux.md`: キーバインド表と動作説明を追記。

## Test plan

- [ ] `prefix + o` でローカル pane の transcript が popup で開き、tool 出力が含まれないこと
- [ ] popup 内で `/` 検索、`V` 複数行選択、`y` で system clipboard にコピーできること
- [ ] 同一 cwd で 2 つの Claude session を起動し、それぞれの pane が自分の transcript を開くこと
- [ ] hook 記録のない既存 pane で cwd フォールバックが動作すること
- [ ] rcon container pane で container 内の transcript が host 側で描画されること
- [ ] `scripts/check-markdown-links.py` / `scripts/check-package-duplication.sh` が通ること