### PR TITLE
fix(install): refresh tools and handle package manager updates

### DIFF
--- a/common/mise/.config/mise/config.toml
+++ b/common/mise/.config/mise/config.toml
@@ -12,7 +12,7 @@ deno = "latest"
 go = "latest"
 cloudflared = "latest"
 "github:babashka/babashka" = { version = "latest", exe = "bb" }
-"github:shonenm/live-pr" = "0.1.0-alpha.12"
+"github:shonenm/live-pr" = "latest"
 
 [tasks.apply]
 description = "Apply package declarations and dotfile links"

--- a/common/mise/.config/mise/mise.lock
+++ b/common/mise/.config/mise/mise.lock
@@ -385,27 +385,27 @@ url = "https://github.com/topgrade-rs/topgrade/releases/download/v17.9.0/topgrad
 provenance = "github-attestations"
 
 [[tools."aqua:tree-sitter/tree-sitter"]]
-version = "0.26.11"
+version = "0.26.12"
 backend = "aqua:tree-sitter/tree-sitter"
 
 [tools."aqua:tree-sitter/tree-sitter"."platforms.linux-arm64"]
-checksum = "sha256:e47dd59bf2f21ad7c15771546a724464ee3c008a60fbb61c6860bd19a44b3060"
-url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.11/tree-sitter-linux-arm64.gz"
+checksum = "sha256:cfbf3d9aad8e326878ab1846885a9c2b782a0333273591616f34bf556d525586"
+url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.12/tree-sitter-linux-arm64.gz"
 provenance = "github-attestations"
 
 [tools."aqua:tree-sitter/tree-sitter"."platforms.linux-x64"]
-checksum = "sha256:8dac3c89bb632eece700ea7a261ad963b251f2228c4aef3b58458ebea8dbe4eb"
-url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.11/tree-sitter-linux-x64.gz"
+checksum = "sha256:d00ac0daefc4bf8c4b57842a5c0509927232faad1d83157b64fbad4e2e8d9a8b"
+url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.12/tree-sitter-linux-x64.gz"
 provenance = "github-attestations"
 
 [tools."aqua:tree-sitter/tree-sitter"."platforms.macos-arm64"]
-checksum = "sha256:0bb646b2a29007233bd44855f00d0b8e238084d5b442f097d841b476318c2c90"
-url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.11/tree-sitter-macos-arm64.gz"
+checksum = "sha256:a7ddeff2507391ebdfd0b8fa0dfe91babed291ea00d86426cb0e6cfade891697"
+url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.12/tree-sitter-macos-arm64.gz"
 provenance = "github-attestations"
 
 [tools."aqua:tree-sitter/tree-sitter"."platforms.macos-x64"]
-checksum = "sha256:0da547d2622ba1583e4c748bb44db5b79af56462da41acf377b9fdc2eb2cd49f"
-url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.11/tree-sitter-macos-x64.gz"
+checksum = "sha256:6827b218bce4d5403cb76ae3c269bc836d3124b75bb3477197ee9a8c8f6e79dc"
+url = "https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.12/tree-sitter-macos-x64.gz"
 provenance = "github-attestations"
 
 [[tools."aqua:typst/typst"]]
@@ -565,28 +565,28 @@ url = "https://github.com/MilesCranmer/rip2/releases/download/v0.9.6/rip-macOS-D
 url_api = "https://api.github.com/repos/MilesCranmer/rip2/releases/assets/331924484"
 
 [[tools."github:achristmascarl/rainfrog"]]
-version = "0.4.2"
+version = "0.4.3"
 backend = "github:achristmascarl/rainfrog"
 
 [tools."github:achristmascarl/rainfrog"."platforms.linux-arm64"]
-checksum = "sha256:4e8d2c9a39eb966246b218dc2acd0712fcf4c620e96162ae27679f71f9c76426"
-url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.2/rainfrog-v0.4.2-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/492907824"
+checksum = "sha256:2098a8c8ffc7c687a97f090fb2a0a290bd88c4651667d2b1f3b28a4c0e944663"
+url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.3/rainfrog-v0.4.3-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/506124166"
 
 [tools."github:achristmascarl/rainfrog"."platforms.linux-x64"]
