### PR TITLE
fix(tmux): tmux 3.4〜3.5a で agent sidebar が描画されない問題を修正し、3.6a への追随を install 経路へ入れる

### DIFF
--- a/config/packages.linux.alpine.txt
+++ b/config/packages.linux.alpine.txt
@@ -4,6 +4,10 @@ openssl-dev
 pkgconf
 zsh
 tmux
+# tmux 3.6a の source build 用 (install_tmux_source)
+libevent-dev
+ncurses-dev
+bison
 jq
 stow
 neovim

--- a/config/packages.linux.apt.txt
+++ b/config/packages.linux.apt.txt
@@ -4,6 +4,10 @@ pkg-config
 libssl-dev
 zsh
 tmux
+# tmux 3.6a の source build 用 (install_tmux_source)
+libevent-dev
+libncurses-dev
+bison
 jq
 stow
 unzip

--- a/docs/install/install-no-sudo.md
+++ b/docs/install/install-no-sudo.md
@@ -38,13 +38,16 @@ no-sudo モードでは **pixi 経由で導入** される (`config/pixi-package
 
 ### tmux (source build)
 
-no-sudo モードでは **tmux は source build** (`install_tmux_source` in `scripts/linux.sh`) で `~/.local/bin/tmux` に入れる。pixi には含めない。理由:
+`install_tmux_source` (`scripts/linux.sh`) は **PATH 上の tmux が 3.6a 未満なら** source build して `~/.local/bin/tmux` に入れる。no-sudo 専用ではなく、sudo がある環境でも distro の tmux が古ければ動く。pixi には含めない。理由:
 
 - **system tmux (3.2a on Ubuntu 22.04)** は `allow-passthrough` / `pane-border-indicators` 等 3.3+ の option を解釈できず、TUI への bracketed paste 転送が崩れる (claude login の auth code paste などが壊れる)
+- **distro の tmux 3.4〜3.5a** (Debian trixie = 3.5a) はコマンド出力を vis エスケープするため、`-F` の `0x1f` 区切りが `\037` に化けて agent index が壊れる。詳細は [agent stop notification](../specs/agent-stop-notification.md)
 - **pixi の conda-forge tmux 3.6** は特定環境で attach 時に crash する (xterm-ghostty + real PTY の組み合わせで "server exited unexpectedly" が再現)
-- **source build の 3.6a** は system libevent / libncurses にリンクされ、両方の問題を回避できる
+- **source build の 3.6a** は system libevent / libncurses にリンクされ、これらの問題を回避できる
 
-build requirements: `gcc make wget tar libevent-dev libncurses-dev`。足りなければ step は skip される (host 管理者にインストール依頼)。
+build requirements: `gcc make wget tar bison libevent-dev libncurses-dev`。sudo 環境ではパッケージリスト (`config/packages.linux.apt.txt` / `.alpine.txt`) に含めてある。足りなければ step は skip される (host 管理者にインストール依頼)。
+
+ビルド済みの binary は `~/.local/bin/tmux`。PATH 上 `/usr/bin` より前なので新規 tmux server は 3.6a で起動するが、**既存 server は再起動するまで古い版のまま**動く。
 
 ### Neovim
 

--- a/docs/specs/agent-stop-notification.md
+++ b/docs/specs/agent-stop-notification.md
@@ -45,6 +45,8 @@ Provider hookはpane state更新を同期完了してから戻る。pi extension
 
 `tmux-agent-index.sh`はtmux socketごとのruntime directoryへpane/session snapshotを保存する。refreshとinvalidateは同じlockで直列化し、状態遷移後の次のconsumer読込で即refreshする。cacheが利用不能ならconsumerは直接`tmux list-*`へfallbackする。
 
+record間のfield区切りは`0x1f`(US)を使う。tmux 3.4〜3.5aはコマンド出力をvisエスケープするため`0x1f`が`\037`という文字列になる(3.6で解消)。該当版では分割が1 fieldに潰れ、sidebar daemonが描画対象を見失って即終了するので、`tmux list-*`出力は読み取り境界で`agent_unvis` (`tmux-agent-lib.sh`) を通して復号する。非該当版ではno-op。
+
 - `prefix+a`: read-only `capture-pane` previewとpane jump。実paneの`swap-pane`は行わない。
 - `prefix+A`: sidebarのtoggle。描画はtmux serverごとに1本のdaemon (`tmux-agent-sidebar.sh daemon`) が担い、同じindexから3秒周期でframeを組み立て、各sidebar paneの`pane_tty`へ直接書き込む。pane側のprocessはpaneを保持するだけで状態を持たない。frameのうちpaneごとに異なるのは現在session/groupのmarkerとpane寸法だけなので、収集は1 tickに1回で済む。sidebarが1枚も無くなるとdaemonは終了し、次のtoggleで再起動する。
 - session/window切替時は`tmux-agent-sidebar.sh poke`がindexをinvalidateしてdaemonへ`SIGUSR1`を送り、polling周期を待たずに再描画する。

--- a/scripts/check-package-duplication.sh
+++ b/scripts/check-package-duplication.sh
@@ -53,6 +53,10 @@ declare -a APT_SUDO_ONLY=(
   libssl-dev
   luarocks
   tmux  # tmux comes from install_tmux_source in no-sudo mode, not pixi
+  # tmux 3.6a の source build 用 toolchain。no-sudo 環境では host 側に依存する。
+  libevent-dev
+  libncurses-dev
+  bison
 )
 
 missing=()

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -551,26 +551,25 @@ install_fancy_cat() {
   log_success "fancy-cat installed to ~/.local/bin"
 }
 
-# Build tmux from source in --no-sudo mode.
-# Rationale: on sudoless hosts we lose access to apt's tmux 3.2+, and pixi's
+# Build tmux 3.6a from source when the available tmux is older.
+# Rationale (no-sudo): sudoless hosts lose apt's tmux 3.2+, and pixi's
 # conda-forge tmux 3.6 crashes on attach in this environment (xterm-ghostty +
 # real PTY combination). The system tmux 3.2a is too old to forward bracketed
-# paste properly to TUIs (allow-passthrough is missing). Source build of
-# upstream tmux 3.6a against system libevent/ncurses works reliably.
+# paste properly to TUIs (allow-passthrough is missing).
+# Rationale (sudo あり): distro が 3.4〜3.5a を配る間 (Debian trixie = 3.5a)、
+# tmux はコマンド出力を vis エスケープし `-F` の 0x1f 区切りが `\037` に化ける。
+# agent index 側は agent_unvis で復号しているが、根本解消は 3.6 以降を使うこと。
+# どちらの経路でも upstream 3.6a を system libevent/ncurses に対してビルドする。
 install_tmux_source() {
-  [[ "$NO_SUDO" == "true" ]] || return 0
-
   local target_version="3.6a"
   local current_bin="$HOME/.local/bin/tmux"
 
-  # Skip if already at target version (idempotent)
-  if [[ -x "$current_bin" ]]; then
-    local have
-    have=$("$current_bin" -V 2>/dev/null | awk '{print $2}')
-    if [[ "$have" == "$target_version" ]]; then
-      log_success "tmux $target_version already installed (~/.local/bin/tmux)"
-      return 0
-    fi
+  # PATH 上の tmux が target 以上なら何もしない (idempotent)
+  local have
+  have=$(tmux -V 2>/dev/null | awk '{print $2}')
+  if [[ -n "$have" && "$(printf '%s\n%s\n' "$target_version" "$have" | sort -V | head -1)" == "$target_version" ]]; then
+    log_success "tmux $have already satisfies >= $target_version"
+    return 0
   fi
 
   # Check build dependencies

--- a/scripts/tmux-agent-index.sh
+++ b/scripts/tmux-agent-index.sh
@@ -59,11 +59,11 @@ refresh_unlocked() {
   sessions_tmp="$SESSIONS_FILE.$$"
   updated_tmp="$UPDATED_FILE.$$"
 
-  tmux list-panes -a -F "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{@agent_state_since}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}${US}#{@agent_sidebar_pane}${US}#{@agent_provider}${US}#{pane_tty}${US}#{pane_width}${US}#{pane_height}" >"$panes_tmp" || {
+  tmux list-panes -a -F "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{@agent_state_since}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}${US}#{@agent_sidebar_pane}${US}#{@agent_provider}${US}#{pane_tty}${US}#{pane_width}${US}#{pane_height}" | agent_unvis >"$panes_tmp" || {
     rm -f "$panes_tmp" "$sessions_tmp" "$updated_tmp"
     return 1
   }
-  tmux list-sessions -F "#{session_name}${US}#{@group}${US}#{session_attached}" >"$sessions_tmp" || {
+  tmux list-sessions -F "#{session_name}${US}#{@group}${US}#{session_attached}" | agent_unvis >"$sessions_tmp" || {
     rm -f "$panes_tmp" "$sessions_tmp" "$updated_tmp"
     return 1
   }

--- a/scripts/tmux-agent-lib.sh
+++ b/scripts/tmux-agent-lib.sh
@@ -15,6 +15,15 @@ agent_runtime_dir() {
   printf '%s/claude/tmux-%s' "$(agent_runtime_base)" "$(agent_server_key)"
 }
 
+# tmux 3.4〜3.5a はコマンド出力を vis エスケープする (0x1f → literal "\037")。
+# cmdq_print が server_client_print へ parse=0 を渡すため VIS_OCTAL 経路に入る。
+# 3.6 で parse=1 固定になり解消したが、3.4〜3.5a を使う環境ではフィールド区切りの
+# 0x1f が壊れて分割できないため、読み取り境界で戻す。該当しない版では no-op。
+agent_unvis() {
+  local us=$'\x1f'
+  sed "s/\\\\037/${us}/g"
+}
+
 agent_is_shell() {
   case "${1#-}" in
     zsh|bash|sh|fish|dash|ksh|tcsh|nu|xonsh|elvish) return 0 ;;

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -14,12 +14,12 @@ US=$'\x1f'
 
 agent_index_panes() {
   "$SCRIPT_DIR/tmux-agent-index.sh" panes 2>/dev/null || tmux list-panes -a -F \
-    "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{@agent_state_since}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}${US}#{@agent_sidebar_pane}${US}#{@agent_provider}${US}#{pane_tty}${US}#{pane_width}${US}#{pane_height}"
+    "#{pane_id}${US}#{session_name}${US}#{window_index}${US}#{@agent_status}${US}#{@agent_heartbeat}${US}#{@agent_state_since}${US}#{pane_current_path}${US}#{pane_current_command}${US}#{pane_title}${US}#{@agent_stashed}${US}#{@agent_sidebar_pane}${US}#{@agent_provider}${US}#{pane_tty}${US}#{pane_width}${US}#{pane_height}" | agent_unvis
 }
 
 agent_index_sessions() {
   "$SCRIPT_DIR/tmux-agent-index.sh" sessions 2>/dev/null || tmux list-sessions -F \
-    "#{session_name}${US}#{@group}${US}#{session_attached}"
+    "#{session_name}${US}#{@group}${US}#{session_attached}" | agent_unvis
 }
 
 C_RED=$'\e[38;5;203m'; C_AMBER=$'\e[38;5;214m'; C_DIM=$'\e[2m'; C_BOLD=$'\e[1m'; C_RST=$'\e[0m'


### PR DESCRIPTION
## Summary

tmux 3.4〜3.5a 環境で prefix+A の agent sidebar が空のまま描画されない問題を修正する。原因は tmux 側の出力エスケープで agent index の field 区切りが壊れることだった。あわせて、根本解消となる tmux 3.6a の source build を sudo 環境でも走るようにする。

## 原因

tmux は `cmdq_print` → `server_client_print` の経路で、`parse == 0` のとき出力を `utf8_stravisx(..., VIS_OCTAL|VIS_CSTYLE|VIS_NOSLASH)` に通す。

| 版 | 挙動 |
|---|---|
| 3.3a | エスケープなし |
| 3.4 / 3.5 / 3.5a | `cmdq_print` が `parse=0` を渡す → **0x1f が literal `\037` に化ける** |
| 3.6 以降 | `cmdq_print_data` が `parse=1` 固定 → エスケープなし |

`tmux-agent-index.sh` は `list-panes -F` の field 区切りに 0x1f を使っているため、該当版では 1 行が 1 field に潰れる。その結果:

- `sidebar_targets` が空 → sidebar daemon が即終了し、prefix+A の pane が描画されないまま残る
- `collect_agents` が状態を拾えず `AGENTS 0`
- prefix+a の横断ビュー、statusline の agent アイコンも同様に機能しない

## Changes

**1. 区切り文字の復号 (該当版での対処)**

- `tmux-agent-lib.sh` に `agent_unvis` を追加し、`\037` を実 0x1f へ戻す
- `tmux-agent-index.sh` の cache 生成 (`list-panes` / `list-sessions`) と、`tmux-agent-status.sh` の cache 不能時 fallback に適用
- 非該当版ではパターンが一致しないため no-op

**2. tmux 3.6a への追随 (根本解消)**

- `install_tmux_source` の `NO_SUDO` ゲートを撤廃し、PATH 上の tmux が 3.6a 未満なら sudo の有無に関係なくビルドする
- build 依存 `libevent-dev` / `libncurses-dev` (alpine: `ncurses-dev`) / `bison` をパッケージリストへ追加。`bison` は configure の `yacc not found` で必要と判明
- `check-package-duplication.sh` の `APT_SUDO_ONLY` に上記を分類

distro が古い tmux を配る環境は今後もありうるため、復号は 3.6a 導入後も残す。

## Test plan

- [x] Debian trixie / tmux 3.5a で `tmux-agent-index.sh panes` の出力が 0x1f 区切りに戻ることを確認
- [x] `sidebar_targets` 相当が sidebar pane を解決 (`%21|dotfiles|/dev/pts/1|40|72`)
- [x] `tmux-agent-sidebar.sh once` が `AGENTS 0` から実数へ回復
- [x] `tmux-agent-status.sh list` (prefix+a の横断ビュー) が行を生成
- [x] source build した 3.6a で `list-sessions -F` が生の 0x1f を返すことを別 socket で確認
- [x] `scripts/check-package-duplication.sh` / `scripts/check-markdown-links.py`
- [ ] `scripts/test-tmux-agent-status.sh` (未実行)
- [ ] macOS 経路の回帰確認 (brew tmux は 3.6 以降のため no-op のはず)

🤖 Generated with [Claude Code](https://claude.com/claude-code)