### PR TITLE
fix(lazygit): manage version with mise

### DIFF
--- a/common/lazygit/.config/lazygit/config.yml
+++ b/common/lazygit/.config/lazygit/config.yml
@@ -1,9 +1,9 @@
 git:
   branchLogCmd: "git log --graph --color=always --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' {{branchName}} --"
-  pagers:
-    - pager: delta --dark --paging=never --side-by-side --line-numbers --syntax-theme="Visual Studio Dark+"
+  diffRenderers:
+    - command: delta --dark --paging=never --side-by-side --line-numbers --syntax-theme="Visual Studio Dark+"
       colorArg: always
-    - pager: delta --dark --paging=never --line-numbers --syntax-theme="Visual Studio Dark+"
+    - command: delta --dark --paging=never --line-numbers --syntax-theme="Visual Studio Dark+"
       colorArg: always
   allBranchesLogCmds:
     - git log --graph --color=always --pretty='%Cred%h%Creset -%C(auto)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --all

--- a/common/mise/.config/mise/config.toml
+++ b/common/mise/.config/mise/config.toml
@@ -8,6 +8,8 @@ python = "latest"
 "npm:pnpm" = "latest"
 deno = "latest"
 "npm:cspell" = "latest"
+"aqua:jesseduffield/lazygit" = "latest"
+"aqua:dandavison/delta" = "latest"
 go = "latest"
 cloudflared = "latest"
 "github:babashka/babashka" = { version = "latest", exe = "bb" }

--- a/common/mise/.config/mise/config.toml
+++ b/common/mise/.config/mise/config.toml
@@ -9,7 +9,6 @@ python = "latest"
 deno = "latest"
 "npm:cspell" = "latest"
 "aqua:jesseduffield/lazygit" = "latest"
-"aqua:dandavison/delta" = "latest"
 go = "latest"
 cloudflared = "latest"
 "github:babashka/babashka" = { version = "latest", exe = "bb" }

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -27,10 +27,8 @@ brew "neovim"
 brew "tree-sitter-cli"  # nvim-treesitter (main branch) がパーサーの generate/build に必須
 brew "typst"
 brew "fancy-cat"    # ターミナル内PDFビューア（Kitty graphics protocol）
-brew "lazygit"
 brew "trasta298/tap/keifu"
 brew "lazydocker"
-brew "git-delta"
 brew "gh"
 brew "ghq"
 brew "mise"

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -27,6 +27,7 @@ brew "neovim"
 brew "tree-sitter-cli"  # nvim-treesitter (main branch) がパーサーの generate/build に必須
 brew "typst"
 brew "fancy-cat"    # ターミナル内PDFビューア（Kitty graphics protocol）
+brew "git-delta"
 brew "trasta298/tap/keifu"
 brew "lazydocker"
 brew "gh"

--- a/config/mise-linux.toml
+++ b/config/mise-linux.toml
@@ -18,11 +18,9 @@
 #                 install.shではrustのpost_installでcargoがPATHに乗る。
 
 [tools]
-# --- aqua registry (25) ---
+# --- aqua registry (23) ---
 "aqua:junegunn/fzf" = "latest"
 "aqua:fastfetch-cli/fastfetch" = "latest"
-"aqua:dandavison/delta" = "latest"
-"aqua:jesseduffield/lazygit" = "latest"
 "aqua:x-motemen/ghq" = "latest"
 "aqua:neovim/neovim" = "latest"
 "aqua:tree-sitter/tree-sitter" = "latest"  # nvim-treesitter (main) のパーサー generate/build に必須

--- a/config/mise-linux.toml
+++ b/config/mise-linux.toml
@@ -18,9 +18,10 @@
 #                 install.shではrustのpost_installでcargoがPATHに乗る。
 
 [tools]
-# --- aqua registry (23) ---
+# --- aqua registry (24) ---
 "aqua:junegunn/fzf" = "latest"
 "aqua:fastfetch-cli/fastfetch" = "latest"
+"aqua:dandavison/delta" = "latest"
 "aqua:x-motemen/ghq" = "latest"
 "aqua:neovim/neovim" = "latest"
 "aqua:tree-sitter/tree-sitter" = "latest"  # nvim-treesitter (main) のパーサー generate/build に必須


### PR DESCRIPTION
## Summary
- lazygit と delta の管理を mise に統一
- macOS の Homebrew と Linux 専用 mise 定義の重複を削除
- lazygit 0.64.0 の `git.diffRenderers` 形式で delta を有効化

## Changes
- `common/mise/.config/mise/config.toml` に lazygit / delta を追加
- `config/Brewfile` から lazygit / git-delta を削除
- `config/mise-linux.toml` から共通ツールの重複定義を削除
- `common/lazygit/.config/lazygit/config.yml` を最新版形式へ更新

## Test plan
- `scripts/check-markdown-links.py`
- `scripts/check-package-duplication.sh`
- TOML parse check
- `mise ls --locked` で lazygit 0.64.0 / delta 0.19.2 を確認
- `git diff --check`