-checksum = "sha256:8878df66c5c8fbc48c1e40ce7a898da4c125b158e6a1040ae2b144c4e74c77c8"
-url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.2/rainfrog-v0.4.2-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/492905487"
+checksum = "sha256:50050cb714e1d6e0f4018e7ed077105acec0ce3037e0060e58f6d090c30462c3"
+url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.3/rainfrog-v0.4.3-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/506122519"
 
 [tools."github:achristmascarl/rainfrog"."platforms.macos-arm64"]
-checksum = "sha256:efd5b1ceda4f3fc98c5a139d132656daf0758303dc688b45accc74201317fd80"
-url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.2/rainfrog-v0.4.2-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/492904621"
+checksum = "sha256:ddbbc8f42c03a09b40a165a4ff0b67c167736fe2fd23920d23dd6ab2ca4ec6c0"
+url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.3/rainfrog-v0.4.3-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/506118283"
 
 [tools."github:achristmascarl/rainfrog"."platforms.macos-x64"]
-checksum = "sha256:46277fcf619ec9b012a9d5219df8f5b97f6968ede0cde768a0dd0f7efbccf4ce"
-url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.2/rainfrog-v0.4.2-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/492907915"
+checksum = "sha256:911657b03061eb2c4c3e94a56ea24f1a9cfc5bf248eabaa47f53870b1cca85c3"
+url = "https://github.com/achristmascarl/rainfrog/releases/download/v0.4.3/rainfrog-v0.4.3-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/achristmascarl/rainfrog/releases/assets/506121138"
 
 [[tools."github:babashka/babashka"]]
 version = "1.13.219"
@@ -681,28 +681,28 @@ url = "https://github.com/lemonade-command/lemonade/releases/download/v1.1.1/lem
 url_api = "https://api.github.com/repos/lemonade-command/lemonade/releases/assets/2516207"
 
 [[tools."github:mr-karan/doggo"]]
-version = "1.2.0"
+version = "1.3.0"
 backend = "github:mr-karan/doggo"
 
 [tools."github:mr-karan/doggo"."platforms.linux-arm64"]
-checksum = "sha256:b15e3e56b1e1d2e4bb3bf81b292a49a1b55781465ab2cb858cdb7f081fd95d0f"
-url = "https://github.com/mr-karan/doggo/releases/download/v1.2.0/doggo-linux-aarch64.tar.gz"
-url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/455378184"
+checksum = "sha256:f034f0d525b165b771370e0ee77e161e1d9bd1f89aa5b20de81b9053cde35d44"
+url = "https://github.com/mr-karan/doggo/releases/download/v1.3.0/doggo-linux-aarch64.tar.gz"
+url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/504896302"
 
 [tools."github:mr-karan/doggo"."platforms.linux-x64"]
-checksum = "sha256:aa6760e7f163958e7626420447385ab938fdc127983edaceb121f809bd3e2bca"
-url = "https://github.com/mr-karan/doggo/releases/download/v1.2.0/doggo-linux-x86_64.tar.gz"
-url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/455378176"
+checksum = "sha256:c0d3f064ab40670720b30833a71e6178ed84242ea53ffb5dfab7b315dcce61c2"
+url = "https://github.com/mr-karan/doggo/releases/download/v1.3.0/doggo-linux-x86_64.tar.gz"
+url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/504896308"
 
 [tools."github:mr-karan/doggo"."platforms.macos-arm64"]
-checksum = "sha256:aa8b866d8bc96ce7a004f3d2f99c26e4bb0dd140c7bd151b2eb12a1d0b01cc06"
-url = "https://github.com/mr-karan/doggo/releases/download/v1.2.0/doggo-darwin-aarch64.tar.gz"
-url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/455378202"
+checksum = "sha256:3898d3563e216a0ffbfc457288b16b7027d3743f5512222ad589074ae4990b93"
+url = "https://github.com/mr-karan/doggo/releases/download/v1.3.0/doggo-darwin-aarch64.tar.gz"
+url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/504896267"
 
 [tools."github:mr-karan/doggo"."platforms.macos-x64"]
