### PR TITLE
Improve Pi interactive collaboration controls

### DIFF
--- a/common/pi/.pi/agent/AGENTS.md
+++ b/common/pi/.pi/agent/AGENTS.md
@@ -35,15 +35,17 @@
 
 ## Delegation
 
+- 利用者がdelegation、subagent、workflow、並列調査、またはmulti-agent reviewを明示した場合だけ委譲する。品質向上だけを理由に自動委譲しない。
 - advisory / explorationは `subagent`（pi-subagents）。`subagent` と `workflow` の子モデルは設定済みの gpt-5.4-mini:medium を使い、呼び出し時に `model` を指定しない。
 - pueue backgroundとdifficulty tierが必要な場合だけ `delegate_agent`。
 - `delegate_agent` のtierは `high`: gpt-5.6-sol、`medium`: gpt-5.4-mini、`low`: gpt-5.3-codex-spark。
-- Piの`web_search`が利用不能なら、共有`deep-research` skillに従いCodex native searchへephemeral委譲する。
+- reviewは原則1 passとし、reviewerの提案を新しい要件として扱わない。再reviewは利用者が明示した場合だけ行う。
+- Piの`web_search`が利用不能なら、利用者がWeb調査を依頼した場合に限り、共有`deep-research` skillに従いCodex native searchへephemeral委譲する。
 - 同じworking treeへ複数writerを置かない。reviewer / scoutはread-onlyにする。
 
 ## Workflow
 
-`workflow` は広いaudit、fan-out research、multi-perspective reviewに使う。単一ファイルの小変更には使わない。
+`workflow` は利用者が明示的にopt-inした広いaudit、fan-out research、multi-perspective reviewだけに使う。単一ファイルの小変更や通常の実装検証には使わない。
 
 ## pi-specific extensions
 

--- a/common/pi/.pi/agent/APPEND_SYSTEM.md
+++ b/common/pi/.pi/agent/APPEND_SYSTEM.md
@@ -4,26 +4,32 @@
 - User communication: Japanese (日本語)
 - Documentation and code comments: Preserve the existing language; do not translate them.
 
-## Execution Behavior
-Counters over-caution common in coding agents. Follow unless the user says otherwise.
-- Finish the full requested scope in one pass. Implement end-to-end, including the
-  supporting changes (wiring, types, tests, docs) needed to make it actually work.
-  Do not ship a deliberately minimal/partial version when the request implies more.
-- Do not stop early to save context or cost, and do not split one coherent task into
-  artificial phases. The user owns context and budget; your job is to complete the
-  task. Keep going until it is done or you hit a real blocker.
-- Pause only when genuinely blocked: a decision only the user can make, a truly
-  ambiguous requirement, or a destructive/irreversible action. Otherwise make a
-  reasonable assumption, state it, and proceed — do not ask permission for routine steps.
-- A pure question is not a work request. "how / why / can you / what" asks for an
-  answer, not action; answer it and stop. Do not edit files or run commands off a
-  question. Act only on an explicit request ("do it / fix it / implement it"). When
-  the answer implies a change, state it and let the user decide whether to start.
+## Interaction and Execution
+Classify the user's intent before acting. Follow unless the user explicitly says otherwise.
+- Questions, problem statements, tentative requirements, and requests for advice are
+  discussion, not implementation. Answer them without modifying files or running
+  mutating commands. Read-only investigation is allowed when needed for an accurate answer.
+- Start implementation only after an explicit action request such as "do it", "fix it",
+  or "implement it". If the user asks to discuss, plan, or settle requirements first,
+  wait for explicit implementation approval even when the likely solution seems obvious.
+- Once implementation is explicitly approved, do not interrupt for routine edits,
+  commands, or reasonable implementation details. Make a reasonable assumption, state it,
+  and proceed; ask only about genuinely ambiguous product decisions or irreversible actions.
+- In normal interactive work, deliver a working 70–80% first implementation with the
+  smallest relevant verification, then return control for user review. Do not chase
+  optional polish, broad CI, exhaustive audits, or speculative edge cases. Use full
+  end-to-end completion only when the user explicitly asks to finalize/autonomously finish
+  or activates `/goal`.
+- Never launch subagents, workflows, parallel reviewers, adversarial reviews, or repeat
+  reviews unless the user explicitly requests delegation or multi-agent review. Reviewer
+  suggestions do not expand the requested scope or acceptance criteria.
+- Give concise natural-language progress updates: before the first tool call, after a
+  meaningful milestone, when the approach changes, on an unexpected finding or blocker,
+  and before a long-running command. Do not narrate every command.
 - If you must estimate or phase work, estimate in autonomous execution time (minutes),
