### PR TITLE
Remove unused pi model providers

### DIFF
--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -10,9 +10,9 @@
 //   oracle     — Second opinion, challenge assumptions, architecture advice
 //
 // Model selection tiers (from AGENTS.md):
-//   high   → kimi-k2.6:high       (design, review, debugging)
-//   medium → deepseek-v4-pro:high (coding from a plan)
-//   low    → deepseek-v4-flash:off (summaries, extraction)
+//   high   → gpt-5.6-sol:high      (design, review, debugging)
+//   medium → gpt-5.4-mini:medium   (coding from a plan)
+//   low    → gpt-5.3-codex-spark:off (summaries, extraction)
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
@@ -30,9 +30,9 @@ const DELEGATION_LOG = join(homedir(), ".pi", "research", "delegation.jsonl");
 const DELEGATE_LABEL = "pi-delegate";
 
 const MODEL_TIERS: Record<string, string> = {
-  high: "opencode-go/kimi-k2.6:high",
-  medium: "opencode-go/deepseek-v4-pro:high",
-  low: "opencode-go/deepseek-v4-flash:off",
+  high: "openai-codex/gpt-5.6-sol:high",
+  medium: "openai-codex/gpt-5.4-mini:medium",
+  low: "openai-codex/gpt-5.3-codex-spark:off",
 };
 
 // ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@ export default function (pi: ExtensionAPI) {
       "worker (implement from plan), oracle (second opinion). " +
       "Supports sync (wait for result) and async (background via pueue) modes. " +
       "Use natural language in the task: 'Use reviewer to audit auth module for security issues'. " +