-checksum = "sha256:2d88ad833fd7616ae5e8908cf765a9734e52c6521d6e46a0b1714c935088708ce"
-url = "https://github.com/mr-karan/doggo/releases/download/v1.2.0/doggo-darwin-x86_64.tar.gz"
-url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/455378251"
+checksum = "sha256:ec67fb4f33a4e630b89462f520365574881b78310845ee8623545eeca233f667"
+url = "https://github.com/mr-karan/doggo/releases/download/v1.3.0/doggo-darwin-x86_64.tar.gz"
+url_api = "https://api.github.com/repos/mr-karan/doggo/releases/assets/504896301"
 
 [[tools."github:ouch-org/ouch"]]
 version = "0.8.1"
@@ -733,28 +733,28 @@ url_api = "https://api.github.com/repos/ouch-org/ouch/releases/assets/461471616"
 provenance = "github-attestations"
 
 [[tools."github:shonenm/live-pr"]]
-version = "0.1.0-alpha.12"
+version = "0.1.0"
 backend = "github:shonenm/live-pr"
 
 [tools."github:shonenm/live-pr"."platforms.linux-arm64"]
-checksum = "sha256:8bed92089213fff39a11eb851541f856106753dc63b87cf6aaaf69c52bb341a1"
-url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0-alpha.12/live-pr_0.1.0-alpha.12_Linux_arm64.tar.gz"
-url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510219791"
+checksum = "sha256:ad1a57a17ed54920eca3a6547594217ae15e45ceaa716b13d70754f7ba12d3cf"
+url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0/live-pr_0.1.0_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510393159"
 
 [tools."github:shonenm/live-pr"."platforms.linux-x64"]
-checksum = "sha256:e6e216c4f6fb9e8014ce131653c34cba614291883b198a34b554d8f3370b460d"
-url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0-alpha.12/live-pr_0.1.0-alpha.12_Linux_amd64.tar.gz"
-url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510219788"
+checksum = "sha256:a4aab54909cbb9110bbecb5e7c98067f6c54bccfa5423d34083c036946c91e01"
+url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0/live-pr_0.1.0_Linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510393143"
 
 [tools."github:shonenm/live-pr"."platforms.macos-arm64"]
-checksum = "sha256:8d4e68be6aef36b2ed49406698612293afc8c89a24e6e0bb56c26d4129aeba88"
-url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0-alpha.12/live-pr_0.1.0-alpha.12_Darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510219810"
+checksum = "sha256:85d794f54fae0688aac88f3feb530bae3dd601a62dd084d65b4d037a672fe345"
+url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0/live-pr_0.1.0_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510393144"
 
 [tools."github:shonenm/live-pr"."platforms.macos-x64"]
-checksum = "sha256:7587e441ed175af8bde58b39ba7bbc4b110ee2fb1de46ee0ad369678d654344b"
-url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0-alpha.12/live-pr_0.1.0-alpha.12_Darwin_amd64.tar.gz"
-url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510219789"
+checksum = "sha256:49994416b3168598e0913ac9713de4eee5bf4e013944060719ced3c57c24f367"
+url = "https://github.com/shonenm/live-pr/releases/download/v0.1.0/live-pr_0.1.0_Darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/shonenm/live-pr/releases/assets/510393142"
 
 [[tools.go]]
 version = "1.26.5"

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -5,6 +5,7 @@
 tap "dotenvx/brew"
 tap "FelixKratz/formulae"
 tap "joshmedeski/sesh"
+tap "nikitabobko/tap"
 tap "trasta298/tap"
 tap "oven-sh/bun"
 

--- a/config/Brewfile
+++ b/config/Brewfile
@@ -4,6 +4,7 @@
 # --- Taps ---
 tap "dotenvx/brew"
 tap "FelixKratz/formulae"