-  never human developer time. Never say "this takes a day/week" for work you can do
-  now; prefer doing it now over proposing a future phase.
-- "Nothing more, nothing less" means do not invent unrequested features — it does NOT
-  mean stopping short of a working result. Bias toward completion over deferral.
+  never human developer time.
+- "Nothing more, nothing less" means implement the explicit request as a working result
+  without inventing adjacent features.
 
 ## Design Principles
 - **Root cause over workarounds.** Investigate the actual mechanism before applying a fix.
@@ -40,9 +46,12 @@ Counters over-caution common in coding agents. Follow unless the user says other
   The user decides what is worth doing.
 
 ## Development Workflow
-- Before finishing any task: run type checks and relevant tests.
+- Before returning an implementation, run the smallest relevant type check and tests.
+  Do not run the full CI pipeline or unrelated suites unless explicitly requested.
+- Fix failures caused by the change. Report unrelated pre-existing failures without
+  expanding the task to fix them.
 - Prefer small, reviewable diffs.
-- When behavior changes, update or add tests.
+- When behavior changes, update or add focused tests.
 - Do not edit generated files (dist/, coverage/, .next/, node_modules/) unless regenerating.
 
 ## Safety

--- a/common/pi/.pi/agent/extensions/agent-delegation.ts
+++ b/common/pi/.pi/agent/extensions/agent-delegation.ts
@@ -87,9 +87,9 @@ export default function (pi: ExtensionAPI) {
       "Difficulty auto-selects model: high=gpt-5.6-sol, medium=gpt-5.4-mini, low=gpt-5.3-codex-spark.",
     promptSnippet: "Delegate a task to a sub-agent (reviewer/scout/worker/oracle)",
     promptGuidelines: [
-      "Use delegate_agent for tasks that benefit from a second set of model eyes.",
+      "Use delegate_agent only when the user explicitly requests delegation, subagents, or multi-agent review.",
       "Prefer role names in the task: 'Use reviewer to...', 'Use scout to explore...', 'Use oracle for a second opinion on...'.",
-      "Run parallel reviewers for different concerns: correctness, tests, complexity.",
+      "Run at most one review pass unless the user explicitly requests another; reviewer suggestions do not expand the task scope.",
       "Use async mode (default) for independent work. Use sync for sequential dependencies.",
       "Difficulty: high=review/design/debug, medium=coding from plan, low=summaries.",
     ],

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -217,6 +217,21 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  // Keep interrupt/steer controls visible while a run is active. Progress
+  // narration stays in the system prompt; this is the deterministic fallback.
+  pi.on("agent_start", async (_event, ctx) => {
+    ctx.ui.setStatus("run-control", "RUN · Esc/Ent");
+  });
+  pi.on("tool_execution_start", async (event, ctx) => {
+    ctx.ui.setStatus("run-control", `${event.toolName} · Esc/Ent`);
+  });
+  pi.on("tool_execution_end", async (_event, ctx) => {
+    ctx.ui.setStatus("run-control", "RUN · Esc/Ent");
+  });
+  pi.on("agent_settled", async (_event, ctx) => {
+    ctx.ui.setStatus("run-control", undefined);
+  });
+
   // -----------------------------------------------------------------------
   // Git dirty check
   // -----------------------------------------------------------------------

--- a/common/pi/.pi/agent/extensions/workflow.ts
+++ b/common/pi/.pi/agent/extensions/workflow.ts
@@ -195,7 +195,8 @@ export default function (pi: ExtensionAPI) {
       "Difficulty selects the model tier (high/medium/low).",
     promptSnippet: "Run independent tasks concurrently across sub-agents",
     promptGuidelines: [
-      "Use agent_parallel when tasks are independent and benefit from concurrency.",
+      "Use agent_parallel only when the user explicitly requests parallel or multi-agent work.",
+      "Do not create iterative review loops; one review pass is the default.",
       "Set jsonKeys when you need to machine-read each result.",
       "Set budgetUSD to cap spend; tasks beyond the budget are skipped.",
     ],
@@ -261,7 +262,8 @@ export default function (pi: ExtensionAPI) {
       "Returns the final output per item plus total tokens/cost.",
     promptSnippet: "Run each item through ordered sub-agent stages",
     promptGuidelines: [
-      "Use agent_pipeline for per-item multi-step transforms (summarize→verify, draft→refine).",
+      "Use agent_pipeline only when the user explicitly requests a multi-agent pipeline.",
+      "Do not use repeated critique/refine stages as an open-ended quality loop.",
       "Reference {input} (previous stage output) and {item} (original item) in stage prompts.",
     ],
     parameters: Type.Object({

--- a/common/pi/.pi/agent/pi-goal.json
+++ b/common/pi/.pi/agent/pi-goal.json
@@ -1,0 +1,6 @@
+{
+  "continuationLimits": {
+    "automaticTurns": 4,
+    "noProgressTurns": 2
+  }
+}

--- a/common/pi/.pi/agent/prompts/implement.md
+++ b/common/pi/.pi/agent/prompts/implement.md
@@ -5,6 +5,7 @@ Implement the requested change following the existing codebase patterns.
 ## Rules
 - Prefer existing patterns over new abstractions
 - Keep domain logic out of UI components
-- Add or update tests when behavior changes
-- Run type checks and relevant tests before finishing
+- Add or update focused tests when behavior changes
+- Run the smallest relevant type check and tests before returning the first implementation
+- Do not run broad CI, audits, or subagent reviews unless explicitly requested
 - Do not edit generated files (dist/, coverage/, .next/, node_modules/)

--- a/docs/ai-agents/pi/agent-delegation.md
+++ b/docs/ai-agents/pi/agent-delegation.md
@@ -2,7 +2,7 @@
 
 > **由来:** **Upstream** pi・pueue / **Plugin** pi-subagents / **Configuration** agent定義・model tier / **Custom** agent-delegation拡張（[区分](../../provenance.md#区分)）
 
-サブエージェントによる並列作業委譲の仕組み。pi-subagents（コミュニティ） + agent-delegation.ts（カスタム）の2層構成。
+利用者が明示的にopt-inした場合だけ使うサブエージェント委譲の仕組み。pi-subagents（コミュニティ） + agent-delegation.ts（カスタム）の2層構成。通常実装の品質向上を理由に自動起動せず、reviewは原則1 passとする。
 
 ## Architecture
 
@@ -101,7 +101,7 @@ pueue wait <id>  # 完了待ち
 | **自然言語委譲** | ✅ | ✅ |
 | **インストール** | `pi install npm:pi-subagents` | dotfiles 内蔵 |
 
-両方インストールして併用するのが推奨構成。
+両方を用途別に利用可能にするが、自動選択はしない。reviewerの提案は元のacceptance criteriaを拡張せず、再reviewは利用者が明示した場合だけ行う。
 
 ## Extensions
 

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -13,13 +13,17 @@
 | pi-cursor-agent | Cursor サブスク → pi プロバイダ | `settings.json` の `packages` → `pi install npm:pi-cursor-agent` |
 | pi-dynamic-workflows | Claude Code-style workflow / fan-out orchestration | `settings.json` の `packages` → `pi install npm:@quintinshaw/pi-dynamic-workflows` |
 | pi-loop | dynamic goal loop、cron/event re-wake loop、background monitor | `settings.json` の `packages` → `pi install npm:@trevonistrevon/pi-loop` |
-| pi-goal | `/goal` で完了まで継続する goal mode | `settings.json` の `packages` → `pi install npm:@narumitw/pi-goal` |
+| pi-goal | `/goal` で上限付き自動継続を行う goal mode | `settings.json` の `packages` + `pi-goal.json` |
 | AGENTS.md | グローバル指示書 | `common/pi/.pi/agent/AGENTS.md` → `~/.pi/agent/AGENTS.md` |
 | pueue | バックグラウンドタスク・並列 delegation 用キュー | `config/Brewfile` (mac), `packages.linux.{apt,alpine}.txt` (linux) |
 
-## LoopとGoalの使い分け
+## 対話・Plan・Goalの使い分け
 
-「全件完了まで継続」のように作業完了を停止条件とする実装には`/goal <goal>`を使う。利用者が「loop」と表現しても、時間間隔に意味がなければcron loopへ変換しない。
+通常対話では、質問・課題感・暫定要件を実装依頼として扱わない。`実装して`などの明示後に変更を開始し、動作するfirst implementationと最小の関連検証まで進めて利用者へ制御を返す。実装中の通常のedit/bashはYOLO modeで止めず、方針変更や節目を自然言語で報告する。
+
+要件や方式を先に固める場合は`/plan`を使う。read-onlyで調査・計画し、画面上のExecute選択または明示的な実装指示まで変更しない。
+
+「全件完了まで継続」のように無人完遂を明示する場合だけ`/goal <goal>`を使う。`pi-goal.json`で自動応答を4回、無進捗を2回に制限し、上限到達時は状態を保持して停止する。必要なら利用者が`/goal resume`を選ぶ。利用者が「loop」と表現しても、時間間隔に意味がなければcron loopへ変換しない。
 
 `/loop <goal>`のdynamic loopは、iteration上限内の反復作業に使う。各iterationの完了後に`LoopUpdate`で次回wakeを設定するため、agent実行中のtimer tickでは`maxFires`を消費しないが、iteration上限に達すると終了する。
 
@@ -98,7 +102,7 @@ pueued -d
 pi
 ```
 
-`AGENTS.md` の指示に従い、advisory / explorationは`pi-subagents`、pueue backgroundだけcustom `delegate_agent`を使う。PiのWeb検索が利用不能な場合は共有`deep-research` skillからCodex native searchへephemeral委譲する。
+subagent / workflowは利用者がdelegation、並列調査、multi-agent reviewを明示した場合だけ使う。通常実装の品質向上を理由に自動reviewせず、reviewは原則1 passとする。明示されたpueue backgroundだけcustom `delegate_agent`を使う。PiのWeb検索が利用不能な場合は、Web調査依頼に限り共有`deep-research` skillからCodex native searchへephemeral委譲する。
 
 ### 非対話モード (`-p`)
 
@@ -145,10 +149,13 @@ pueue用の `delegate_agent` だけは独立しているため、必要なら `c
 - `Ctrl+T`: 思考ブロックを展開/折り畳み
 - `Ctrl+O`: ツール出力を展開/折り畳み
 - `Esc` を2回: `/tree` を開く。tree 内の `Ctrl+T` でツール結果を表示/非表示
+- 実行中は現在のtoolと`Esc/Enter`をフッターに表示（`Esc`は停止、`Enter`はsteer）
 - `/statusline compact`: Cursor のプラン上限を含むフッターを1行表示に切り替え（取得元は `ai-usage cursor`）
 - 入力中の既知 skill 名はアクセント色でハイライトされる（`/reload` または再起動で skill 一覧を再読込）。
 
 ### Permission gate
+
+`permission-system.json`の`yoloMode`と`settings.json`の`hideThinkingBlock`は有効のままにする。対話の承認境界はwrite permissionではなく、明示的な実装指示と`/plan`で管理するため、実装開始後の通常操作は止めない。
 
 `common/pi/.pi/agent/extensions/permission-gate.ts`はdangerous shell commandを実行前に確認する。agentはセッション開始時のmain repositoryまたは既存worktreeで実装し、利用者の明示なしに別worktreeへ移動しない。worktree capacity追加は確認対象ではなくhard denyし、`git worktree add`と`pnpm wt provision`は実行しない。利用者が明示した既存pooled slotのclaim/listは許可する。capacity追加が必要な場合は利用者がpi外のterminalから実行する。
 

--- a/scripts/test-pi-statusline.sh
+++ b/scripts/test-pi-statusline.sh
@@ -16,7 +16,8 @@ printf '%s' 'Refine the pi statusline' >"$tmp/home/.pi/agent/goal"
 printf '%s\n' '#!/bin/sh' \
   'printf '\''%s'\'' '\''{"tasks":{"1":{"label":"pi-delegate","status":"Running"},"2":{"label":"pi-delegate","status":"Queued"}}}'\''' \
   >"$tmp/bin/pueue"
-chmod +x "$tmp/bin/pueue"
+printf '%s\n' '#!/bin/sh' 'exit 1' >"$tmp/bin/ai-usage"
+chmod +x "$tmp/bin/pueue" "$tmp/bin/ai-usage"
 
 cd "$tmp"
 HOME="$tmp/home" PATH="$tmp/bin:$PATH" node --experimental-strip-types --preserve-symlinks --input-type=module - "$tmp" <<'JS'
@@ -30,6 +31,7 @@ const commands = new Map();
 let footerFactory;
 let contextPercent = 42;
 let reloaded = false;
+const statuses = new Map([["stash", "📝 STASHED"]]);
 
 registerStatusline({
   registerCommand: (name, options) => commands.set(name, options),
@@ -54,12 +56,15 @@ const ctx = {
   model: { id: "gpt-5.6-sol", contextWindow: 100000 },
   ui: {
     setFooter: (factory) => { footerFactory = factory; },
+    setStatus: (key, value) => value === undefined ? statuses.delete(key) : statuses.set(key, value),
     notify: () => {},
   },
   reload: async () => { reloaded = true; },
 };
 
 for (const handler of handlers.get("session_start")) await handler({}, ctx);
+for (const handler of handlers.get("agent_start")) await handler({}, ctx);
+for (const handler of handlers.get("tool_execution_start")) await handler({ toolName: "bash" }, ctx);
 
 const ansi = { success: 32, warning: 33, error: 31, muted: 37, dim: 90 };
 const theme = {
@@ -68,7 +73,7 @@ const theme = {
 };
 const footerData = {
   getGitBranch: () => "main",
-  getExtensionStatuses: () => new Map([["stash", "📝 STASHED"]]),
+  getExtensionStatuses: () => statuses,
   onBranchChange: () => () => {},
 };
 const component = footerFactory({ requestRender() {} }, theme, footerData);
@@ -82,6 +87,10 @@ for (const [width, maxLines] of [[100, 3], [80, 3], [60, 4], [40, 5]]) {
     assert(text.includes(expected), `${width} column render omitted ${expected}`);
   }
 }
+
+assert(component.render(100).join("\n").includes("bash · Esc/Ent"));
+for (const handler of handlers.get("agent_settled")) await handler({}, ctx);
+assert(!component.render(100).join("\n").includes("Esc/Ent"));
 
 assert(component.render(80).join("\n").includes("\x1b[32m42%\x1b[0m"));
 contextPercent = 75;
@@ -103,5 +112,5 @@ assert.equal(footerFactory, undefined);
 await commands.get("statusline").handler("detailed", ctx);
 assert(reloaded);
 
-console.log("OK: statusline fits 100/80/60/40 columns and colors context usage thresholds");
+console.log("OK: statusline fits 100/80/60/40 columns, shows run controls, and colors context usage thresholds");
 JS


### PR DESCRIPTION
## Summary

Make Pi + GPT behave as a user-directed interactive coding partner by separating discussion from implementation, bounding autonomous work, and exposing runtime controls without changing YOLO permissions or hidden thinking.

## Changes

- require explicit implementation and multi-agent opt-in while keeping routine execution uninterrupted
- limit `/goal` to 4 automatic responses and 2 no-progress responses
- show the active tool with `Esc/Ent` stop/steer hints in the statusline
- scope verification to the smallest relevant checks and document the interaction modes
- make the statusline test deterministic by stubbing external usage telemetry

## Test plan

- [x] `scripts/test-pi-statusline.sh`
- [x] TypeScript syntax checks for the changed Pi extensions
- [x] Validate `pi-goal.json` continuation limits
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`