### PR TITLE
feat(pi): integrate coding shell and auto mode

### DIFF
--- a/common/pi/.pi/agent/automode.json
+++ b/common/pi/.pi/agent/automode.json
@@ -1,0 +1,12 @@
+{
+  "autoMode": {
+    "classifierModel": "openai-codex/gpt-5.4-mini",
+    "classifierReasoningLevel": "low",
+    "allowInsideWorkingDirectory": true,
+    "classifyReadOnlyTools": false,
+    "log": {
+      "enabled": false,
+      "classifierIo": false
+    }
+  }
+}

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -1,120 +1,126 @@
-// Statusline Extension for pi
-//
-// Balanced telemetry footer with:
-//   Focus rail: goal + extension status
-//   Core rail: branch + model | context gauge
-//   Telemetry rail: tokens | cost | Cursor limits | agents | web | MCP
-//   3 modes: detailed / compact / off (toggle via /statusline)
+// Pi UI shell: one owner for header, composer, footer, working indicator, and tab title.
+// Keeps the original rich telemetry while adding responsive profiles and /status.
 
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+  CustomEditor,
+  VERSION,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
+import {
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+  type Focusable,
+} from "@earendil-works/pi-tui";
 import { execFileSync, execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
-// ---------------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------------
+type DisplayMode = "off" | "minimal" | "compact" | "balanced" | "detailed" | "legacy";
+type EditorFactory = NonNullable<ReturnType<ExtensionContext["ui"]["getEditorComponent"]>>;
+type ShellEditorFactory = EditorFactory & { __piUiShell?: true };
 
-type DisplayMode = "off" | "compact" | "detailed";
-
-// Persist the chosen mode across sessions.
 const MODE_FILE = join(homedir(), ".pi", "agent", "statusline-mode");
+const GOAL_FILE = join(homedir(), ".pi", "agent", "goal");
+const DIRTY_CHECK_INTERVAL_MS = 5000;
+const STATS_CACHE_TTL = 10_000;
+
 function loadMode(): DisplayMode {
   try {
-    const v = readFileSync(MODE_FILE, "utf-8").trim();
-    if (v === "off" || v === "compact" || v === "detailed") return v;
+    const value = readFileSync(MODE_FILE, "utf-8").trim();
+    if (["off", "minimal", "compact", "balanced", "detailed", "legacy"].includes(value)) {
+      return value as DisplayMode;
+    }
   } catch { /* default below */ }
   return "detailed";
 }
-function saveMode(m: DisplayMode): void {
-  try { writeFileSync(MODE_FILE, m); } catch { /* non-fatal */ }
+
+function saveMode(value: DisplayMode): void {
+  try { writeFileSync(MODE_FILE, value); } catch { /* non-fatal */ }
 }
 
-let mode: DisplayMode = loadMode();
+let mode = loadMode();
 let dirtyState = false;
 let lastDirtyCheck = 0;
-const DIRTY_CHECK_INTERVAL_MS = 5000;
-
-// Cached token totals — recomputed on turn_end / session_start instead of
-// re-summing the entire branch on every footer render (cheap on large sessions).
+let goalCache = "";
+let currentTool = "";
+let running = false;
+let latestStatuses: string[] = [];
 let tokCache = { input: 0, output: 0, cost: 0 };
-function recomputeTokens(branch: Iterable<{ type: string; message?: { role: string } }>): void {
-  let input = 0, output = 0, cost = 0;
-  for (const e of branch) {
-    if (e.type === "message" && e.message?.role === "assistant") {
-      const m = e.message as unknown as AssistantMessage;
-      input += m.usage.input; output += m.usage.output; cost += m.usage.cost.total;
-    }
-  }
-  tokCache = { input, output, cost };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function checkGitDirty(): boolean {
-  try {
-    const output = execSync("git status --porcelain", {
-      encoding: "utf-8", timeout: 1000,
-      stdio: ["pipe", "pipe", "ignore"],
-    });
-    return output.trim().length > 0;
-  } catch { return false; }
-}
-
-function formatTokens(n: number): string {
-  if (n < 1000) return `${n}`;
-  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
-  return `${(n / 1_000_000).toFixed(1)}M`;
-}
+let agentStatus = { running: 0, queued: 0 };
+let cursorLimits = "";
 
 interface StatsSnapshot {
-  webSearch: number; webFetch: number; webCache: number;
-  mcpCalls: number; mcpErrors: number;
+  webSearch: number;
+  webFetch: number;
+  webCache: number;
+  mcpCalls: number;
+  mcpErrors: number;
 }
 
 let cachedStats: StatsSnapshot | null = null;
 let statsCacheMs = 0;
-const STATS_CACHE_TTL = 10_000;
 
-function readStats(): StatsSnapshot {
+function recomputeTokens(branch: Iterable<{ type: string; message?: { role: string } }>): void {
+  let input = 0, output = 0, cost = 0;
+  for (const entry of branch) {
+    if (entry.type !== "message" || entry.message?.role !== "assistant") continue;
+    const message = entry.message as unknown as AssistantMessage;
+    input += message.usage.input;
+    output += message.usage.output;
+    cost += message.usage.cost.total;
+  }
+  tokCache = { input, output, cost };
+}
+
+function checkGitDirty(): boolean {
+  try {
+    return execSync("git status --porcelain", {
+      encoding: "utf-8",
+      timeout: 1000,
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim().length > 0;
+  } catch { return false; }
+}
+
+function refreshGoal(): void {
+  try { goalCache = readFileSync(GOAL_FILE, "utf-8").trim(); } catch { goalCache = ""; }
+}
+
+function refreshStats(): StatsSnapshot {
   const now = Date.now();
   if (cachedStats && now - statsCacheMs < STATS_CACHE_TTL) return cachedStats;
-  const s: StatsSnapshot = { webSearch: 0, webFetch: 0, webCache: 0, mcpCalls: 0, mcpErrors: 0 };
+
+  const stats: StatsSnapshot = { webSearch: 0, webFetch: 0, webCache: 0, mcpCalls: 0, mcpErrors: 0 };
   const dir = join(homedir(), ".pi", "research");
   try {
-    const ws = JSON.parse(readFileSync(join(dir, "stats.json"), "utf-8"));
-    s.webSearch = ws.searchCount ?? 0; s.webFetch = ws.fetchCount ?? 0; s.webCache = ws.cacheHits ?? 0;
-  } catch { /* ignore */ }
+    const web = JSON.parse(readFileSync(join(dir, "stats.json"), "utf-8"));
+    stats.webSearch = web.searchCount ?? 0;
+    stats.webFetch = web.fetchCount ?? 0;
+    stats.webCache = web.cacheHits ?? 0;
+  } catch { /* absent or invalid */ }
   try {
-    const ms = JSON.parse(readFileSync(join(dir, "mcp-stats.json"), "utf-8"));
-    for (const [, v] of Object.entries(ms) as [string, { calls?: number; errors?: number }][]) {
-      s.mcpCalls += v.calls ?? 0; s.mcpErrors += v.errors ?? 0;
+    const mcp = JSON.parse(readFileSync(join(dir, "mcp-stats.json"), "utf-8"));
+    for (const value of Object.values(mcp) as Array<{ calls?: number; errors?: number }>) {
+      stats.mcpCalls += value.calls ?? 0;
+      stats.mcpErrors += value.errors ?? 0;
     }
-  } catch { /* ignore */ }
-  cachedStats = s; statsCacheMs = now;
-  return s;
+  } catch { /* absent or invalid */ }
+  cachedStats = stats;
+  statsCacheMs = now;
+  return stats;
 }
-
-// Pinned session note (set via /pin-goal in the memory extension). Tiny file — read directly.
-const GOAL_FILE = join(homedir(), ".pi", "agent", "goal");
-function readGoal(): string {
-  try { return readFileSync(GOAL_FILE, "utf-8").trim(); } catch { return ""; }
-}
-
-// Active delegated sub-agents (pueue tasks labeled pi-delegate). Refreshed off
-// the render path (turn_end / session_start) since `pueue status` shells out.
-let agentStatus = { running: 0, queued: 0 };
-let cursorLimits = "";
 
 function refreshCursorLimits(): void {
   try {
     const rows = execFileSync("ai-usage", ["cursor"], {
-      encoding: "utf-8", timeout: 6000, stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+      timeout: 6000,
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim().split("\n");
     cursorLimits = rows.map((row) => {
       const [, label, , pct, remaining] = row.split("\x1f");
@@ -124,41 +130,64 @@ function refreshCursorLimits(): void {
 }
 
 function refreshAgents(): void {
-  let running = 0, queued = 0;
+  let active = 0, queued = 0;
   try {
-    const out = execSync("pueue status --json", {
-      encoding: "utf-8", timeout: 1500, stdio: ["pipe", "pipe", "ignore"],
-    });
-    const data = JSON.parse(out);
+    const data = JSON.parse(execSync("pueue status --json", {
+      encoding: "utf-8",
+      timeout: 1500,
+      stdio: ["pipe", "pipe", "ignore"],
+    }));
     const tasks = (data.tasks ?? {}) as Record<string, { label?: string; status?: unknown }>;
-    for (const id of Object.keys(tasks)) {
-      const t = tasks[id];
-      if (t?.label !== "pi-delegate") continue;
-      const state = typeof t.status === "string" ? t.status : Object.keys(t.status ?? {})[0];
-      if (state === "Running") running++;
+    for (const task of Object.values(tasks)) {
+      if (task?.label !== "pi-delegate") continue;
+      const state = typeof task.status === "string" ? task.status : Object.keys(task.status ?? {})[0];
+      if (state === "Running") active++;
       else if (state === "Queued" || state === "Paused") queued++;
     }
-  } catch { /* pueue not running / unparseable — show nothing */ }
-  agentStatus = { running, queued };
+  } catch { /* pueue unavailable */ }
+  agentStatus = { running: active, queued };
+}
+
+function refreshSnapshot(ctx: ExtensionContext, includeRemote = false): void {
+  recomputeTokens(ctx.sessionManager.getBranch());
+  refreshGoal();
+  refreshAgents();
+  refreshStats();
+  if (includeRemote) refreshCursorLimits();
+  const now = Date.now();
+  if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
+    dirtyState = checkGitDirty();
+    lastDirtyCheck = now;
+  }
+}
+
+function formatTokens(value: number): string {
+  if (value < 1000) return `${value}`;
+  if (value < 1_000_000) return `${(value / 1000).toFixed(1)}k`;
+  return `${(value / 1_000_000).toFixed(1)}M`;
+}
+
+function formatCwd(cwd: string): string {
+  const home = homedir();
+  return cwd === home ? "~" : cwd.startsWith(`${home}/`) ? `~/${cwd.slice(home.length + 1)}` : cwd;
+}
+
+function cleanStatus(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, "").replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
 function balanceLine(left: string, right: string, width: number): string {
   if (!left) return truncateToWidth(right, width);
   if (!right) return truncateToWidth(left, width);
-
-  const gap = 3;
   const rightWidth = visibleWidth(right);
-  if (rightWidth >= width - gap) return truncateToWidth(right, width);
-
-  const fittedLeft = truncateToWidth(left, width - rightWidth - gap);
-  const padding = " ".repeat(Math.max(gap, width - visibleWidth(fittedLeft) - rightWidth));
-  return truncateToWidth(fittedLeft + padding + right, width);
+  if (rightWidth >= width - 3) return truncateToWidth(right, width);
+  const fittedLeft = truncateToWidth(left, width - rightWidth - 3);
+  return truncateToWidth(fittedLeft + " ".repeat(Math.max(3, width - visibleWidth(fittedLeft) - rightWidth)) + right, width);
 }
 
-function wrapGroups(groups: string[], width: number, separator = " │ "): string[] {
+function wrapGroups(groups: string[], width: number, separator: string): string[] {
   const lines: string[] = [];
   let line = "";
-
   for (const group of groups.filter(Boolean)) {
     const candidate = line ? line + separator + group : group;
     if (line && visibleWidth(candidate) > width) {
@@ -172,192 +201,291 @@ function wrapGroups(groups: string[], width: number, separator = " │ "): strin
   return lines;
 }
 
-function packCompact(groups: string[], width: number, separator = " · "): string {
-  let line = "";
-  for (const group of groups.filter(Boolean)) {
-    const candidate = line ? line + separator + group : group;
-    if (visibleWidth(candidate) <= width) line = candidate;
+function prioritizedLine(groups: Array<{ text: string; priority: number }>, width: number, separator: string): string {
+  const selected: typeof groups = [];
+  for (const group of [...groups].filter(({ text }) => text).sort((a, b) => a.priority - b.priority)) {
+    const candidate = [...selected, group].sort((a, b) => groups.indexOf(a) - groups.indexOf(b));
+    if (visibleWidth(candidate.map(({ text }) => text).join(separator)) <= width) selected.push(group);
   }
-  return truncateToWidth(line || groups.find(Boolean) || "", width);
+  return truncateToWidth(selected.sort((a, b) => groups.indexOf(a) - groups.indexOf(b)).map(({ text }) => text).join(separator), width);
 }
 
-// ---------------------------------------------------------------------------
-// Extension
-// ---------------------------------------------------------------------------
+function fitBorder(left: string, right: string, width: number, paint: (text: string) => string): string {
+  if (width <= 1) return paint("─".repeat(Math.max(0, width)));
+  let lhs = left, rhs = right;
+  while (visibleWidth(lhs) + visibleWidth(rhs) + 5 > width && visibleWidth(rhs) > 0) {
+    rhs = truncateToWidth(rhs, visibleWidth(rhs) - 1, "");
+  }
+  while (visibleWidth(lhs) + visibleWidth(rhs) + 5 > width && visibleWidth(lhs) > 0) {
+    lhs = truncateToWidth(lhs, visibleWidth(lhs) - 1, "");
+  }
+  return paint("─") + lhs + paint("─".repeat(Math.max(1, width - visibleWidth(lhs) - visibleWidth(rhs) - 2))) + rhs + paint("─");
+}
+
+function contextLabel(ctx: ExtensionContext): string {
+  const usage = ctx.getContextUsage();
+  return usage?.percent === null || usage?.percent === undefined ? "CTX ?" : `CTX ${Math.round(usage.percent)}%`;
+}
+
+function setTabTitle(ctx: ExtensionContext, state: string): void {
+  ctx.ui.setTitle(`π ${state} · ${basename(ctx.cwd)}`);
+}
+
+function installHeader(ctx: ExtensionContext): void {
+  ctx.ui.setHeader((_tui, theme) => ({
+    render(width: number): string[] {
+      const mark = theme.bold(theme.fg("accent", "π"));
+      const title = theme.bold(theme.fg("text", "CODING SHELL"));
+      const meta = theme.fg("muted", `${ctx.model?.id ?? "no-model"} · ${formatCwd(ctx.cwd)}`);
+      const first = balanceLine(` ${mark}  ${title}`, theme.fg("dim", `v${VERSION}`), width);
+      return width < 48 ? [first] : [first, truncateToWidth(` ${theme.fg("dim", "╰─")} ${meta}`, width)];
+    },
+    invalidate() {},
+  }));
+}
+
+function installEditor(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  const existing = ctx.ui.getEditorComponent() as ShellEditorFactory | undefined;
+  if (existing?.__piUiShell) return;
+
+  const factory: ShellEditorFactory = (tui, editorTheme, keybindings) => {
+    const editor = existing
+      ? existing(tui, editorTheme, keybindings)
+      : new CustomEditor(tui, editorTheme, keybindings, { paddingX: 0 });
+    const render = editor.render.bind(editor);
+    editor.render = (width) => {
+      const lines = render(width);
+      if (lines.length < 2) return lines;
+      const theme = ctx.ui.theme;
+      const state = currentTool ? ` TOOL · ${currentTool} ` : running ? " RUN " : " ASK ";
+      const stateColor = currentTool ? "warning" : running ? "accent" : "success";
+      const topLeft = theme.bold(theme.fg(stateColor, state));
+      const topRight = theme.fg("dim", ` ${pi.getThinkingLevel()} `);
+      const bottomLeft = theme.fg("muted", ` ${ctx.model?.id ?? "no-model"} · ${contextLabel(ctx)} `);
+      const bottomRight = theme.fg("dim", " /status ");
+      lines[0] = fitBorder(topLeft, topRight, width, (text) => theme.fg(stateColor, text));
+      lines[lines.length - 1] = fitBorder(bottomLeft, bottomRight, width, (text) => theme.fg("border", text));
+      return lines;
+    };
+    return editor;
+  };
+  factory.__piUiShell = true;
+  ctx.ui.setEditorComponent(factory);
+}
+
+class StatusOverlay implements Focusable {
+  focused = false;
+  readonly width = Math.max(36, Math.min(84, (process.stdout.columns || 88) - 4));
+
+  constructor(
+    private readonly theme: Theme,
+    private readonly lines: Array<[string, string]>,
+    private readonly done: () => void,
+  ) {}
+
+  handleInput(data: string): void {
+    if (matchesKey(data, "escape") || matchesKey(data, "return") || data === "q") this.done();
+  }
+
+  render(): string[] {
+    const inner = this.width - 2;
+    const border = (text: string) => this.theme.fg("border", text);
+    const row = (text = "") => {
+      const clipped = truncateToWidth(` ${text}`, inner);
+      return border("│") + clipped + " ".repeat(Math.max(0, inner - visibleWidth(clipped))) + border("│");
+    };
+    const output = [
+      border(`╭${"─".repeat(inner)}╮`),
+      row(`${this.theme.bold(this.theme.fg("accent", "π  SESSION STATUS"))}  ${this.theme.fg("dim", `profile: ${mode}`)}`),
+      row(),
+    ];
+    for (const [label, value] of this.lines) {
+      output.push(row(`${this.theme.fg("muted", label.padEnd(10))} ${value || this.theme.fg("dim", "—")}`));
+    }
+    output.push(row(), row(this.theme.fg("dim", "Esc / Enter / q  close")), border(`╰${"─".repeat(inner)}╯`));
+    return output;
+  }
+}
 
 export default function (pi: ExtensionAPI) {
-  // -----------------------------------------------------------------------
-  // Command: /statusline [detailed|compact|off]
-  // -----------------------------------------------------------------------
   pi.registerCommand("statusline", {
-    description: "Toggle statusline mode: detailed, compact, or off",
+    description: "Set UI profile: detailed, balanced, minimal, legacy, or off",
     getArgumentCompletions: () => [
-      { value: "detailed", label: "Balanced rich telemetry rails" },
-      { value: "compact", label: "Single line, minimal" },
-      { value: "off", label: "Disable custom statusline" },
+      { value: "detailed", label: "Rich responsive telemetry" },
+      { value: "balanced", label: "Two compact rails" },
+      { value: "minimal", label: "One priority-driven rail" },
+      { value: "legacy", label: "Original three-rail layout" },
+      { value: "off", label: "Disable the footer" },
     ],
     handler: async (args, ctx) => {
-      const previousMode = mode;
-      if (args === "detailed" || args === "compact" || args === "off") {
-        mode = args;
+      const requested = args.trim() === "compact" ? "balanced" : args.trim();
+      if (["off", "minimal", "balanced", "detailed", "legacy"].includes(requested)) {
+        mode = requested as DisplayMode;
       } else {
-        const cycle: DisplayMode[] = ["detailed", "compact", "off"];
-        mode = cycle[(cycle.indexOf(mode) + 1) % cycle.length];
+        const cycle: DisplayMode[] = ["detailed", "balanced", "minimal", "off"];
+        mode = cycle[(cycle.indexOf(mode) + 1) % cycle.length]!;
       }
       saveMode(mode);
-      if (mode === "off") {
-        ctx.ui.setFooter(undefined);
-        ctx.ui.notify("Statusline: off", "info");
-      } else if (previousMode === "off") {
-        await ctx.reload();
-        return;
-      } else {
-        ctx.ui.notify(`Statusline: ${mode}`, "info");
-      }
+      if (mode === "off") ctx.ui.setFooter(undefined);
+      else installFooter(ctx);
+      ctx.ui.notify(`UI profile: ${mode}`, "info");
     },
   });
 
-  // Keep interrupt/steer controls visible while a run is active. Progress
-  // narration stays in the system prompt; this is the deterministic fallback.
-  pi.on("agent_start", async (_event, ctx) => {
-    ctx.ui.setStatus("run-control", "RUN · Esc/Ent");
-  });
-  pi.on("tool_execution_start", async (event, ctx) => {
-    ctx.ui.setStatus("run-control", `${event.toolName} · Esc/Ent`);
-  });
-  pi.on("tool_execution_end", async (_event, ctx) => {
-    ctx.ui.setStatus("run-control", "RUN · Esc/Ent");
-  });
-  pi.on("agent_settled", async (_event, ctx) => {
-    ctx.ui.setStatus("run-control", undefined);
-  });
-
-  // -----------------------------------------------------------------------
-  // Git dirty check
-  // -----------------------------------------------------------------------
-  pi.on("turn_end", async (_event, ctx) => {
-    if (mode === "off") return;
-    recomputeTokens(ctx.sessionManager.getBranch());
-    refreshAgents();
-    refreshCursorLimits();
-    const now = Date.now();
-    if (now - lastDirtyCheck > DIRTY_CHECK_INTERVAL_MS) {
-      dirtyState = checkGitDirty(); lastDirtyCheck = now;
-    }
-  });
-  pi.on("session_start", async () => {
-    if (mode === "off") return;
-    dirtyState = checkGitDirty(); lastDirtyCheck = Date.now();
+  pi.registerCommand("status", {
+    description: "Show full Pi session telemetry",
+    handler: async (_args, ctx) => {
+      refreshSnapshot(ctx, true);
+      const stats = refreshStats();
+      const usage = ctx.getContextUsage();
+      await ctx.ui.custom<void>(
+        (_tui, theme, _keybindings, done) => new StatusOverlay(theme, [
+          ["PROJECT", `${formatCwd(ctx.cwd)}${dirtyState ? "  *dirty" : ""}`],
+          ["MODEL", `${ctx.model?.provider ?? "—"}/${ctx.model?.id ?? "—"} · ${pi.getThinkingLevel()}`],
+          ["CONTEXT", usage?.percent == null ? "unknown" : `${usage.percent.toFixed(1)}% / ${formatTokens(usage.contextWindow ?? 0)}`],
+          ["TOKENS", `↑${formatTokens(tokCache.input)}  ↓${formatTokens(tokCache.output)}  $${tokCache.cost.toFixed(3)}`],
+          ["CURSOR", cursorLimits],
+          ["AGENTS", `running ${agentStatus.running} · queued ${agentStatus.queued}`],
+          ["WEB", `search ${stats.webSearch} · fetch ${stats.webFetch} · cache ${stats.webCache}`],
+          ["MCP", `calls ${stats.mcpCalls} · errors ${stats.mcpErrors}`],
+          ["GOAL", goalCache],
+          ["STATUS", latestStatuses.join(" · ")],
+        ], () => done()),
+        { overlay: true },
+      );
+    },
   });
 
-  // -----------------------------------------------------------------------
-  // Footer renderer
-  // -----------------------------------------------------------------------
   pi.on("session_start", async (_event, ctx) => {
-    recomputeTokens(ctx.sessionManager.getBranch());
-    refreshAgents();
-    refreshCursorLimits();
-    if (mode === "off") {
-      ctx.ui.setFooter(undefined);
-      return;
-    }
-    ctx.ui.setFooter((tui, theme, footerData) => {
-      const unsub = footerData.onBranchChange(() => tui.requestRender());
-      return {
-        dispose: unsub,
-        invalidate() {},
-        render(width: number): string[] {
-          if (mode === "off") return [];
+    refreshSnapshot(ctx, true);
+    installShell(pi, ctx);
+    setTabTitle(ctx, dirtyState ? "●" : "READY");
+  });
 
-          // ---- Token stats (cached; recomputed on turn_end / session_start) ----
-          const { input, output, cost } = tokCache;
+  // resources_discover runs after package session handlers. Re-applying here
+  // makes this extension the deterministic owner while preserving wrapped editor behavior.
+  pi.on("resources_discover", async (_event, ctx) => {
+    installShell(pi, ctx);
+    setImmediate(() => installShell(pi, ctx));
+  });
 
-          // ---- Context ----
-          const usage = ctx.getContextUsage();
-          const rawUsedPct = usage?.percent;
-          const usedPct = rawUsedPct === null || rawUsedPct === undefined
-            ? null
-            : Math.max(0, Math.min(100, rawUsedPct));
-          const gaugeChars = width >= 100 ? 10 : width >= 70 ? 8 : 6;
-          const ctxColor = usedPct === null
-            ? "muted"
-            : usedPct >= 85
-              ? "error"
-              : usedPct >= 70
-                ? "warning"
-                : "success";
-          const filled = usedPct === null ? 0 : Math.round((usedPct / 100) * gaugeChars);
-          const pctText = usedPct === null ? "?" : `${usedPct.toFixed(0)}%`;
-          const gaugeStr = [
-            theme.fg("muted", "CTX"),
-            theme.fg(ctxColor, "█".repeat(filled)) + theme.fg("dim", "░".repeat(gaugeChars - filled)),
-            theme.fg(ctxColor, pctText),
-          ].join(" ");
+  pi.on("agent_start", async (_event, ctx) => {
+    running = true;
+    currentTool = "";
+    ctx.ui.setStatus("run-control", "RUN · Esc stop · Enter steer");
+    setTabTitle(ctx, "RUN");
+  });
 
-          // ---- Stats ----
-          const stats = readStats();
+  pi.on("tool_execution_start", async (event, ctx) => {
+    currentTool = event.toolName;
+    ctx.ui.setStatus("run-control", `${event.toolName} · Esc stop · Enter steer`);
+    setTabTitle(ctx, event.toolName);
+  });
 
-          // ---- Visual grammar ----
-          const minor = theme.fg("dim", " · ");
-          const major = theme.fg("dim", " │ ");
-          const label = (text: string) => theme.fg("muted", text);
+  pi.on("tool_execution_end", async (_event, ctx) => {
+    currentTool = "";
+    ctx.ui.setStatus("run-control", "RUN · Esc stop · Enter steer");
+    setTabTitle(ctx, "RUN");
+  });
 
-          // ---- Focus rail ----
-          const goal = readGoal();
-          const goalStr = goal
-            ? `${theme.fg("accent", "▌")} ${label("Goal:")} ${theme.fg("text", goal)}`
-            : "";
-          const extensionStatuses = [...footerData.getExtensionStatuses().values()];
-          const statusStr = extensionStatuses.join(minor);
+  pi.on("agent_settled", async (_event, ctx) => {
+    running = false;
+    currentTool = "";
+    ctx.ui.setStatus("run-control", undefined);
+    dirtyState = checkGitDirty();
+    lastDirtyCheck = Date.now();
+    setTabTitle(ctx, dirtyState ? "●" : "✓");
+  });
 
-          // ---- Core rail ----
-          const branch = footerData.getGitBranch();
-          const branchStr = branch
-            ? theme.fg(dirtyState ? "warning" : "border", `${branch}${dirtyState ? "*" : ""}`)
-            : "";
-          const modelStr = theme.fg("customMessageLabel", ctx.model?.id || "no-model");
-          const projectStr = [branchStr, modelStr].filter(Boolean).join(minor);
+  pi.on("turn_end", async (_event, ctx) => refreshSnapshot(ctx, true));
+}
 
-          // ---- Telemetry rail ----
-          const tokIn = theme.fg("text", `↑${formatTokens(input)}`);
-          const tokOut = theme.fg("accent", `↓${formatTokens(output)}`);
-          const tokenStr = `${label("TOK")} ${tokIn}${minor}${tokOut}`;
-          const costStr = `${label("COST")} ${theme.fg("syntaxNumber", `$${cost.toFixed(3)}`)}`;
-          const limitStr = cursorLimits
-            ? `${label("CURSOR")} ${theme.fg("text", cursorLimits)}`
-            : "";
-          const agentStr = agentStatus.running > 0 || agentStatus.queued > 0
-            ? `${label("AGT")} ${theme.fg("customMessageLabel", `R${agentStatus.running}`)}${minor}${theme.fg("customMessageLabel", `Q${agentStatus.queued}`)}`
-            : "";
-          const webStr = stats.webSearch > 0 || stats.webFetch > 0
-            ? `${label("WEB")} ${theme.fg("syntaxType", `S${stats.webSearch}`)}${minor}${theme.fg("syntaxType", `F${stats.webFetch}`)}${minor}${theme.fg("syntaxType", `C${stats.webCache}`)}`
-            : "";
-          const mcpError = stats.mcpErrors > 0
-            ? minor + theme.fg("error", `E${stats.mcpErrors}`)
-            : "";
-          const mcpStr = stats.mcpCalls > 0 || stats.mcpErrors > 0
-            ? `${label("MCP")} ${theme.fg("border", `Q${stats.mcpCalls}`)}${mcpError}`
-            : "";
+function installShell(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  if (!ctx.hasUI) return;
+  installHeader(ctx);
+  installEditor(pi, ctx);
+  ctx.ui.setWorkingIndicator({
+    frames: ["·π·", "∙π∙", "•π•", "✦π✦", "•π•", "∙π∙"].map((frame) => ctx.ui.theme.fg("accent", frame)),
+    intervalMs: 180,
+  });
+  installFooter(ctx);
+}
 
-          if (mode === "compact") {
-            const compactFocus = truncateToWidth(
-              [statusStr, goalStr].filter(Boolean).join(minor),
-              width >= 100 ? 36 : width >= 70 ? 24 : 14,
-            );
-            return [packCompact(
-              [compactFocus, gaugeStr, branchStr, modelStr, limitStr, tokenStr, costStr],
-              width,
-              minor,
-            )];
-          }
+function installFooter(ctx: ExtensionContext): void {
+  if (mode === "off") {
+    ctx.ui.setFooter(undefined);
+    return;
+  }
 
-          const lines: string[] = [];
-          if (goalStr || statusStr) lines.push(balanceLine(goalStr, statusStr, width));
-          lines.push(balanceLine(projectStr, gaugeStr, width));
-          lines.push(...wrapGroups([tokenStr, costStr, limitStr, agentStr, webStr, mcpStr], width, major));
-          return lines;
-        },
-      };
-    });
+  ctx.ui.setFooter((tui, theme, footerData) => {
+    const unsubscribe = footerData.onBranchChange(() => tui.requestRender());
+    return {
+      dispose: unsubscribe,
+      invalidate() {},
+      render(width: number): string[] {
+        const usage = ctx.getContextUsage();
+        const usedPct = usage?.percent == null ? null : Math.max(0, Math.min(100, usage.percent));
+        const gaugeWidth = width >= 100 ? 10 : width >= 70 ? 8 : 6;
+        const gaugeColor = usedPct == null ? "muted" : usedPct >= 85 ? "error" : usedPct >= 70 ? "warning" : "success";
+        const filled = usedPct == null ? 0 : Math.round(usedPct / 100 * gaugeWidth);
+        const minor = theme.fg("dim", " · ");
+        const major = theme.fg("dim", " │ ");
+        const label = (text: string) => theme.fg("muted", text);
+        const gauge = `${label("CTX")} ${theme.fg(gaugeColor, "█".repeat(filled))}${theme.fg("dim", "░".repeat(gaugeWidth - filled))} ${theme.fg(gaugeColor, usedPct == null ? "?" : `${Math.round(usedPct)}%`)}`;
+
+        const statuses = [...footerData.getExtensionStatuses().values()].map(cleanStatus).filter(Boolean);
+        latestStatuses = statuses;
+        const statusText = statuses.slice(0, 5).map((status) => theme.fg(/error|fail|blocked/i.test(status) ? "error" : /run|work|pending/i.test(status) ? "warning" : "muted", truncateToWidth(status, 32, "…"))).join(minor);
+        const goal = goalCache ? `${theme.fg("accent", "▌")} ${label("Goal:")} ${theme.fg("text", goalCache)}` : "";
+        const branch = footerData.getGitBranch();
+        const branchText = branch ? theme.fg(dirtyState ? "warning" : "border", `${branch}${dirtyState ? "*" : ""}`) : "";
+        const model = theme.fg("customMessageLabel", ctx.model?.id ?? "no-model");
+        const path = theme.fg("dim", formatCwd(ctx.cwd));
+        const tokens = `${label("TOK")} ${theme.fg("text", `↑${formatTokens(tokCache.input)}`)}${minor}${theme.fg("accent", `↓${formatTokens(tokCache.output)}`)}`;
+        const cost = `${label("COST")} ${theme.fg("syntaxNumber", `$${tokCache.cost.toFixed(3)}`)}`;
+        const limits = cursorLimits ? `${label("CURSOR")} ${theme.fg("text", cursorLimits)}` : "";
+        const agents = agentStatus.running || agentStatus.queued ? `${label("AGT")} ${theme.fg("customMessageLabel", `R${agentStatus.running}`)}${minor}${theme.fg("customMessageLabel", `Q${agentStatus.queued}`)}` : "";
+        const stats = cachedStats ?? { webSearch: 0, webFetch: 0, webCache: 0, mcpCalls: 0, mcpErrors: 0 };
+        const web = stats.webSearch || stats.webFetch ? `${label("WEB")} ${theme.fg("syntaxType", `S${stats.webSearch}`)}${minor}${theme.fg("syntaxType", `F${stats.webFetch}`)}${minor}${theme.fg("syntaxType", `C${stats.webCache}`)}` : "";
+        const mcp = stats.mcpCalls || stats.mcpErrors ? `${label("MCP")} ${theme.fg("border", `Q${stats.mcpCalls}`)}${stats.mcpErrors ? minor + theme.fg("error", `E${stats.mcpErrors}`) : ""}` : "";
+        const activity = currentTool ? theme.fg("warning", `◆ ${currentTool}`) : running ? theme.fg("accent", "◆ RUN") : "";
+
+        if (mode === "minimal") {
+          return [prioritizedLine([
+            { text: activity, priority: 0 },
+            { text: gauge, priority: 1 },
+            { text: branchText, priority: 2 },
+            { text: model, priority: 3 },
+            { text: limits, priority: 4 },
+            { text: tokens, priority: 5 },
+          ], width, minor)];
+        }
+
+        if (mode === "compact" || mode === "balanced" || (mode === "detailed" && width < 64)) {
+          const focus = prioritizedLine([
+            { text: activity, priority: 0 },
+            { text: goal, priority: 1 },
+            { text: statusText, priority: 2 },
+          ], width, minor);
+          const telemetry = prioritizedLine([
+            { text: branchText, priority: 2 },
+            { text: model, priority: 3 },
+            { text: gauge, priority: 0 },
+            { text: limits, priority: 1 },
+            { text: tokens, priority: 4 },
+            { text: cost, priority: 5 },
+          ], width, major);
+          return [focus, telemetry].filter(Boolean);
+        }
+
+        const lines: string[] = [];
+        if (goal || statusText || activity) lines.push(balanceLine(goal || activity, [goal && activity ? activity : "", statusText].filter(Boolean).join(minor), width));
+        lines.push(balanceLine([path, branchText, model].filter(Boolean).join(minor), gauge, width));
+        lines.push(...wrapGroups([tokens, cost, limits, agents, web, mcp], width, major));
+
+        if (mode === "legacy") return lines;
+        return lines.slice(0, width >= 90 ? 4 : 3);
+      },
+    };
   });
 }

--- a/common/pi/.pi/agent/settings.json
+++ b/common/pi/.pi/agent/settings.json
@@ -1,6 +1,6 @@
 {
   "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.6-luna",
+  "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "medium",
   "subagents": {
     "defaultModel": "openai-codex/gpt-5.4-mini",
@@ -93,7 +93,44 @@
     "npm:pi-remote-control",
     "npm:pi-cursor-agent",
     "npm:pi-permission-system",
-    "git:github.com/DietrichGebert/ponytail"
+    "npm:@czottmann/pi-automode",
+    "git:github.com/DietrichGebert/ponytail",
+    {
+      "source": "npm:pi-open-tui",
+      "extensions": [
+        "!extensions/open-tui/index.ts"
+      ]
+    },
+    "npm:awesome-pi-themes",
+    "npm:pi-studio",
+    "npm:pi-extmgr",
+    {
+      "source": "npm:pi-beautiful-tui",
+      "extensions": [
+        "!index.ts"
+      ]
+    },
+    {
+      "source": "npm:pi-agent-extensions",
+      "extensions": [
+        "!extensions/powerline-footer/index.ts",
+        "!extensions/whimsical/index.ts",
+        "!extensions/workflow/index.ts"
+      ]
+    },
+    {
+      "source": "npm:pi-system-theme",
+      "extensions": [
+        "!index.ts"
+      ]
+    },
+    {
+      "source": "git:github.com/tomsej/pi-ext",
+      "extensions": [
+        "!extensions/custom-footer/custom-footer.ts",
+        "!extensions/permissions/permissions.ts"
+      ]
+    }
   ],
   "lastChangelogVersion": "0.84.1"
 }

--- a/docs/agent-plan.md
+++ b/docs/agent-plan.md
@@ -1,0 +1,8 @@
+# Pi UI shell prototype plan
+
+> **由来:** **Custom** Pi UI shellの実装計画（[区分](provenance.md#区分)）
+
+- [x] `statusline.ts`を単一UI ownerへ拡張し、header・editor・footer・working indicator・tab titleを統合する。
+- [x] 既存3段telemetryを保持しつつ、幅とprofileに応じたresponsive表示と`/status`詳細overlayを追加する。
+- [x] 競合するpackage UI、重複permission、working message tickerをfilterし、Pi Studio・extmgrなど重複しない機能は残す。
+- [x] Pi実起動、overlay、Markdown link・package duplication checkで検証する。

--- a/docs/ai-agents/pi/overview.md
+++ b/docs/ai-agents/pi/overview.md
@@ -14,6 +14,8 @@
 | pi-dynamic-workflows | Claude Code-style workflow / fan-out orchestration | `settings.json` の `packages` → `pi install npm:@quintinshaw/pi-dynamic-workflows` |
 | pi-loop | dynamic goal loop、cron/event re-wake loop、background monitor | `settings.json` の `packages` → `pi install npm:@trevonistrevon/pi-loop` |
 | pi-goal | `/goal` で上限付き自動継続を行う goal mode | `settings.json` の `packages` + `pi-goal.json` |
+| pi-automode | Claude Code-styleの実行前classifier guardrail | `settings.json` の `packages` + `automode.json` |
+| UI比較package | header / footer / editor / theme / browser workspaceを実機比較 | `settings.json` の `packages`（下記参照） |
 | AGENTS.md | グローバル指示書 | `common/pi/.pi/agent/AGENTS.md` → `~/.pi/agent/AGENTS.md` |
 | pueue | バックグラウンドタスク・並列 delegation 用キュー | `config/Brewfile` (mac), `packages.linux.{apt,alpine}.txt` (linux) |
 
@@ -142,22 +144,51 @@ pueue用の `delegate_agent` だけは独立しているため、必要なら `c
 
 `tokyonight-high-contrast` を標準テーマとして `common/pi/.pi/agent/themes/` で管理する。通常は `settings.json` の `theme` がこれを選ぶ。pi を再起動すると反映され、調整中のテーマファイルは pi 上で自動再読込される。
 
+### 統合Pi UI shell
+
+`extensions/statusline.ts`がheader、composer、footer、working indicator、terminal tab titleを単一ownerとして管理する。packageを重ねて同じsurfaceを後勝ちで上書きせず、既存のprompt history editorとskill highlightをwrapして入力機能を保持する。
+
+- compact header: model、作業directory、Pi version
+- state composer: `ASK` / `RUN` / `TOOL`、thinking level、context、`/status`導線
+- responsive footer: Goal、extension status、branch、model、context、tokens、cost、Cursor上限、agents、Web、MCP
+- `/status`: 常時表示から省いた情報も含むsession telemetry overlay
+- terminal tab: `READY` / `RUN` / tool名 / dirty状態
+- working indicator: Tokyo Nightのaccentに合わせたPi orbit
+
+`/statusline detailed|balanced|minimal|legacy|off`で表示密度を切り替える。`detailed`は幅が狭いと自動的にbalanced表示へ縮退し、`legacy`は従来の3段情報量を確認する比較用profileとして残す。
+
+比較用packageはinstall状態を維持するが、surface ownershipが競合する`pi-open-tui`、`pi-beautiful-tui`、`pi-system-theme`のextension entrypointはfilterする。theme collection、Pi Studio、extmgr、leader palette、tool pills、session／todo機能など、統合shellと重複しない機能は引き続き読み込む。
+
+| Package | 状態・利用箇所 |
+| --- | --- |
+| `pi-open-tui` | install維持、UI entrypointは統合shellとの競合を避けてfilter |
+| `awesome-pi-themes` | theme比較用に有効 |
+| `pi-studio` | browser workspace、preview、annotationを有効 |
+| `pi-extmgr` | package管理overlayを有効 |
+| `pi-beautiful-tui` | install維持、UI entrypointはfilter |
+| `pi-agent-extensions` | footer、workflow、周期的にworking messageを書き換えるwhimsicalをfilter。session / todo / prompt history等は有効 |
+| `pi-system-theme` | Tokyo Night固定と競合するためentrypointをfilter |
+| `git:github.com/tomsej/pi-ext` | custom footerと重複permissionをfilter、tool pillsとleader palette等は有効 |
+
 ### 表示を簡潔にする
 
-標準設定では思考ブロックを隠し、起動ヘッダーを省略し、`/tree` はツール結果を除外して開く。必要な詳細だけをキーバインドで表示する。
+独自UI導入前の標準設定では思考ブロックを隠し、起動ヘッダーを省略し、`/tree` はツール結果を除外して開く。必要な詳細だけをキーバインドで表示する。
 
 - `Ctrl+T`: 思考ブロックを展開/折り畳み
 - `Ctrl+O`: ツール出力を展開/折り畳み
 - `Esc` を2回: `/tree` を開く。tree 内の `Ctrl+T` でツール結果を表示/非表示
 - 実行中は現在のtoolと`Esc/Enter`をフッターに表示（`Esc`は停止、`Enter`はsteer）
-- `/statusline compact`: Cursor のプラン上限を含むフッターを1行表示に切り替え（取得元は `ai-usage cursor`）
+- `/statusline minimal`: Cursor のプラン上限を含む優先度ベースの1行表示へ切り替え（取得元は `ai-usage cursor`）
+- `/status`: Goal、usage、agents、Web、MCP、extension statusをoverlayで一覧表示
 - 入力中の既知 skill 名はアクセント色でハイライトされる（`/reload` または再起動で skill 一覧を再読込）。
 
-### Permission gate
+### Permission gate / Auto Mode
 
 `permission-system.json`の`yoloMode`と`settings.json`の`hideThinkingBlock`は有効のままにする。対話の承認境界はwrite permissionではなく、明示的な実装指示と`/plan`で管理するため、実装開始後の通常操作は止めない。
 
-`common/pi/.pi/agent/extensions/permission-gate.ts`はdangerous shell commandを実行前に確認する。agentはセッション開始時のmain repositoryまたは既存worktreeで実装し、利用者の明示なしに別worktreeへ移動しない。worktree capacity追加は確認対象ではなくhard denyし、`git worktree add`と`pnpm wt provision`は実行しない。利用者が明示した既存pooled slotのclaim/listは許可する。capacity追加が必要な場合は利用者がpi外のterminalから実行する。
+`@czottmann/pi-automode`はagentのtool callを実行前に分類する。`automode.json`で`allowInsideWorkingDirectory: true`にし、working tree内の通常file操作はclassifierなしで許可する。bash、MCP、外部path、protected pathは`openai-codex/gpt-5.4-mini:low`で判定し、classifier障害時はfail-closedとする。`/automode status`で状態確認、`/automode off`でsession中だけ無効化できる。dotfiles自身のpermission・auto-mode設定を変更する作業ではhard-denyと衝突するため、明示的にoffにしてから行う。
+
+`common/pi/.pi/agent/extensions/permission-gate.ts`はautomodeとは独立してdangerous shell commandを実行前に確認する。agentはセッション開始時のmain repositoryまたは既存worktreeで実装し、利用者の明示なしに別worktreeへ移動しない。worktree capacity追加は確認対象ではなくhard denyし、`git worktree add`と`pnpm wt provision`は実行しない。利用者が明示した既存pooled slotのclaim/listは許可する。capacity追加が必要な場合は利用者がpi外のterminalから実行する。
 
 ### 拡張機能
 


### PR DESCRIPTION
## Summary

- Piのheader、composer、footer、working indicator、tab titleを単一UI shellへ統合
- Claude Code-styleの`pi-automode` guardrailを追加
- 比較導入したUI packageのうち競合entrypointだけをfilter

## Changes

- `statusline.ts`へresponsive profile、`/status` overlay、ASK/RUN/TOOL composerを追加
- Goal、Cursor limits、agents、Web、MCPを維持したrich telemetryを提供
- `@czottmann/pi-automode`を`gpt-5.4-mini:low` classifierで設定
- working tree内の通常file操作はsilent allow、bash・外部path・protected pathはclassifier判定
- 重複permission extensionと画面再描画を増やすwhimsical tickerを無効化
- Pi UI shellとpermission構成の運用ドキュメントを更新

## Test plan

- [x] Pi print sessionでextension loaderを確認
- [x] 実TUIでheader、composer、footer、`/status` overlayを確認
- [x] Auto Mode config読込と`AM●` status表示を確認
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`
- [x] `git diff --check`

## Notes

- 反映にはPiの`/reload`または再起動が必要
- 既知の`woodpecker-ci` MCP code 127 warningは本変更と無関係