+tap "joshmedeski/sesh"
 tap "trasta298/tap"
 tap "oven-sh/bun"
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -79,8 +79,8 @@ no-sudo環境では `~/.local/bin/op signin` を実行し、再実行にも `--n
 ## 運用コマンド
 
 ```bash
-dots apply             # 宣言を反映
-dots update            # fast-forward後に依存を再取得して反映
+dots apply             # 現在の宣言とlockfileを反映
+dots update            # fast-forward後にmise lockを更新し、依存を再取得して反映
 dots check             # CIと同じ検証
 dots doctor            # toolとStow linkを診断
 dots lock              # maintainer向け: mise lockfileを更新
@@ -93,7 +93,7 @@ dots lock              # maintainer向け: mise lockfileを更新
 - mise tool: `common/mise/.config/mise/mise.lock`にmacOS / Linux、x86_64 / arm64のversion・download URL・checksumを固定
 - npm CLI: `config/packages.npm.txt`にversionを固定
 - GitHub Actions: commit SHAを固定
-- 更新: `.github/workflows/dependencies.yml`が週次でRenovateと`dots lock`を実行し、3日以上経過したreleaseだけをPR化
+- 更新: `dots update`または`.github/workflows/dependencies.yml`の週次実行が`dots lock`を更新する。3日以上経過したreleaseだけを対象とする
 
 ## CI
 

--- a/install.sh
+++ b/install.sh
@@ -226,7 +226,7 @@ normalize_dotfiles_symlinks() {
     for source in "$DOTFILES_DIR"/common/*/"$relative" "$DOTFILES_DIR"/mac/*/"$relative"; do
       [[ -e "$source" && "$resolved" == "$(realpath "$source")" ]] && { unlink "$link"; break; }
     done
-  done < <(find "$HOME/.pi" "$HOME/.config/raycast" -type l -print0 2>/dev/null)
+  done < <(find "$HOME/.pi" -type l -print0 2>/dev/null)
 }
 
 # Stow a package with conflict detection and backup
