### PR TITLE
feat(nvim): octo.nvim を PR レビュー用に設定する

### DIFF
--- a/common/nvim/.config/nvim/lua/plugins/octo.lua
+++ b/common/nvim/.config/nvim/lua/plugins/octo.lua
@@ -1,0 +1,13 @@
+return {
+  {
+    "pwntester/octo.nvim",
+    opts = {
+      use_local_fs = true,
+      default_to_projects_v2 = false,
+    },
+    keys = {
+      { "<leader>gc", "<cmd>Octo pr checks<cr>", desc = "PR Checks (Octo)" },
+      { "<leader>gw", "<cmd>Octo run list<cr>", desc = "Workflow Runs (Octo)" },
+    },
+  },
+}

--- a/common/nvim/.config/nvim/lua/plugins/render-markdown.lua
+++ b/common/nvim/.config/nvim/lua/plugins/render-markdown.lua
@@ -14,6 +14,7 @@ local ft = {
   "Avante",
   "AvanteInput",
   "copilot-chat",
+  "octo",
 }
 
 return {

--- a/docs/tools/neovim/overview.md
+++ b/docs/tools/neovim/overview.md
@@ -322,6 +322,7 @@ common/nvim/.config/nvim/lua/plugins/
 ├── lualine.lua            # ステータスライン強化 (リポジトリ全体diff, Copilot, LSP名)
 ├── multicursor.lua        # マルチカーソル (vim-visual-multi)
 ├── noice.lua              # メッセージ表示最適化 (種類別ルーティング)
+├── octo.lua               # GitHub PR レビュー (use_local_fs で LSP 有効化)
 ├── scroll.lua             # スクロール設定（snacks.scroll 無効化）
 ├── neotest.lua            # テストランナー設定 (4アダプター, monorepo対応)
 ├── overseer.lua           # タスクランナー設定 (タスク出力表示強化)
@@ -429,6 +430,10 @@ LazyVim のデフォルトキーバインドを使用。`<leader>` は `Space`�
 | `<leader>gF` | コミット履歴                     |
 | `<leader>gH` | GH Dash（GitHub Dashboard）      |
 | `<leader>gR` | リポジトリ/サブモジュール切替    |
+| `<leader>gp` | PR 一覧（Octo）                  |
+| `<leader>gi` | Issue 一覧（Octo）               |
+| `<leader>gc` | PR の CI checks（Octo）          |
+| `<leader>gw` | workflow run 一覧（Octo）        |
 
 ### CodeDiff 内操作
 


### PR DESCRIPTION
## Summary

ターミナル内で GitHub PR のレビューを完結させるため、導入済みだった octo.nvim を実際に使える状態にする。

## Changes

- `default_to_projects_v2 = false` — LazyVim の `util.octo` extra が有効化しているが、`read:project` スコープを持たない token では PR 取得が丸ごと失敗する。Projects v2 はレビューに不要
- `use_local_fs = true` — review の右ペインをローカル実ファイルにして LSP を有効化。定義ジャンプ・診断・補完が review 中に使える
- `<leader>gc` / `<leader>gw` — PR の CI checks と workflow run 一覧
- render-markdown.nvim の `file_types` に `octo` を追加 — PR 本文・コメントの checklist や見出しを描画
- docs/tools/neovim/overview.md にキーマップとプラグインファイルを追記

## Test plan

- [x] `use_local_fs` / `default_to_projects_v2` の設定反映と `<leader>gc` `<leader>gw` の登録を確認
- [x] 実 PR (#320) の取得成功を確認 (projects v2 無効化前はスコープエラーで失敗)
- [x] octo バッファに merge state の virtual text が描画されることを確認
- [x] octo バッファで checkbox / heading が render-markdown により描画されることを確認
- [ ] open PR での review フロー (`\vs` → コメント → submit) と conflict 表示は、この repo に open PR がないため未確認