### PR TITLE
imprv(agents): prefer native Codex harness features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ linux/zsh/.zshrc.local
 .pi-subagents/
 .pi-loop/
 .pi/loops/
+.pi/tasks/
 
 # Python
 __pycache__/

--- a/common/agent/.config/agent/skills/deep-research/SKILL.md
+++ b/common/agent/.config/agent/skills/deep-research/SKILL.md
@@ -1,44 +1,39 @@
 ---
 name: deep-research
-description: "Conduct thorough web research using the pi web research toolchain. Search → fetch → cross-reference → cite. Use when investigating topics, finding solutions to errors, or gathering information from multiple sources."
+description: "Conduct thorough web research using the host agent's native search and fetch tools. Search → fetch → cross-reference → cite. Use when investigating topics, errors, or multiple sources."
 ---
 
 # Deep Web Research
 
-Conduct thorough, multi-source web investigations using the pi research toolchain.
+Conduct thorough, multi-source web investigations with the current runtime's native tools.
 
 ## Toolchain Protocol
 
-Follow this exact sequence for all research:
+- **Pi:** `web_search` → `web_cache_lookup` → `web_fetch` → `web_cache_write` → `web_citation_add`.
+- **Codex:** use native web search, open the primary sources it finds, and return their URLs.
+- If Pi `web_search` is unavailable, delegate only the search to Codex with:
 
+```sh
+codex --search exec --skip-git-repo-check --ephemeral \
+  -c model_reasoning_effort=medium \
+  "Search for <topic>. Return primary-source URLs and exact supporting quotes."
 ```
-web_search (discovery)
-  ↓
-web_cache_lookup (check cache first)
-  ↓
-web_fetch (source retrieval — call once per URL)
-  ↓
-web_cache_write (persist findings)
-  ↓
-web_citation_add (track sources)
-  ↓
-web_citation_list (summarize with citations)
-```
+
+Fetch and verify the returned sources in the parent session when possible.
 
 ## Rules
 
 1. **Search is for discovery only** — Never rely on search snippets as your answer. Always fetch the full source content.
 2. **Multiple sources** — Search with at least 2 different query variations. Cross-reference findings.
 3. **Primary sources first** — Official docs > source code > reputable blogs > forums > social media.
-4. **Cache everything** — Use `web_cache_write` after fetching useful content. This prevents redundant requests.
-5. **Check cache first** — Use `web_cache_lookup` before `web_fetch` to avoid redundant requests.
-6. **Cite everything** — Use `web_citation_add` for every source that informed your answer.
+4. **Cache when available** — In Pi, check `web_cache_lookup` before fetching and store useful content with `web_cache_write`.
+5. **Cite everything** — In Pi, use `web_citation_add`; otherwise retain source URLs in the answer.
 7. **Note contradictions** — If sources disagree, mark the conflicting one with `relevance: "contradictory"`.
 8. **State uncertainty** — If information is unverified, say so explicitly.
 
 ## Search Strategy
 
-Use `web_search` with these query variations:
+Use the runtime's native search with these query variations:
 
 ```
 1. Exact error message (quoted)
@@ -59,7 +54,7 @@ When presenting research results:
 
 ## Sources
 
-[List from web_citation_list]
+[List from web_citation_list or the retained source URLs]
 
 ## Unresolved / Uncertain
 
@@ -68,4 +63,4 @@ When presenting research results:
 
 ## Cache Location
 
-All cached content is stored in `~/.pi/research/`.
+Pi cached content is stored in `~/.pi/research/`; Codex uses its native search storage.

--- a/common/agent/.config/agent/skills/docs-research/SKILL.md
+++ b/common/agent/.config/agent/skills/docs-research/SKILL.md
@@ -33,11 +33,13 @@ go list -m <module-path>
 
 ### 2. Search for Documentation
 
-Use `web_search` with the package name and the installed version in the query:
+Use the runtime's native search with the package name and installed version. In Pi, call `web_search`; in Codex, use native web search. If Pi search is unavailable, follow the Codex fallback in the `deep-research` skill.
+
+Search for:
 
 ```
-web_search("<package-name> <installed-version> documentation")
-web_search("<package-name> <installed-version> changelog OR release notes")
+<package-name> <installed-version> documentation
+<package-name> <installed-version> changelog OR release notes
 ```
 
 ### 3. Fetch Official Sources
