### PR TITLE
imprv(pi): pin delegated agent model usage

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -35,7 +35,7 @@
 
 ## Delegation
 
-- advisory / explorationは `subagent`（pi-subagents）。
+- advisory / explorationは `subagent`（pi-subagents）。`subagent` と `workflow` の子モデルは設定済みの gpt-5.4-mini:medium を使い、呼び出し時に `model` を指定しない。
 - pueue backgroundとdifficulty tierが必要な場合だけ `delegate_agent`。
 - `delegate_agent` のtierは `high`: gpt-5.6-sol、`medium`: gpt-5.4-mini、`low`: gpt-5.3-codex-spark。
 - Piの`web_search`が利用不能なら、共有`deep-research` skillに従いCodex native searchへephemeral委譲する。

--- a/common/pi/.pi/agent/settings.json
+++ b/common/pi/.pi/agent/settings.json
@@ -2,6 +2,16 @@
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "medium",
+  "subagents": {
+    "defaultModel": "openai-codex/gpt-5.4-mini",
+    "defaultThinking": "medium",
+    "modelScope": {
+      "enforce": true,
+      "allow": [
+        "openai-codex/gpt-5.4-mini"
+      ]
+    }
+  },
   "enabledModels": [
     "openai-codex/*",
     "cursor-agent/*"

--- a/common/pi/.pi/workflows/model-tiers.json
+++ b/common/pi/.pi/workflows/model-tiers.json
@@ -1,0 +1,7 @@
+{
+  "tiers": {
+    "small": "openai-codex/gpt-5.4-mini:medium",
+    "medium": "openai-codex/gpt-5.4-mini:medium",
+    "big": "openai-codex/gpt-5.4-mini:medium"
+  }
+}

--- a/docs/ai-agents/pi/agent-delegation.md
+++ b/docs/ai-agents/pi/agent-delegation.md
@@ -41,10 +41,12 @@
 
 | ロール | 用途 | 推奨難易度 | モデル |
 |--------|------|:--:|--------|
-| `reviewer` | コードレビュー、セキュリティ監査、品質チェック | high | gpt-5.6-sol |
-| `scout` | コードベース探索、read-only調査、依存関係分析 | medium | gpt-5.4-mini |
-| `worker` | 承認済み計画からの実装 | medium | gpt-5.4-mini |
-| `oracle` | セカンドオピニオン、設計レビュー、前提検証 | high | gpt-5.6-sol |
+| `reviewer` | コードレビュー、セキュリティ監査、品質チェック | high | gpt-5.4-mini:medium |
+| `scout` | コードベース探索、read-only調査、依存関係分析 | medium | gpt-5.4-mini:medium |
+| `worker` | 承認済み計画からの実装 | medium | gpt-5.4-mini:medium |
+| `oracle` | セカンドオピニオン、設計レビュー、前提検証 | high | gpt-5.4-mini:medium |
+
+`pi-subagents` は `settings.json` の `subagents.defaultModel` / `defaultThinking` で固定し、`modelScope` で呼び出し時の別モデル指定を拒否する。`pi-dynamic-workflows` は `~/.pi/workflows/model-tiers.json` の全tierを同じモデルへ割り当てる。変更時は両方を同時に更新する。
 
 ## Model Auto-Selection
 

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -129,7 +129,9 @@ dotfiles の拡張により Web Research Layer が利用可能。通常はSearXN
 
 ### モデル選択を変更する
 
-`common/pi/.pi/agent/extensions/agent-delegation.ts` の `MODEL_TIERS` を編集し、piを再起動する。runtimeの利用方針だけを `AGENTS.md` に記載する。
+`subagent` の固定モデルは `common/pi/.pi/agent/settings.json` の `subagents.defaultModel` / `defaultThinking` / `modelScope.allow`、`workflow` は `common/pi/.pi/workflows/model-tiers.json` の全tierで管理する。両方を同じモデルへ変更してpiを再起動する。
+
+pueue用の `delegate_agent` だけは独立しているため、必要なら `common/pi/.pi/agent/extensions/agent-delegation.ts` の `MODEL_TIERS` を編集する。runtimeの利用方針は `AGENTS.md` に記載する。
 
 ### TUI テーマ
 


### PR DESCRIPTION
## Summary
Pin `subagent` and `workflow` child agents to `openai-codex/gpt-5.4-mini:medium` instead of allowing automatic selection to choose `sol-high`.

## Changes
- Configure `pi-subagents` default model, thinking level, and model scope.
- Configure all workflow model tiers to the same model.
- Document the two configuration points.

## Test plan
- [x] Validate JSON configuration.
- [x] Run Markdown link and package duplication checks.