@@ -497,6 +497,7 @@ link_dotfiles() {
     log_info "Linking common dotfiles..."
     local common_packages=()
     for pkg in "$DOTFILES_DIR/common"/*/; do
+      git -C "$DOTFILES_DIR" ls-files --error-unmatch "${pkg#"$DOTFILES_DIR"/}" >/dev/null 2>&1 || continue
       common_packages+=("$(basename "$pkg")")
     done
     if ! stow_package_group "$DOTFILES_DIR/common" "${common_packages[@]}"; then
@@ -509,6 +510,7 @@ link_dotfiles() {
     log_info "Linking $os-specific dotfiles..."
     local os_packages=()
     for pkg in "$DOTFILES_DIR/$os"/*/; do
+      git -C "$DOTFILES_DIR" ls-files --error-unmatch "${pkg#"$DOTFILES_DIR"/}" >/dev/null 2>&1 || continue
       os_packages+=("$(basename "$pkg")")
     done
     if ! stow_package_group "$DOTFILES_DIR/$os" "${os_packages[@]}"; then

--- a/install.sh
+++ b/install.sh
@@ -214,6 +214,21 @@ setup_environment() {
 
 # --- 3. Link Dotfiles (Stow) ---
 
+# Replace absolute links into this repository with links owned by Stow.
+# Older installer runs created these links directly; Stow 2.4 rejects them even
+# though source and target resolve to the same file.
+normalize_dotfiles_symlinks() {
+  local link relative resolved source
+  while IFS= read -r -d '' link; do
+    [[ $(readlink "$link") == /* ]] || continue
+    relative=${link#"$HOME"/}
+    resolved=$(realpath "$link" 2>/dev/null || true)
+    for source in "$DOTFILES_DIR"/common/*/"$relative" "$DOTFILES_DIR"/mac/*/"$relative"; do
+      [[ -e "$source" && "$resolved" == "$(realpath "$source")" ]] && { unlink "$link"; break; }
+    done
+  done < <(find "$HOME/.pi" "$HOME/.config/raycast" -type l -print0 2>/dev/null)
+}
+
 # Stow a package with conflict detection and backup
 stow_package() {
   local pkg_dir="$1"
@@ -475,6 +490,7 @@ link_dotfiles() {
   # Create .config if not exists
   mkdir -p "$HOME/.config"
   cleanup_broken_skill_links
+  normalize_dotfiles_symlinks
 
   # Stow common packages
   if [[ -d "$DOTFILES_DIR/common" ]]; then
@@ -1010,7 +1026,7 @@ install_pi_packages() {
 import json
 with open('$settings_file') as f:
     for pkg in json.load(f).get('packages', []):
-        print(pkg)
+        print(pkg if isinstance(pkg, str) else pkg['source'])
 " 2>/dev/null) || {
     log_warn "Failed to read pi packages from settings.json"
     return 0
@@ -1028,15 +1044,19 @@ with open('$settings_file') as f:
   fi
 
   log_info "Installing pi packages..."
+  local package_failed=false
   while IFS= read -r pkg; do
     [[ -z "$pkg" ]] && continue
     if pi install "$pkg" >/dev/null 2>&1; then
       log_success "  pi package: $pkg"
     else
       log_warn "  pi package failed: $pkg"
+      package_failed=true
     fi
   done <<< "$packages"
-  record_install_state pi-packages "$packages_fp"
+  if [[ "$package_failed" == "false" ]]; then
+    record_install_state pi-packages "$packages_fp"
+  fi
 }
 
 # --- 4.5. Configure rtk Claude Code hook ---

--- a/install.sh
+++ b/install.sh
@@ -646,8 +646,7 @@ generate_ai_cli_configs() {
 
   # Claude CLI — merge the template into the existing settings instead of
   # regenerating from scratch. Template keys win (single source of truth),
-  # but keys only present locally (model, hooks registered by other steps
-  # like rtk, feedbackSurveyState, ...) are preserved.
+  # but keys only present locally (model, feedbackSurveyState, ...) are preserved.
   if [[ -f "$templates_dir/claude-settings.json" ]]; then
     mkdir -p "$HOME/.claude"
     local rendered_template
@@ -974,10 +973,6 @@ main() {
   # 4. Generate AI CLI configs (with absolute paths)
   generate_ai_cli_configs
 
-  # 4.5. Configure rtk Claude Code hook (token compression)
-  configure_rtk_claude_hook
-  configure_rtk_passthrough
-
   # 4.6. Disable Serena MCP dashboard auto-open
   configure_serena_dashboard
 
@@ -1059,71 +1054,6 @@ with open('$settings_file') as f:
   if [[ "$package_failed" == "false" ]]; then
     record_install_state pi-packages "$packages_fp"
   fi
-}
-
-# --- 4.5. Configure rtk Claude Code hook ---
-# rtk init -g registers a Bash hook in ~/.claude/settings.json that transparently
-# rewrites commands like `git status` -> `rtk git status` for 60-90% token reduction.
-# --auto-patch is required: without it rtk prompts before patching settings.json,
-# and in non-interactive installs the prompt fails, leaving RTK.md claiming a
-# hook that was never installed.
-# Idempotent: skips if hook already configured. Must run after
-# generate_ai_cli_configs, whose template merge resets the hook arrays.
-configure_rtk_claude_hook() {
-  if ! command_exists rtk; then
-    log_warn "rtk not installed, skipping rtk Claude hook setup"
-    return 0
-  fi
-
-  local settings_file="$HOME/.claude/settings.json"
-  if [[ -f "$settings_file" ]] && grep -q '"rtk"' "$settings_file" 2>/dev/null; then
-    log_info "rtk Claude hook already configured"
-    return 0
-  fi
-
-  log_info "Configuring rtk Claude Code hook (token compression)..."
-  if rtk init -g --auto-patch; then
-    log_success "rtk Claude hook configured"
-  else
-    log_warn "rtk init -g --auto-patch failed (non-fatal)"
-  fi
-}
-
-# rtk's heuristic digest corrupts machine-readable output: it truncates long
-# file reads, caps grep/ls results, mangles git porcelain, and has even
-# fabricated content. List the file-op and git commands in
-# [hooks].exclude_commands of ~/.config/rtk/config.toml so they pass through
-# raw, while test/lint/typecheck/build commands stay digested (where the token
-# savings actually are). Idempotent: rewrites only the exclude_commands array,
-# preserving rtk's other (machine-local) keys such as telemetry consent.
-configure_rtk_passthrough() {
-  command_exists rtk || return 0
-  local cfg="${XDG_CONFIG_HOME:-$HOME/.config}/rtk/config.toml"
-  [[ -f "$cfg" ]] || rtk config --create >/dev/null 2>&1 || true
-  [[ -f "$cfg" ]] || { log_warn "rtk config.toml absent, skipping passthrough setup"; return 0; }
-
-  python3 - "$cfg" <<'PYEOF'
-import re, sys
-
-path = sys.argv[1]
-with open(path) as f:
-    text = f.read()
-
-excluded = ["cat", "head", "tail", "sed", "awk", "ls", "grep", "rg", "find", "wc", "git"]
-array = "exclude_commands = [\n" + "".join(f'    "{c}",\n' for c in excluded) + "]"
-
-pattern = re.compile(r'exclude_commands\s*=\s*\[[^\]]*\]')
-if pattern.search(text):
-    text = pattern.sub(array, text, count=1)
-elif re.search(r'^\[hooks\]\s*$', text, re.M):
-    text = re.sub(r'(^\[hooks\][^\n]*\n)', r'\1' + array + "\n", text, count=1, flags=re.M)
-else:
-    text = text.rstrip() + "\n\n[hooks]\n" + array + "\n"
-
-with open(path, "w") as f:
-    f.write(text)
-PYEOF
-  log_success "  rtk: file-op/git commands pass through raw (savings kept for test/lint/build)"
 }
 
 # --- 4.6. Disable Serena MCP dashboard auto-open ---

--- a/scripts/dots
+++ b/scripts/dots
@@ -11,6 +11,7 @@ case "$command" in
     ;;
   update)
     git -C "$root" pull --ff-only
+    "$root/scripts/update-mise-lock"
     exec "$root/install.sh" --update "$@"
     ;;
   check)

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -20,6 +20,10 @@ install_brew_bundle() {
     return 1
   fi
   log_info "Installing Homebrew packages from Brewfile..."
+  # Homebrew 6 refuses formulae from third-party taps until explicitly trusted.
+  while IFS= read -r tap; do
+    brew trust --tap "$tap" >/dev/null
+  done < <(sed -n 's/^tap "\([^"]*\)".*/\1/p' "$brewfile")
   if brew bundle check --file="$brewfile" >/dev/null 2>&1; then
     log_success "Brewfile packages already installed"
     return 0


### PR DESCRIPTION
## Summary

Refresh mise-managed tools during `dots update` and fix installer failures caused by updated Homebrew, Stow, and Pi package behavior.

## Changes

- refresh the cross-platform mise lockfile after pulling updates
- track `live-pr` with `latest` and lock stable `v0.1.0`
- trust third-party Brewfile taps before running Homebrew 6 `brew bundle`
- install object-form Pi packages using their declared `source`
- skip runtime-only directories when collecting Stow packages
- remove unused RTK hook configuration
- document `dots apply` versus `dots update`

## Test plan

- [x] Run `dots update` successfully on macOS
- [x] Verify Homebrew bundle completes
- [x] Verify grouped Stow linking completes
- [x] Verify all declared Pi packages install
- [x] Run ShellCheck and shell syntax checks
- [x] Run `scripts/test-install-fast-paths.sh`
- [x] Run `scripts/check-markdown-links.py`
- [x] Run `scripts/check-package-duplication.sh`