@@ -45,19 +47,13 @@ web_search("<package-name> <installed-version> changelog OR release notes")
 Prioritize in this order:
 
 1. **Official documentation** — docs.{package}.com, package docs URL
-2. **GitHub README / docs directory** — find the repo via `web_search`, then `git clone --depth 1` and read locally (see the github-research skill)
+2. **GitHub README / docs directory** — find the repo with native search, then `git clone --depth 1` and read locally (see the github-research skill)
 3. **Release notes / changelog** — GitHub releases, CHANGELOG.md
 4. **API reference** — JSDoc, OpenAPI spec, type definitions
 
 ### 4. Cache Findings
 
-After fetching useful documentation (`web_fetch` already auto-caches; use
-`web_cache_write` only to store content you assembled yourself):
-
-```
-web_cache_write(url, content)
-web_citation_add(url, title, note)
-```
+In Pi, rely on `web_fetch` auto-caching, use `web_cache_write` only for assembled content, and call `web_citation_add`. In Codex, retain each source URL for the final answer.
 
 ### 5. Present Findings
 
@@ -76,7 +72,7 @@ Structure your answer:
 
 ## Sources
 
-<Citations from web_citation_list>
+<Citations from web_citation_list or retained source URLs>
 ```
 
 ## Rules

--- a/common/agent/.config/agent/skills/github-delegate/SKILL.md
+++ b/common/agent/.config/agent/skills/github-delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-delegate
-description: サブエージェントにタスクを委譲します。設計・レビュー・デバッグ・実装を並列化します。
+description: read-onlyの設計・レビュー・調査をサブエージェントへ委譲します。repository編集は親sessionに残します。
 user-invocable: true
 arguments: "<task-description> [high|medium|low]"
 ---
@@ -8,12 +8,22 @@ arguments: "<task-description> [high|medium|low]"
 # Delegate - サブエージェント委譲
 
 ## 手順
-1. タスクの難易度を判定（high=設計/レビュー/デバッグ, medium=実装, low=要約/抽出）
-2. `delegate_agent` ツールでサブエージェントを起動
-3. 非同期の場合は `check_delegation` + `wait_delegation` で結果を回収
-4. 結果を親セッションに統合
+
+1. タスクの難易度を判定（high=設計/レビュー/デバッグ、medium=調査、low=要約/抽出）
+2. Piではadvisory・調査に`subagent`、pueue backgroundが必要な場合だけ`delegate_agent`を使う
+3. Codexではnative subagentを使う
+4. PiのWeb検索が利用不能な場合は、検索だけを次で委譲する
+
+```sh
+codex --search exec --skip-git-repo-check --ephemeral \
+  -c model_reasoning_effort=medium \
+  "<self-contained research task; require primary-source URLs and exact quotes>"
+```
+
+5. 結果を親セッションで検証・統合する。repositoryへの編集は親だけが行う
 
 ## 注意事項
-- 独立したタスクは async で並列化する
-- 依存関係がある場合は sync で逐次実行
-- 親セッションのコンテキストを明示的に渡す
+
+- 独立したread-onlyタスクだけを並列化する
+- 親セッションの履歴は渡らないため、必要な背景と期待する出力を明記する
+- Codexではnative Web検索とnative subagentを用途に応じて使い分ける

--- a/common/agent/.config/agent/skills/github-research/SKILL.md
+++ b/common/agent/.config/agent/skills/github-research/SKILL.md
@@ -17,10 +17,12 @@ Investigate GitHub repositories, issues, PRs, and source code using a clone-firs
 
 ### 1. Locate the Repository
 
-Use `web_search` to find the repository (restrict to GitHub):
+Use the runtime's native search to find the repository, restricted to GitHub. In Pi, call `web_search`; in Codex, use native web search. If Pi search is unavailable, follow the Codex fallback in the `deep-research` skill.
+
+Search for:
 
 ```