-      "Difficulty auto-selects model: high=kimi-k2.6, medium=deepseek-v4-pro, low=deepseek-v4-flash.",
+      "Difficulty auto-selects model: high=gpt-5.6-sol, medium=gpt-5.4-mini, low=gpt-5.3-codex-spark.",
     promptSnippet: "Delegate a task to a sub-agent (reviewer/scout/worker/oracle)",
     promptGuidelines: [
       "Use delegate_agent for tasks that benefit from a second set of model eyes.",
@@ -97,7 +97,7 @@ export default function (pi: ExtensionAPI) {
       task: Type.String({ description: "Task description/instructions for the sub-agent" }),
       difficulty: Type.Optional(Type.String({ description: "high, medium, or low. Default: medium" })),
       mode: Type.Optional(Type.String({ description: "'async' (pueue background) or 'sync' (wait). Default: 'async'" })),
-      model: Type.Optional(Type.String({ description: "Override model (e.g., 'opencode-go/kimi-k2.6:high')" })),
+      model: Type.Optional(Type.String({ description: "Override model (e.g., 'openai-codex/gpt-5.6-sol:high')" })),
     }),
     async execute(_toolCallId, params, _signal, onUpdate) {
       const difficulty = params.difficulty || "medium";

--- a/common/pi/.pi/agent/extensions/quick-question.ts
+++ b/common/pi/.pi/agent/extensions/quick-question.ts
@@ -20,7 +20,7 @@ export default function (pi: ExtensionAPI) {
       try {
         const escaped = args.replace(/'/g, "'\\''");
         const result = execSync(
-          `pi --model 'opencode-go/deepseek-v4-flash:off' -p '${escaped}' < /dev/null 2>&1`,
+          `pi --model 'openai-codex/gpt-5.3-codex-spark:off' -p '${escaped}' < /dev/null 2>&1`,
           { encoding: "utf-8", timeout: 30_000, stdio: ["pipe", "pipe", "pipe"] }
         );
 

--- a/common/pi/.pi/agent/extensions/workflow.ts
+++ b/common/pi/.pi/agent/extensions/workflow.ts
@@ -23,9 +23,9 @@ const DEPTH_ENV = "PI_WORKFLOW_DEPTH";
 
 // Difficulty → model. Mirrors agent-delegation.ts; change per provider.
 const MODEL_TIERS: Record<string, string> = {
-  high: "opencode-go/kimi-k2.6:high",
-  medium: "opencode-go/deepseek-v4-pro:high",
-  low: "opencode-go/deepseek-v4-flash:off",
+  high: "openai-codex/gpt-5.6-sol:high",
+  medium: "openai-codex/gpt-5.4-mini:medium",
+  low: "openai-codex/gpt-5.3-codex-spark:off",
 };
 function resolveModel(difficulty?: string, model?: string): string {
   return model || MODEL_TIERS[difficulty ?? "medium"] || MODEL_TIERS.medium;
@@ -165,7 +165,7 @@ export async function mapLimit<T, R>(items: T[], limit: number, fn: (item: T, in
 const TaskSpec = Type.Object({
   task: Type.String({ description: "Instruction for the sub-agent" }),
   difficulty: Type.Optional(Type.String({ description: "high | medium | low (model tier). Default medium" })),
-  model: Type.Optional(Type.String({ description: "Override model id (e.g. opencode-go/kimi-k2.6:high)" })),
+  model: Type.Optional(Type.String({ description: "Override model id (e.g. openai-codex/gpt-5.6-sol:high)" })),
   jsonKeys: Type.Optional(Type.Array(Type.String(), { description: "If set, instruct the sub-agent to return JSON with these keys and parse it" })),
 });
 

--- a/common/pi/.pi/agent/settings.json
+++ b/common/pi/.pi/agent/settings.json
@@ -2,6 +2,10 @@
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "low",
+  "enabledModels": [
+    "openai-codex/*",
+    "cursor-agent/*"
+  ],
   "hideThinkingBlock": true,
   "theme": "tokyonight-high-contrast",
   "quietStartup": true,
@@ -78,7 +82,6 @@
     "npm:@narumitw/pi-goal",
     "npm:pi-remote-control",
     "npm:pi-cursor-agent",
-    "npm:pi-commandcode-provider",
     "npm:pi-permission-system",
     "git:github.com/DietrichGebert/ponytail"
   ],

--- a/docs/ai-agents/cursor/overview.md
+++ b/docs/ai-agents/cursor/overview.md
@@ -169,7 +169,7 @@ Cursor CLI をそのままバックエンドにする薄いラッパ。導入は
 ### その他
 
 - **シェル委譲:** `cursor-agent -p --trust "task"` を pi の Bash から実行 (別ハーネス)
-- **delegate_agent:** サブエージェントは引き続き OpenCode Go / Codex の `pi -p` (Cursor モデルにしたい場合はメインセッションを Cursor プロバイダに)
+- **delegate_agent:** サブエージェントは Codex の `pi -p`（Cursor モデルは手動オーバーライド可能）
 
 詳細: [pi overview — Cursor Provider](../pi/overview.md#cursor-provider-pi-cursor-agent)
 

--- a/docs/ai-agents/pi/agent-delegation.md
+++ b/docs/ai-agents/pi/agent-delegation.md
@@ -41,22 +41,22 @@
 
 | ロール | 用途 | 推奨難易度 | モデル |
 |--------|------|:--:|--------|
-| `reviewer` | コードレビュー、セキュリティ監査、品質チェック | high | kimi-k2.6 |
-| `scout` | コードベース探索、read-only調査、依存関係分析 | medium | deepseek-v4-pro |
-| `worker` | 承認済み計画からの実装 | medium | deepseek-v4-pro |
-| `oracle` | セカンドオピニオン、設計レビュー、前提検証 | high | kimi-k2.6 |
+| `reviewer` | コードレビュー、セキュリティ監査、品質チェック | high | gpt-5.6-sol |
+| `scout` | コードベース探索、read-only調査、依存関係分析 | medium | gpt-5.4-mini |
+| `worker` | 承認済み計画からの実装 | medium | gpt-5.4-mini |
+| `oracle` | セカンドオピニオン、設計レビュー、前提検証 | high | gpt-5.6-sol |
 
 ## Model Auto-Selection
 
 `delegate_agent` は difficulty に応じて自動的にモデルを選択する:
 
-| Difficulty | Primary Model | Fallback |
+| Difficulty | Primary Model | Override |
 |:----------:|---------------|----------|
-| `high` | opencode-go/kimi-k2.6:high | opencode-go/kimi-k2.6:high |
-| `medium` | opencode-go/deepseek-v4-pro:high | opencode-go/glm-5.1:high |
-| `low` | opencode-go/deepseek-v4-flash:off | opencode-go/glm-5:high |
+| `high` | openai-codex/gpt-5.6-sol:high | 手動オーバーライド |
+| `medium` | openai-codex/gpt-5.4-mini:medium | 手動オーバーライド |
+| `low` | openai-codex/gpt-5.3-codex-spark:off | 手動オーバーライド |
 
-モデル・フォールバックは手動オーバーライド可能。
+モデルは手動オーバーライド可能。
 
 ## Execution Modes
 

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -1,10 +1,8 @@
-# pi-coding-agent (OpenCode Go + Codex + Cursor)
+# pi-coding-agent (Codex + Cursor)
 
 > **由来:** **Upstream** pi本体・provider / **Plugin** settings.json導入package / **Configuration** settings・AGENTS.md・テーマ / **Custom** extensions（[区分](../../provenance.md#区分)）
 
-[pi](https://pi.dev/) はミニマルな terminal coding harness。MCP / sub-agents / permission popup / plan mode を持たず、CLI extensions と skills で組み立てる思想。dotfiles では OpenCode Go / Codex を主軸に、Cursor サブスク向けに [pi-cursor-agent](https://www.npmjs.com/package/pi-cursor-agent) プロバイダも同梱している。
-
-参考: [OpenCode Go + pi-coding-agent のすゝめ](https://zenn.dev/kimuson/articles/pi-coding-agent-with-opencode-go)
+[pi](https://pi.dev/) はミニマルな terminal coding harness。MCP / sub-agents / permission popup / plan mode を持たず、CLI extensions と skills で組み立てる思想。dotfiles では Codex を主軸に、Cursor サブスク向けに [pi-cursor-agent](https://www.npmjs.com/package/pi-cursor-agent) プロバイダも同梱している。`enabledModels` で利用対象をこの2 providerに限定している。
 
 ## 構成
 
@@ -51,8 +49,6 @@ ls -la ~/.pi/agent/AGENTS.md  # dotfiles へのシンボリックリンクであ
 ```bash
 pi
 > /login
-# OpenCode Go を選択 → ブラウザで OAuth
-> /login
 # ChatGPT (Codex) を選択 → ブラウザで OAuth
 > /login
 # Cursor Agent を選択 → ブラウザで OAuth (pi-cursor-agent)
@@ -62,10 +58,8 @@ pi
 
 サブスクリプションのおすすめ組合せ:
 
-- **OpenCode Go ($10/月)** をメイン
-  - `deepseek-v4-pro`, `kimi-k2.6`, `glm-5.1` 等の Open Model にアクセス
-- **Codex ($20 or $100/月)** をフォールバックの Frontier モデル枠
-  - `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex-spark` 等
+- **Codex ($20 or $100/月)** をメイン
+  - `gpt-5.6-sol`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` 等
 - **Cursor Pro/Team** — pi ハーネス内で Composer / Claude / GPT 等を使う場合
   - `/model cursor-agent/composer-2-fast` 等 (`enabledModels`: `cursor-agent/*`)
 - Claude Pro/Max は pi 経由だと利用規約上 extra usage 課金になるため非推奨
@@ -108,15 +102,15 @@ pi
 ### 非対話モード (`-p`)
 
 ```bash
-pi --model 'opencode-go/deepseek-v4-pro:high' \
-   --fallback-models 'openai-codex/gpt-5.4:low' \
+pi --model 'openai-codex/gpt-5.6-sol:high' \
+   --fallback-models 'openai-codex/gpt-5.4-mini:medium' \
    -p '<instructions>'
 ```
 
 ### 並列 delegation (pueue)
 
 ```bash
-pueue add -i --print-task-id -- "pi --model 'opencode-go/deepseek-v4-pro:high' -p '<instruction>' < /dev/null"
+pueue add -i --print-task-id -- "pi --model 'openai-codex/gpt-5.4-mini:medium' -p '<instruction>' < /dev/null"
 pueue wait <task-id>
 pueue log <task-id>
 ```


### PR DESCRIPTION
## Summary

pi の利用モデルを Codex と Cursor に限定し、使用しなくなった OpenCode Go / Command Code 依存を除去します。

## Changes

- `pi-commandcode-provider` package を削除し、`enabledModels` を Codex / Cursor に限定
- delegation、workflow、quick question の既定モデルを Codex に変更
- pi / Cursor の関連ドキュメントを現行構成に更新

## Test plan

- [x] `python3 -m json.tool common/pi/.pi/agent/settings.json`
- [x] `node --experimental-strip-types --check` で変更した TypeScript を検証
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`