### PR TITLE
fix(pi): prevent tmux zoom crashes in narrow panes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
         run: scripts/check-package-duplication.sh
       - name: Test Markdown link checker
         run: python3 scripts/test_check_markdown_links.py
-      - name: Test pi-tui narrow terminal patch
-        run: scripts/test-pi-tui-patch.sh
       - name: Validate Markdown links
         run: scripts/check-markdown-links.py
       - name: Validate documentation provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         run: scripts/check-package-duplication.sh
       - name: Test Markdown link checker
         run: python3 scripts/test_check_markdown_links.py
+      - name: Test pi-tui narrow terminal patch
+        run: scripts/test-pi-tui-patch.sh
       - name: Validate Markdown links
         run: scripts/check-markdown-links.py
       - name: Validate documentation provenance

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -9,6 +9,7 @@
 | 要素 | 役割 | 配置 |
 | --- | --- | --- |
 | pi CLI | エージェント本体 | `config/packages.npm.txt` の `@earendil-works/pi-coding-agent` (npm global) |
+| pi-tui narrow terminal patch | tmux focus zoomで1列/1行になった間は描画を停止し、Piの終了とscrollを防止 | `scripts/patch-pi-tui.sh` (Local patch) |
 | pi-cursor-agent | Cursor サブスク → pi プロバイダ | `settings.json` の `packages` → `pi install npm:pi-cursor-agent` |
 | pi-dynamic-workflows | Claude Code-style workflow / fan-out orchestration | `settings.json` の `packages` → `pi install npm:@quintinshaw/pi-dynamic-workflows` |
 | pi-loop | dynamic goal loop、cron/event re-wake loop、background monitor | `settings.json` の `packages` → `pi install npm:@trevonistrevon/pi-loop` |
@@ -33,7 +34,7 @@ cd ~/dotfiles
 ./install.sh
 ```
 
-`install_npm_packages` が `@earendil-works/pi-coding-agent` を含めて global install する。`stow` で `common/pi/` がリンクされ `~/.pi/agent/AGENTS.md` が配置される。
+`install_npm_packages` が `@earendil-works/pi-coding-agent` を含めて global installし、続けて`patch-pi-tui.sh`を適用する。pi-tui 0.84.1はterminal幅1で幅3の行を描画すると例外終了するため、極小paneの間だけ描画を停止するlocal patchを再適用可能な形で管理する。`stow` で `common/pi/` がリンクされ `~/.pi/agent/AGENTS.md` が配置される。
 
 確認:
 

--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -89,6 +89,10 @@ install_npm_packages() {
       log_success "$pkg already installed"
     fi
   done < <(read_package_list "$npm_file")
+
+  # pi-tui 0.84.1でも、tmux focus zoomでpaneが1列/1行になると描画例外でPiが終了する。
+  # npm更新のたびに再現可能なlocal patchを適用する。
+  "$DOTFILES_DIR/scripts/patch-pi-tui.sh"
 }
 
 install_claude_mem() {

--- a/scripts/patch-pi-tui.sh
+++ b/scripts/patch-pi-tui.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# pi-tui が tmux の極小 pane (1列/1行) で描画して例外終了するのを防ぐ local patch。
+set -euo pipefail
+
+dist_dir="${PI_TUI_DIST_DIR:-$(npm root -g)/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui/dist}"
+
+node - "$dist_dir" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dir = process.argv[2];
+const files = ["tui-main-screen.js", "tui.js"];
+const needle = `    doRender() {
+        if (this.stopped)
+            return;
+        const width = this.terminal.columns;
+        const height = this.terminal.rows;
+`;
+const replacement = `${needle}        // Local patch: tmux focus zoom may temporarily reduce a sibling pane to 1 row/column.
+        // Suspend rendering until it is visible again; rendering at that size crashes and scrolls the terminal.
+        if (width < 4 || height < 2)
+            return;
+`;
+let found = 0;
+
+for (const name of files) {
+  const file = path.join(dir, name);
+  if (!fs.existsSync(file)) continue;
+  const source = fs.readFileSync(file, "utf8");
+  if (source.includes("Local patch: tmux focus zoom")) {
+    found++;
+    continue;
+  }
+  if (!source.includes(needle)) continue;
+  fs.writeFileSync(file, source.replace(needle, replacement));
+  found++;
+  console.log(`Patched ${file}`);
+}
+
+if (found === 0) {
+  console.error(`No compatible pi-tui renderer found in ${dir}`);
+  process.exit(1);
+}
+NODE

--- a/scripts/test-pi-tui-patch.sh
+++ b/scripts/test-pi-tui-patch.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+cat > "$tmp/tui.js" <<'JS'
+class TUI {
+    doRender() {
+        if (this.stopped)
+            return;
+        const width = this.terminal.columns;
+        const height = this.terminal.rows;
+        this.render(width, height);
+    }
+}
+JS
+
+PI_TUI_DIST_DIR="$tmp" "$(dirname "$0")/patch-pi-tui.sh" >/dev/null
+PI_TUI_DIST_DIR="$tmp" "$(dirname "$0")/patch-pi-tui.sh" >/dev/null
+
+count=$(grep -c 'Local patch: tmux focus zoom' "$tmp/tui.js")
+[[ "$count" == 1 ]]
+grep -q 'if (width < 4 || height < 2)' "$tmp/tui.js"
+echo "pi-tui narrow terminal patch test passed"


### PR DESCRIPTION
## Summary

Prevent Pi from exiting when tmux focus zoom temporarily reduces a sibling pane to one row or column. Keep this PR limited to the Pi local patch, installer wiring, focused test, and Pi documentation.

## Changes
- Patch compatible `pi-tui` renderers to skip rendering while the terminal is narrower than 4 columns or 2 rows.
- Reapply the idempotent patch after global npm package installation.
- Add focused regression coverage.
- Document the local patch in the Pi setup guide.

## Test plan
- [x] `scripts/test-pi-tui-patch.sh`
- [x] `scripts/test-install-fast-paths.sh`
- [x] `shellcheck -e SC1090 -e SC1091 scripts/patch-pi-tui.sh scripts/test-pi-tui-patch.sh scripts/install-common.sh`
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-doc-provenance.py`
- [x] `scripts/check-package-duplication.sh`
- [x] Independent reviewer: no blocker/high findings

## Integration

The canonical `scripts/check` runner in #336 executes this regression test when the script is present.