-web_search("site:github.com <topic OR package-name>")
+site:github.com <topic OR package-name>
 ```
 
 ### 2. Clone the Repository

--- a/common/agent/.config/agent/skills/mcp-research/SKILL.md
+++ b/common/agent/.config/agent/skills/mcp-research/SKILL.md
@@ -10,8 +10,9 @@ MCP toolは、local read / web researchより対象serverの情報が適して�
 
 ## Rules
 
-- `~/.config/agent/mcp.json` を確認し、`enabled: false` のserverを使える前提にしない。
-- sessionに登録された `mcp_<server>_<tool>` だけを利用する。
+- Piでは`~/.config/agent/mcp.json`を確認し、`enabled: false`のserverを使える前提にしない。
+- Codexでは`codex mcp list`とsessionのtool一覧を確認する。
+- runtimeが実際に登録したMCP toolだけを利用し、tool名を推測しない。
 - 最小のserver・toolを選び、取得範囲を絞る。
 - write、外部投稿、browser操作はpermission policyに従う。
 - secret、credential、private source全文をremote serverへ送らない。
@@ -26,7 +27,7 @@ MCP toolは、local read / web researchより対象serverの情報が適して�
 | `serena` | disabled | project code navigation |
 | `token-optimizer` | disabled | context最適化 |
 
-projectの `.mcp.json` / `.pi/mcp.json` でserverが追加・overrideされるため、固定一覧ではなく実際のregistered toolを優先する。
+Piではprojectの`.mcp.json` / `.pi/mcp.json`でserverが追加・overrideされる。Codexのplugin/MCP構成は別管理なので、どちらも固定一覧より実際のregistered toolを優先する。
 
 ## 手順
 
@@ -38,4 +39,4 @@ projectの `.mcp.json` / `.pi/mcp.json` でserverが追加・overrideされる�
 
 ## Permission / Audit
 
-MCP toolの `allow` / `ask` / `deny` はpiのpermission policyが決める。gatewayはresultを既定8000文字に制限し、呼び出しを `~/.pi/research/mcp-audit.jsonl` へ記録する。
+PiではMCP toolの`allow` / `ask` / `deny`をpi-permission-systemが決め、gatewayが呼び出しを`~/.pi/research/mcp-audit.jsonl`へ記録する。CodexではCodexのapproval・permission policyに従う。

--- a/common/codex/.codex/AGENTS.md
+++ b/common/codex/.codex/AGENTS.md
@@ -1,0 +1,16 @@
+# Codex Global Instructions
+
+## Project context
+
+- Follow the nearest `AGENTS.md`; when absent, `CLAUDE.md` is the configured fallback.
+- Shared skills are installed in `~/.codex/skills/`. Read the matching `SKILL.md` before acting.
+- Preserve the existing language in documentation and code comments.
+
+## Execution
+
+- Read the existing implementation and trace callers before editing.
+- Prefer repository code, the standard library, and native Codex features over new wrappers or dependencies.
+- Use native web search and native subagents. Delegate bulky research or long output, but keep repository edits in the parent agent.
+- Never expose secrets in commands, logs, output, or commits. Do not read `.env*`, private keys, credentials, or production dumps.
+- Stage and commit only explicit paths; never use catch-all `git add` flags or `git commit -a`.
+- Run relevant tests and type checks before finishing.

--- a/common/codex/.codex/config.toml
+++ b/common/codex/.codex/config.toml
@@ -1,13 +1,38 @@
-# codex は notify(単一プログラム)のみで turn 完了時に呼ばれる。引数末尾に JSON が
-# 付くが tmux-claude-pane.sh set は $2 のみ参照するため無害。turn 完了=入力待ち→ idle。
-# 注: codex は実行中の heartbeat イベントが無いため running/ハング検知は対象外。
-notify = ["/home/matsushima/dotfiles/scripts/tmux-claude-pane.sh", "set", "idle"]
+# install.sh が templates/codex-config.toml から生成するruntime設定と同じ基本方針。
+# lifecycle hooksの絶対パスはtemplate側でHOMEに合わせて生成する。
+notify = ["/home/matsushima/dotfiles/scripts/tmux-claude-pane.sh", "set", "idle", "codex"]
 model = "gpt-5.6-sol"
-model_reasoning_effort = "low"
-approval_policy = "never"
+model_reasoning_effort = "medium"
+personality = "pragmatic"
+service_tier = "fast"
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
 default_permissions = "repo-autonomous"
+allow_login_shell = true
+project_doc_fallback_filenames = ["CLAUDE.md"]
 
-# 確認なしで現在の workspace 内（Git metadataを含む）を完全に操作する。
+[shell_environment_policy]
+inherit = "all"
+experimental_use_profile = true
+
+[features]
+goals = true
+memories = true
+multi_agent = true
+
+[notice]
+fast_default_opt_out = false
+
+[desktop]
+preventSleepWhileRunning = true
+"show-context-window-usage" = true
+"hotkey-window-projectless-default-enabled" = false
+"enabled-reasoning-efforts" = ["low", "medium", "high", "xhigh", "ultra", "max"]
+
+[plugins."github@openai-curated"]
+enabled = true
+
+# workspace内（Git metadataを含む）は自律操作し、範囲外だけ確認する。
 # Mac 全体への書き込みは許可しない。
 # permission profiles と旧 sandbox/sandbox_workspace_write は併用不可。
 [permissions.repo-autonomous]
@@ -22,7 +47,12 @@ description = "Autonomous work limited to the active repository and GitHub"
 [permissions.repo-autonomous.filesystem.":workspace_roots"]
 "." = "write"
 ".git/**" = "write"
-"**/*.env" = "deny"
+"**/.env" = "deny"
+"**/.env.*" = "deny"
+"**/*.pem" = "deny"
+"**/*.key" = "deny"
+"**/*.p12" = "deny"
+"**/*.pfx" = "deny"
 
 [permissions.repo-autonomous.network]
 enabled = true

--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -36,8 +36,9 @@
 ## Delegation
 
 - advisory / explorationは `subagent`（pi-subagents）。
-- pueue backgroundとdifficulty tierが必要なら `delegate_agent`。
-- `high`: kimi-k2.6、`medium`: deepseek-v4-pro、`low`: deepseek-v4-flash。
+- pueue backgroundとdifficulty tierが必要な場合だけ `delegate_agent`。
+- `delegate_agent` のtierは `high`: gpt-5.6-sol、`medium`: gpt-5.4-mini、`low`: gpt-5.3-codex-spark。
+- Piの`web_search`が利用不能なら、共有`deep-research` skillに従いCodex native searchへephemeral委譲する。
 - 同じworking treeへ複数writerを置かない。reviewer / scoutはread-onlyにする。
 
 ## Workflow

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -47,6 +47,7 @@
 
 ### その他
 
+- [Codex CLI](ai-agents/codex/overview.md)
 - [Command Code](ai-agents/commandcode/overview.md)
 - [Cursor Agent CLI](ai-agents/cursor/overview.md)
 - [Ralph](ai-agents/ralph/overview.md)

--- a/docs/ai-agents/codex/overview.md
+++ b/docs/ai-agents/codex/overview.md
@@ -1,0 +1,47 @@
+# Codex CLI
+
+> **由来:** **Upstream** Codex CLI・native Web search・subagents / **Configuration** config・global instructions・shared skills・hooks（[区分](../../provenance.md#区分)）
+
+Codexはrepository内の自律作業と、PiからのWeb検索fallback・second opinionに使う。Pi側へCodex native機能を再実装せず、Codexのsandbox、Web検索、goals、memories、multi-agentを利用する。
+
+## 正本
+
+| 対象 | 正本 |
+|---|---|
+| runtime config | `templates/codex-config.toml`（`install.sh`が`__HOME__`を展開） |
+| global instructions | `common/codex/.codex/AGENTS.md` |
+| shared skills | `common/agent/.config/agent/skills/` |
+| lifecycle hooks | `templates/codex-config.toml` |
+
+`common/codex/.codex/config.toml`はStow単体利用時の基本設定であり、通常の`install.sh`ではtemplateから生成した設定がruntimeの正本となる。
+
+## 主要設定
+
+- `model_reasoning_effort = "medium"`: 対話速度を保ちつつ、`low`で起きやすい調査精度低下を避ける。
+- `project_doc_fallback_filenames = ["CLAUDE.md"]`: `AGENTS.md`がないprojectでも既存のproject規則を読む。
+- `service_tier = "fast"`: 対話latencyを優先する。
+- `goals` / `memories` / `multi_agent`: Codex native機能を使う。
+- `approval_policy = "on-request"` + `repo-autonomous`: repository内は自律実行し、範囲外だけ確認する。
+
+## Shared skills
+
+`install.sh`は`common/agent/.config/agent/skills/*`を`~/.codex/skills/`へsymlinkする。既存の非symlink skillは上書きしない。research skillはruntimeを判別し、Codexではnative search、Piでは`web_*` toolsを使う。
+
+## PiからのWeb検索fallback
+
+Piの`web_search` backendが利用不能な場合だけ、共有`deep-research` skillに従って検索を委譲する。
+
+```bash
+codex --search exec --skip-git-repo-check --ephemeral \
+  -c model_reasoning_effort=medium \
+  "Search for <topic>. Return primary-source URLs and exact supporting quotes."
+```
+
+repositoryへの編集は親sessionだけが行い、Codexの検索結果はURLまたは原典で再確認する。`--search`はnative Web検索、`multi_agent`はnative subagentの設定として独立に管理する。
+
+## 検証
+
+```bash
+scripts/test-codex-config.sh
+codex features list
+```

--- a/docs/ai-agents/pi/agent-layer.md
+++ b/docs/ai-agents/pi/agent-layer.md
@@ -22,13 +22,14 @@
 | pi | `settings.json` の `skills` に `~/.config/agent/skills` を指定 |
 | Command Code | shared skill pathを探索し、MCPはinstall時に `cmd mcp add-json` で登録 |
 | Claude Code | Claude固有skillは `~/.claude/skills`。MCPはClaude専用設定から登録 |
-| Cursor / Codex | 対応する標準skillだけ利用し、runtime固有設定は共有しない |
+| Codex | `install.sh` が共有skillを `~/.codex/skills/` へlink。runtime固有設定は `templates/codex-config.toml` |
+| Cursor | 対応する標準skillだけ利用し、runtime固有設定は共有しない |
 
 ## 責任分離
 
 ### Skills
 
-共有skillの正本は `common/agent/.config/agent/skills/<name>/SKILL.md`。pi固有skillとの重複コピーは置かない。Ponytailはpi package / Claude pluginを正本とする。
+共有skillの正本は `common/agent/.config/agent/skills/<name>/SKILL.md`。pi固有skillとの重複コピーは置かない。PiとCodexの双方で利用するskillはruntime固有toolを分岐して記載する。Ponytailはpi package / Claude pluginを正本とする。
 
 ### MCP
 

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -97,7 +97,7 @@ pueued -d
 pi
 ```
 
-`AGENTS.md` の指示に従い、必要に応じてサブエージェント (別 pi インスタンス) を spawn する設計。
+`AGENTS.md` の指示に従い、advisory / explorationは`pi-subagents`、pueue backgroundだけcustom `delegate_agent`を使う。PiのWeb検索が利用不能な場合は共有`deep-research` skillからCodex native searchへephemeral委譲する。
 
 ### 非対話モード (`-p`)
 
@@ -123,7 +123,7 @@ pueue log <task-id>
 
 詳細は [web-research.md](web-research.md) を参照。
 
-dotfiles の拡張により Web Research Layer が利用可能。SearXNG + Jina + ローカルキャッシュで API key 不要の調査基盤。
+dotfiles の拡張により Web Research Layer が利用可能。通常はSearXNG + Jina + ローカルキャッシュを使い、検索backendが利用不能な場合だけ`codex --search exec --ephemeral`のnative searchへfallbackする。Codexには`medium` reasoning、primary-source URL、根拠quoteを要求し、親sessionで取得元を検証する。
 
 ## カスタマイズ
 

--- a/install.sh
+++ b/install.sh
@@ -304,6 +304,36 @@ cleanup_broken_skill_links() {
   done
 }
 
+link_codex_skills() {
+  local src="$1" dest="$2" skill_dir skill_name target_dir current
+  [[ -d "$src" ]] || return 0
+  mkdir -p "$dest"
+
+  for skill_dir in "$src"/*/; do
+    [[ -d "$skill_dir" ]] || continue
+    skill_dir=${skill_dir%/}
+    skill_name=$(basename "$skill_dir")
+    target_dir="$dest/$skill_name"
+
+    if [[ -L "$target_dir" ]]; then
+      current=$(readlink "$target_dir")
+      if [[ "$current" == "$skill_dir" ]]; then
+        continue
+      fi
+      case "$current" in
+        */common/agent/.config/agent/skills/"$skill_name") ;;
+        *) log_warn "  Kept externally managed Codex skill: $skill_name"; continue ;;
+      esac
+    elif [[ -e "$target_dir" ]]; then
+      log_warn "  Kept unmanaged Codex skill: $skill_name"
+      continue
+    fi
+
+    ln -sfn "$skill_dir" "$target_dir"
+    log_success "  Linked Codex skill: $skill_name"
+  done
+}
+
 # Clean up orphaned (non-symlink) files left behind in stow-managed directories.
 # stow --adopt only handles files present in the stow package. Files that exist
 # only in the target directory are ignored, causing stale configs to persist.
