### PR TITLE
imprv(agents): show Cursor limits in status views

### DIFF
--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -3,13 +3,13 @@
 // Balanced telemetry footer with:
 //   Focus rail: goal + extension status
 //   Core rail: branch + model | context gauge
-//   Telemetry rail: tokens | cost | agents | web | MCP
+//   Telemetry rail: tokens | cost | Cursor limits | agents | web | MCP
 //   3 modes: detailed / compact / off (toggle via /statusline)
 
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -109,6 +109,20 @@ function readGoal(): string {
 // Active delegated sub-agents (pueue tasks labeled pi-delegate). Refreshed off
 // the render path (turn_end / session_start) since `pueue status` shells out.
 let agentStatus = { running: 0, queued: 0 };
+let cursorLimits = "";
+
+function refreshCursorLimits(): void {
+  try {
+    const rows = execFileSync("ai-usage", ["cursor"], {
+      encoding: "utf-8", timeout: 6000, stdio: ["ignore", "pipe", "ignore"],
+    }).trim().split("\n");
+    cursorLimits = rows.map((row) => {
+      const [, label, , pct, remaining] = row.split("\x1f");
+      return label && label !== "--" ? `${label} ${pct}${remaining ? ` ${remaining}` : ""}` : "";
+    }).filter(Boolean).join(" · ");
+  } catch { cursorLimits = ""; }
+}
+
 function refreshAgents(): void {
   let running = 0, queued = 0;
   try {
@@ -210,6 +224,7 @@ export default function (pi: ExtensionAPI) {
     if (mode === "off") return;
     recomputeTokens(ctx.sessionManager.getBranch());
     refreshAgents();
+    refreshCursorLimits();
     const now = Date.now();
     if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
       dirtyState = checkGitDirty(); lastDirtyCheck = now;
@@ -226,6 +241,7 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     recomputeTokens(ctx.sessionManager.getBranch());
     refreshAgents();
+    refreshCursorLimits();
     if (mode === "off") {
       ctx.ui.setFooter(undefined);
       return;
@@ -292,6 +308,9 @@ export default function (pi: ExtensionAPI) {
           const tokOut = theme.fg("accent", `↓${formatTokens(output)}`);
           const tokenStr = `${label("TOK")} ${tokIn}${minor}${tokOut}`;
           const costStr = `${label("COST")} ${theme.fg("syntaxNumber", `$${cost.toFixed(3)}`)}`;
+          const limitStr = cursorLimits
+            ? `${label("CURSOR")} ${theme.fg("text", cursorLimits)}`
+            : "";
           const agentStr = agentStatus.running > 0 || agentStatus.queued > 0
             ? `${label("AGT")} ${theme.fg("customMessageLabel", `R${agentStatus.running}`)}${minor}${theme.fg("customMessageLabel", `Q${agentStatus.queued}`)}`
             : "";
@@ -311,7 +330,7 @@ export default function (pi: ExtensionAPI) {
               width >= 100 ? 36 : width >= 70 ? 24 : 14,
             );
             return [packCompact(
-              [compactFocus, gaugeStr, branchStr, modelStr, tokenStr, costStr],
+              [compactFocus, gaugeStr, branchStr, modelStr, limitStr, tokenStr, costStr],
               width,
               minor,
             )];
@@ -320,7 +339,7 @@ export default function (pi: ExtensionAPI) {
           const lines: string[] = [];
           if (goalStr || statusStr) lines.push(balanceLine(goalStr, statusStr, width));
           lines.push(balanceLine(projectStr, gaugeStr, width));
-          lines.push(...wrapGroups([tokenStr, costStr, agentStr, webStr, mcpStr], width, major));
+          lines.push(...wrapGroups([tokenStr, costStr, limitStr, agentStr, webStr, mcpStr], width, major));
           return lines;
         },
       };

--- a/docs/ai-agents/cursor/overview.md
+++ b/docs/ai-agents/cursor/overview.md
@@ -108,7 +108,7 @@ Cursor CLI 内でフッターが見えない場合は `cursor-agent` を再起�
 
 ## tmux 使用量表示
 
-tmux status-right に Claude / Codex / Gemini と並べて Cursor のプラン使用量を表示する (`◆ ▁▁ 2%/3% 29d` 形式)。
+tmux サイドバー (`prefix+b`) と pi のカスタムフッターに Cursor のプラン使用量を表示する。どちらも `ai-usage cursor` の同じキャッシュ済みデータを使う。
 
 | 表示 | 意味 |
 | --- | --- |

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -144,7 +144,7 @@ pueue用の `delegate_agent` だけは独立しているため、必要なら `c
 - `Ctrl+T`: 思考ブロックを展開/折り畳み
 - `Ctrl+O`: ツール出力を展開/折り畳み
 - `Esc` を2回: `/tree` を開く。tree 内の `Ctrl+T` でツール結果を表示/非表示
-- `/statusline compact`: フッターを1行表示に切り替え
+- `/statusline compact`: Cursor のプラン上限を含むフッターを1行表示に切り替え（取得元は `ai-usage cursor`）
 - 入力中の既知 skill 名はアクセント色でハイライトされる（`/reload` または再起動で skill 一覧を再読込）。
 
 ### Permission gate

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -143,12 +143,12 @@ usage_section() {
   {
     local sc out col icon label gauge pct rem
     for sc in claude codex gemini cursor; do
-      # AI ごとの色分け(ステータスバーと同じ): claude=橙 codex=水色 gemini=青 cursor=紫
+      # AI ごとの色分け: claude=橙 codex=水色 gemini=青 cursor=白
       case "$sc" in
         claude) col=$'\033[38;2;255;102;0m' ;;
         codex)  col=$'\033[38;2;125;211;252m' ;;
         gemini) col=$'\033[38;2;66;133;244m' ;;
-        cursor) col=$'\033[38;2;153;102;255m' ;;
+        cursor) col=$'\033[38;2;255;255;255m' ;;
         *)      col="" ;;
       esac
       out=$(${TO:+$TO 6} ai-usage "$sc" 2>/dev/null)


### PR DESCRIPTION
## Summary

OpenCode Go 廃止後の使用量表示を Cursor のプラン上限表示へ置き換え、Pi と tmux で同じ `ai-usage cursor` データを利用します。

## Changes

- Pi statusline の compact / detailed 両モードへ Cursor の total / auto 使用量を追加
- tmux サイドバーの Cursor 表示色をブランドに合わせて白へ変更
- Cursor / Pi ドキュメントを現在の表示先とデータソースに更新

## Test plan

- [x] `cargo test --manifest-path tools/ai-usage/Cargo.toml`
- [x] `scripts/test-tmux-agent-status.sh`
- [x] `shellcheck -S warning -x scripts/tmux-agent-*.sh scripts/tmux-claude-pane.sh scripts/ai-notify.sh`
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`
- [x] `pi --list-models`
- [x] Cursor limit の取得・整形とサイドバーのライブキャッシュ反映を確認