@@ -709,6 +739,9 @@ for name, config in servers.items():
       log_success "  ~/.codex/config.toml already current"
     fi
   fi
+
+  # Shared Agent Skills for Codex. Keep runtime/plugin-managed entries intact.
+  link_codex_skills "$DOTFILES_DIR/common/agent/.config/agent/skills" "$HOME/.codex/skills"
 
   # Gemini CLI
   if [[ -f "$templates_dir/gemini-settings.json" ]]; then
@@ -1211,4 +1244,6 @@ print_install_summary() {
   echo "────────────────────────────────────────────────────────"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/test-codex-config.sh
+++ b/scripts/test-codex-config.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/codex"
+sed "s|__HOME__|$tmp/home|g" "$root/templates/codex-config.toml" > "$tmp/codex/config.toml"
+
+python3 - "$tmp/codex/config.toml" "$root/common/codex/.codex/config.toml" <<'PY'
+import sys, tomllib
+
+with open(sys.argv[1], "rb") as f:
+    generated = tomllib.load(f)
+with open(sys.argv[2], "rb") as f:
+    fallback = tomllib.load(f)
+
+keys = (
+    "model", "model_reasoning_effort", "personality", "service_tier",
+    "approval_policy", "approvals_reviewer", "default_permissions",
+    "allow_login_shell", "project_doc_fallback_filenames",
+    "shell_environment_policy", "features", "notice", "desktop", "plugins",
+)
+for key in keys:
+    assert generated[key] == fallback[key], key
+generated_policy = generated["permissions"]["repo-autonomous"]
+fallback_policy = fallback["permissions"]["repo-autonomous"]
+assert generated_policy["description"] == fallback_policy["description"]
+assert generated_policy["network"] == fallback_policy["network"]
+assert generated_policy["filesystem"][":minimal"] == fallback_policy["filesystem"][":minimal"]
+for pattern in (".", ".git/**", "**/.env", "**/.env.*", "**/*.pem", "**/*.key", "**/*.p12", "**/*.pfx"):
+    assert generated_policy["filesystem"][":workspace_roots"][pattern] == fallback_policy["filesystem"][":workspace_roots"][pattern]
+PY
+
+for skill in "$root"/common/agent/.config/agent/skills/*/SKILL.md; do
+  grep -q '^name:' "$skill"
+  grep -q '^description:' "$skill"
+done
+
+# Source functions without running main, then exercise every Codex skill-link branch.
+HOME="$tmp/home"
+# shellcheck disable=SC1091
+source "$root/install.sh"
+src="$tmp/source/common/agent/.config/agent/skills"
+dest="$HOME/.codex/skills"
+mkdir -p "$src"/{new,managed,external,plain} "$dest/plain"
+ln -s "/old/common/agent/.config/agent/skills/managed" "$dest/managed"
+ln -s "/external/skills/external" "$dest/external"
+link_codex_skills "$src" "$dest"
+[[ "$(readlink "$dest/new")" == "$src/new" ]]
+[[ "$(readlink "$dest/managed")" == "$src/managed" ]]
+[[ "$(readlink "$dest/external")" == "/external/skills/external" ]]
+[[ -d "$dest/plain" && ! -L "$dest/plain" ]]
+link_codex_skills "$src" "$dest"
+[[ "$(readlink "$dest/managed")" == "$src/managed" ]]
+
+bash -n "$root/install.sh"
+if command -v codex >/dev/null; then
+  CODEX_HOME="$tmp/codex" codex features list >/dev/null
+  CODEX_HOME="$tmp/codex" codex --search exec --help >/dev/null
+fi
+
+echo "codex config tests: OK"

--- a/templates/codex-config.toml
+++ b/templates/codex-config.toml
@@ -1,5 +1,64 @@
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
+personality = "pragmatic"
+service_tier = "fast"
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
+default_permissions = "repo-autonomous"
+allow_login_shell = true
+project_doc_fallback_filenames = ["CLAUDE.md"]
+
 # Legacy completion callback remains as a fallback for older Codex builds.
 notify = ["__HOME__/dotfiles/scripts/tmux-claude-pane.sh", "set", "idle", "codex"]
+
+[shell_environment_policy]
+inherit = "all"
+experimental_use_profile = true
+
+[features]
+goals = true
+memories = true
+multi_agent = true
+
+[notice]
+fast_default_opt_out = false
+
+[desktop]
+preventSleepWhileRunning = true
+"show-context-window-usage" = true
+"hotkey-window-projectless-default-enabled" = false
+"enabled-reasoning-efforts" = ["low", "medium", "high", "xhigh", "ultra", "max"]
+
+[plugins."github@openai-curated"]
+enabled = true
+
+# Confirm operations outside the repository while allowing autonomous work inside it.
+[permissions.repo-autonomous]
+description = "Autonomous work limited to the active repository and GitHub"
+
+[permissions.repo-autonomous.filesystem]
+":minimal" = "read"
+"__HOME__/.config/gh/**" = "read"
+"/opt/homebrew/bin/gh" = "read"
+"/opt/homebrew/Cellar/gh/**" = "read"
+
+[permissions.repo-autonomous.filesystem.":workspace_roots"]
+"." = "write"
+".git/**" = "write"
+"**/.env" = "deny"
+"**/.env.*" = "deny"
+"**/*.pem" = "deny"
+"**/*.key" = "deny"
+"**/*.p12" = "deny"
+"**/*.pfx" = "deny"
+
+[permissions.repo-autonomous.network]
+enabled = true
+
+[permissions.repo-autonomous.network.domains]
+"github.com" = "allow"
+"*.github.com" = "allow"
+"**.githubusercontent.com" = "allow"
 
 # Codex 0.135+ stable lifecycle hooks.
 [hooks]


### PR DESCRIPTION
## Summary

Codexのnative harness機能を主軸にし、Pi側で重複実装せずにWeb検索・subagentへfallbackできる構成へ整理します。

## Changes

- Codexをmedium reasoning、fast tier、goals/memories/multi-agent、`CLAUDE.md` fallback、GitHub plugin構成へ更新
- repository内自律実行と範囲外確認、`.env*`・private key保護をpermission profileへ追加
- global `AGENTS.md`と共有Agent Skillsの安全・冪等なCodex配布を追加
- PiのWeb検索失敗時に`codex --search exec --ephemeral`へ委譲するcross-runtime research手順を追加
- Codex設定・skill link分岐・template parityを検証するテストと運用ドキュメントを追加

## Test plan

- [x] `scripts/test-codex-config.sh`
- [x] `scripts/test-install-fast-paths.sh`
- [x] `shellcheck scripts/test-codex-config.sh`
- [x] `bash -n install.sh`
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`
- [x] `git diff --check`
