### PR TITLE
Improve CodeReview workflow and CLI

### DIFF
--- a/common/nvim/.config/nvim/lua/config/autocmds.lua
+++ b/common/nvim/.config/nvim/lua/config/autocmds.lua
@@ -8,6 +8,20 @@
 -- Disable built-in spell check for markdown etc. (Japanese text gets flagged as SpellBad)
 vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
 
+-- Neovim only tries a-z for ShaDa temporary files. Stale files can exhaust all
+-- names and cause E138 on exit, so remove only old leftovers from dead sessions.
+do
+  local shada_dir = vim.fn.stdpath("state") .. "/shada"
+  local cutoff = os.time() - 24 * 60 * 60
+  for name, kind in vim.fs.dir(shada_dir) or function() return nil end do
+    if kind == "file" and name:match("^main%.shada%.tmp%.[a-z]$") then
+      local path = shada_dir .. "/" .. name
+      local stat = vim.uv.fs_stat(path)
+      if stat and stat.mtime.sec < cutoff then vim.uv.fs_unlink(path) end
+    end
+  end
+end
+
 -- Auto reload files when changed externally. Focus/entry checks are sufficient;
 -- CursorHold and one fs_event watcher per buffer caused duplicate polling.
 vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter" }, {

--- a/common/nvim/.config/nvim/lua/config/codediff.lua
+++ b/common/nvim/.config/nvim/lua/config/codediff.lua
@@ -1525,6 +1525,45 @@ function M.setup(opts)
         orig_on_file_select(file_data)
       end
 
+      local path_buf = nil
+      local path_win = nil
+
+      local function hide_review_path()
+        if path_win and vim.api.nvim_win_is_valid(path_win) then vim.api.nvim_win_close(path_win, true) end
+        if path_buf and vim.api.nvim_buf_is_valid(path_buf) then
+          vim.api.nvim_buf_delete(path_buf, { force = true })
+        end
+        path_buf, path_win = nil, nil
+      end
+
+      local function update_review_path(path)
+        if not path then
+          hide_review_path()
+          return
+        end
+        if not path_buf or not vim.api.nvim_buf_is_valid(path_buf) then
+          path_buf = vim.api.nvim_create_buf(false, true)
+        end
+        vim.bo[path_buf].modifiable = true
+        vim.api.nvim_buf_set_lines(path_buf, 0, -1, false, { " " .. path .. " " })
+        vim.bo[path_buf].modifiable = false
+        local width = math.max(1, math.min(vim.o.columns - 2, vim.fn.strdisplaywidth(path) + 2))
+        local height = math.max(1, math.ceil((vim.fn.strdisplaywidth(path) + 2) / width))
+        local status_height = vim.o.laststatus == 0 and 0 or 1
+        local row = math.max(0, vim.o.lines - vim.o.cmdheight - status_height - height - 2)
+        local config = {
+          relative = "editor", row = row, col = 0, width = width, height = height,
+          style = "minimal", border = "rounded", focusable = false, noautocmd = true, zindex = 105,
+        }
+        if path_win and vim.api.nvim_win_is_valid(path_win) then
+          vim.api.nvim_win_set_config(path_win, config)
+        else
+          path_win = vim.api.nvim_open_win(path_buf, false, config)
+          vim.wo[path_win].wrap = true
+          vim.wo[path_win].winhighlight = "Normal:NormalFloat,FloatBorder:Comment"
+        end
+      end
+
       -- ヘルプ表示関数（このexplorerに特化）
       local function update_help_line()
         local bufnr = explorer.bufnr
@@ -1565,18 +1604,19 @@ function M.setup(opts)
           help_lines = vim.deepcopy(in_diff and review_diff_help_lines or review_explorer_help_lines)
           local checked, total = review_counts(rexpl, rexpl.git_root, rexpl.base_revision, rexpl.target_revision)
           table.insert(help_lines, 1, { { "reviewed ", "Normal" }, { checked .. "/" .. total, review_progress_hl(checked, total) } })
-          if rexpl.current_file_path then
-            help_lines[#help_lines + 1] = { { rexpl.git_root .. "/" .. rexpl.current_file_path, "Comment" } }
-          end
+          update_review_path(rexpl.current_file_path and (rexpl.git_root .. "/" .. rexpl.current_file_path) or nil)
         elseif in_conflict then
+          hide_review_path()
           help_lines = conflict_help_lines
         elseif in_diff then
+          hide_review_path()
           local in_staged = false
           if session_check and session_check.modified_revision == ":0" then
             in_staged = true
           end
           help_lines = in_staged and diff_staged_help_lines or diff_help_lines
         else
+          hide_review_path()
           help_lines = explorer_help_lines
         end
 
@@ -1630,6 +1670,9 @@ function M.setup(opts)
           if current_tabpage ~= explorer_tabpage then return end
           vim.schedule(update_help_line)
         end,
+      })
+      vim.api.nvim_create_autocmd({ "TabLeave", "TabClosed" }, {
+        callback = hide_review_path,
       })
 
       -- スクロール時にヘルプ位置を更新

--- a/common/nvim/.config/nvim/lua/config/codediff.lua
+++ b/common/nvim/.config/nvim/lua/config/codediff.lua
@@ -447,7 +447,27 @@ function M.setup(opts)
       end
     end
 
+    local function enable_codediff_wrap()
+      local ok, session_mod = pcall(require, "codediff.ui.lifecycle.session")
+      if not ok then return end
+      for _, session in pairs(session_mod.get_active_diffs()) do
+        for _, win in ipairs({ session.original_win, session.modified_win, session.result_win }) do
+          if win and vim.api.nvim_win_is_valid(win) then
+            vim.wo[win].wrap = true
+            vim.wo[win].linebreak = true
+            vim.wo[win].breakindent = true
+          end
+        end
+      end
+    end
+
     local hunk_notification_group = vim.api.nvim_create_augroup("CodeDiffHunkNotification", { clear = true })
+    vim.api.nvim_create_autocmd({ "CursorMoved", "BufEnter", "WinEnter", "TabEnter", "VimResized" }, {
+      group = hunk_notification_group,
+      callback = function()
+        vim.schedule(enable_codediff_wrap)
+      end,
+    })
     vim.api.nvim_create_autocmd({ "CursorMoved", "BufEnter", "WinEnter", "TabEnter" }, {
       group = hunk_notification_group,
       callback = function()
@@ -458,7 +478,10 @@ function M.setup(opts)
       group = hunk_notification_group,
       pattern = "CodeDiffVirtualFileLoaded",
       callback = function()
-        vim.schedule(update_hunk_notification)
+        vim.schedule(function()
+          enable_codediff_wrap()
+          update_hunk_notification()
+        end)
       end,
     })
     vim.api.nvim_create_autocmd({ "TabClosed", "WinClosed" }, {
@@ -1368,8 +1391,8 @@ function M.setup(opts)
           vim.api.nvim_win_set_cursor(modified_win, { 1, 0 })
           vim.wo[original_win].scrollbind = true
           vim.wo[modified_win].scrollbind = true
-          vim.wo[original_win].wrap = false
-          vim.wo[modified_win].wrap = false
+          vim.wo[original_win].wrap = true
+          vim.wo[modified_win].wrap = true
 
           if auto_scroll_to_first_hunk and #cached_diff.changes > 0 then
             local first_change = cached_diff.changes[1]

--- a/common/nvim/.config/nvim/lua/config/codediff.lua
+++ b/common/nvim/.config/nvim/lua/config/codediff.lua
@@ -197,6 +197,8 @@ function M.setup(opts)
       file:close()
       local ok, decoded = pcall(vim.json.decode, data)
       if not ok or type(decoded) ~= "table" then return end
+      reviewed_marks = {}
+      review_fingerprints = {}
       for k, fingerprint in pairs(decoded) do
         if type(k) == "string" and type(fingerprint) == "string" then
           reviewed_marks[k] = fingerprint
@@ -256,7 +258,39 @@ function M.setup(opts)
       save_reviewed_marks()
     end
 
+    local function toggle_reviewed_paths(git_root, base_rev, target_rev, paths)
+      local mark = false
+      for _, path in ipairs(paths) do
+        if not is_reviewed(git_root, base_rev, target_rev, path) then
+          mark = true
+          break
+        end
+      end
+      for _, path in ipairs(paths) do
+        local key = review_key(git_root, base_rev, target_rev, path)
+        if mark then
+          local fingerprint = review_diff_fingerprint(git_root, base_rev, target_rev, path)
+          if fingerprint then
+            reviewed_marks[key] = fingerprint
+            review_fingerprints[key] = fingerprint
+          end
+        else
+          reviewed_marks[key] = nil
+          review_fingerprints[key] = nil
+        end
+      end
+      save_reviewed_marks()
+    end
+
     load_reviewed_marks()
+    vim.api.nvim_create_autocmd("FocusGained", {
+      callback = function()
+        load_reviewed_marks()
+        local ok, lifecycle = pcall(require, "codediff.ui.lifecycle")
+        local explorer = ok and lifecycle.get_explorer and lifecycle.get_explorer(vim.api.nvim_get_current_tabpage()) or nil
+        if explorer and explorer.tree then explorer.tree:render() end
+      end,
+    })
     -- Returns git_root, base_rev, target_rev when the current tab is a two-commit
     -- review diff (both sides real commits), else nil. Reads the explorer object
     -- (authoritative for base/target; the session's revisions can lag before a file
@@ -333,16 +367,22 @@ function M.setup(opts)
       vim.notify("All files reviewed", vim.log.levels.INFO)
     end
 
-    -- Keep the current hunk position visible while a CodeDiff tab is active.
-    -- This is shared by normal CodeDiff and two-commit CodeReview sessions.
-    local hunk_notification_id = "codediff_hunk_position"
+    -- Keep the current hunk position in a dedicated top-right window. Normal
+    -- notifications reserve these rows and therefore always stack below it.
     local hunk_notification_label = nil
+    local hunk_notification_buf = nil
+    local hunk_notification_win = nil
 
     local function hide_hunk_notification()
-      if hunk_notification_label and _G.Snacks and Snacks.notifier then
-        Snacks.notifier.hide(hunk_notification_id)
+      if hunk_notification_win and vim.api.nvim_win_is_valid(hunk_notification_win) then
+        vim.api.nvim_win_close(hunk_notification_win, true)
+      end
+      if hunk_notification_buf and vim.api.nvim_buf_is_valid(hunk_notification_buf) then
+        vim.api.nvim_buf_delete(hunk_notification_buf, { force = true })
       end
       hunk_notification_label = nil
+      hunk_notification_buf = nil
+      hunk_notification_win = nil
     end
 
     local function update_hunk_notification()
@@ -386,15 +426,24 @@ function M.setup(opts)
       if label == hunk_notification_label then return end
       hunk_notification_label = label
 
-      if _G.Snacks and Snacks.notifier then
-        Snacks.notifier.notify(label, vim.log.levels.INFO, {
-          id = hunk_notification_id,
-          title = "CodeDiff",
-          timeout = false,
-          history = false,
-        })
+      if not hunk_notification_buf or not vim.api.nvim_buf_is_valid(hunk_notification_buf) then
+        hunk_notification_buf = vim.api.nvim_create_buf(false, true)
+      end
+      vim.bo[hunk_notification_buf].modifiable = true
+      vim.api.nvim_buf_set_lines(hunk_notification_buf, 0, -1, false, { " " .. label .. " " })
+      vim.bo[hunk_notification_buf].modifiable = false
+      local width = vim.fn.strdisplaywidth(label) + 2
+      local row = vim.o.showtabline == 0 and 0 or 1
+      local config = {
+        relative = "editor", row = row, col = math.max(0, vim.o.columns - width - 2),
+        width = width, height = 1, style = "minimal", border = "rounded",
+        focusable = false, noautocmd = true, zindex = 110,
+      }
+      if hunk_notification_win and vim.api.nvim_win_is_valid(hunk_notification_win) then
+        vim.api.nvim_win_set_config(hunk_notification_win, config)
       else
-        vim.notify(label, vim.log.levels.INFO, { title = "CodeDiff", timeout = false })
+        hunk_notification_win = vim.api.nvim_open_win(hunk_notification_buf, false, config)
+        vim.wo[hunk_notification_win].winhighlight = "Normal:SnacksNotifierInfo,FloatBorder:SnacksNotifierBorderInfo"
       end
     end
 
@@ -460,7 +509,11 @@ function M.setup(opts)
 
       if data.type == "group" then
         line:append(" ", "Directory")
-        line:append(node.text, "Directory")
+        if codereview_ctx() then
+          line:append(string.format("Files (%d)", data.file_count or 0), "Directory")
+        else
+          line:append(node.text, "Directory")
+        end
       elseif data.type == "directory" then
         local indent = build_indent_markers(data.indent_state)
         local folder_icon, folder_color = nodes_mod.get_folder_icon(node:is_expanded())
@@ -1020,6 +1073,15 @@ function M.setup(opts)
       { { "[co]", "Special" }, { " ours  ", "Normal" }, { "[ct]", "Special" }, { " theirs  ", "Normal" }, { "[cb]", "Special" }, { " both  ", "Normal" }, { "[c0]", "Special" }, { " none", "Normal" } },
       { { "[", "Special" }, { "]x", "Normal" }, { "/", "Special" }, { "[x", "Normal" }, { "]", "Special" }, { " conflict  ", "Normal" }, { "[Tab]", "Special" }, { " sidebar  ", "Normal" }, { "[q]", "Special" }, { " close", "Normal" } },
     }
+    local review_progress_colors = { "#f7768e", "#ff9e64", "#e0af68", "#9ece6a", "#73daca", "#7dcfff", "#7aa2f7" }
+    for i, color in ipairs(review_progress_colors) do
+      vim.api.nvim_set_hl(0, "CodeReviewProgress" .. i, { fg = color, bold = true })
+    end
+
+    local function review_progress_hl(checked, total)
+      local ratio = total == 0 and 1 or checked / total
+      return "CodeReviewProgress" .. math.min(7, math.floor(ratio * 7) + 1)
+    end
 
     -- view.updateをラップしてeventignoreを設定
     -- オリジナルのview.updateを使いつつ、BufEnter/WinEnterのみを一時的に抑制
@@ -1472,7 +1534,7 @@ function M.setup(opts)
         local win_height = vim.api.nvim_win_get_height(winid)
         local line_count = vim.api.nvim_buf_line_count(bufnr)
         local first_visible = vim.fn.line("w0", winid)
-        local help_height = #explorer_help_lines -- both help tables have similar height
+        local help_height = 5 -- progress/path plus the largest help table
         -- ウィンドウ下部にヘルプを固定（最低限の領域確保）
         local max_target = first_visible + win_height - help_height - 2
         local target_line = math.min(max_target, line_count - 1)
@@ -1502,7 +1564,10 @@ function M.setup(opts)
         if is_review then
           help_lines = vim.deepcopy(in_diff and review_diff_help_lines or review_explorer_help_lines)
           local checked, total = review_counts(rexpl, rexpl.git_root, rexpl.base_revision, rexpl.target_revision)
-          table.insert(help_lines, 1, { { "reviewed ", "Normal" }, { checked .. "/" .. total, "Title" } })
+          table.insert(help_lines, 1, { { "reviewed ", "Normal" }, { checked .. "/" .. total, review_progress_hl(checked, total) } })
+          if rexpl.current_file_path then
+            help_lines[#help_lines + 1] = { { rexpl.git_root .. "/" .. rexpl.current_file_path, "Comment" } }
+          end
         elseif in_conflict then
           help_lines = conflict_help_lines
         elseif in_diff then
@@ -1675,18 +1740,19 @@ function M.setup(opts)
       if explorer.base_revision and explorer.target_revision and explorer.target_revision ~= "WORKING" then
         vim.keymap.set("n", "c", function()
           local node = tree:get_node()
-          if not node or not node.data or not node.data.path then return end
-          if node.data.type == "group" or node.data.type == "directory" then return end
+          if not node or not node.data or node.data.type == "group" then return end
           local gr, o, m = codereview_ctx()
           if not gr then return end
-          local k = review_key(gr, o, m, node.data.path)
-          if is_reviewed(gr, o, m, node.data.path) then
-            reviewed_marks[k] = nil
-            review_fingerprints[k] = nil
-            save_reviewed_marks()
-          else
-            mark_reviewed(gr, o, m, node.data.path)
+          local paths = {}
+          if node.data.type == "directory" then
+            for _, file in ipairs(node.data.files or {}) do
+              paths[#paths + 1] = file.path
+            end
+          elseif node.data.path then
+            paths[1] = node.data.path
           end
+          if #paths == 0 then return end
+          toggle_reviewed_paths(gr, o, m, paths)
           tree:render()
         end, vim.tbl_extend("force", map_opts, { desc = "Toggle reviewed mark" }))
         vim.keymap.set("n", ".", function()
@@ -2208,6 +2274,20 @@ function M.setup(opts)
     end
 
     vim.keymap.set("n", "<leader>gd", open_all_repos_with_changes, { desc = "CodeDiff Open" })
+
+    vim.api.nvim_create_user_command("CodeReviewCopyPath", function()
+      local git_root, _, _ = codereview_ctx()
+      local ok, lifecycle = pcall(require, "codediff.ui.lifecycle")
+      local explorer = ok and lifecycle.get_explorer and lifecycle.get_explorer(vim.api.nvim_get_current_tabpage()) or nil
+      local path = explorer and explorer.current_file_path or nil
+      if not git_root or not path then
+        vim.notify("No CodeReview file selected", vim.log.levels.WARN)
+        return
+      end
+      local full_path = git_root .. "/" .. path
+      vim.fn.setreg("+", full_path)
+      vim.notify("Copied: " .. full_path, vim.log.levels.INFO)
+    end, { desc = "Copy current CodeReview file path" })
 
     -- :CodeReview [base] [target] - two-commit review diff (default HEAD~1 HEAD)
     vim.api.nvim_create_user_command("CodeReview", function(o)

--- a/common/nvim/.config/nvim/lua/plugins/codediff.lua
+++ b/common/nvim/.config/nvim/lua/plugins/codediff.lua
@@ -1,6 +1,15 @@
 return {
-  -- Disable snacks_picker's <leader>gd (Git Diff hunks) to free it for CodeDiff
-  { "folke/snacks.nvim", keys = { { "<leader>gd", false } } },
+  -- Disable snacks_picker's <leader>gd (Git Diff hunks) to free it for CodeDiff.
+  -- Reserve the first three rows for CodeDiff's fixed hunk indicator and wrap
+  -- long notifications instead of clipping them at the screen edge.
+  {
+    "folke/snacks.nvim",
+    keys = { { "<leader>gd", false } },
+    opts = {
+      notifier = { margin = { top = 3, right = 1, bottom = 0 } },
+      styles = { notification = { wo = { wrap = true } } },
+    },
+  },
   {
     "esmuellert/codediff.nvim",
     dependencies = { "MunifTanjim/nui.nvim" },

--- a/common/nvim/.config/nvim/lua/plugins/codediff.lua
+++ b/common/nvim/.config/nvim/lua/plugins/codediff.lua
@@ -6,7 +6,10 @@ return {
     "folke/snacks.nvim",
     keys = { { "<leader>gd", false } },
     opts = {
-      notifier = { margin = { top = 3, right = 1, bottom = 0 } },
+      notifier = {
+        margin = { top = 3, right = 1, bottom = 0 },
+        width = { min = 40, max = 0.9 },
+      },
       styles = { notification = { wo = { wrap = true } } },
     },
   },

--- a/common/zsh/.zshrc.common
+++ b/common/zsh/.zshrc.common
@@ -378,12 +378,6 @@ dexec() {
   docker exec -it -e TERM="$TERM" -e COLORTERM="$COLORTERM" -e CLAUDE_CONTEXT="$context" "$container" "${@:-bash}"
 }
 
-# 2コミット間レビュー diff を nvim で開く (:CodeReview のラッパー)
-# Usage: codereview [base-ref] [target-ref]   (省略時 HEAD~1 HEAD)
-codereview() {
-  nvim -c "CodeReview $*"
-}
-
 # 現在ブランチをデフォルトブランチと3点diffでレビュー (:CodeReviewBranch のラッパー)
 # Usage: codereview-branch [base-ref]   (省略時デフォルトブランチ自動検出)
 codereview-branch() {

--- a/docs/tools/neovim/overview.md
+++ b/docs/tools/neovim/overview.md
@@ -463,7 +463,7 @@ LazyVim のデフォルトキーバインドを使用。`<leader>` は `Space`�
 
 `gs`/`gr` は gitsigns コマンド実行後に diff キャッシュを無効化し、仮想バッファ・実ファイルバッファ・diff 計算結果を自動再読み込みする。ビジュアルモードでの範囲選択にも対応。`gu` は staged diff view（HEAD vs `:0`）でカーソル位置のハンクを `git apply --reverse --cached` で個別 unstage する。
 
-CodeDiff の diff を表示している間は、右上最上段の固定枠に現在の hunk 位置（`Hunk N of M`）を常時表示する。カーソル移動・hunk 移動・ファイル切替に追従し、CodeDiff のタブを離れると閉じる。通常の notification はその下へ積まれ、画面幅を超える本文は折り返す。通常の CodeDiff とレビューモードで共通の表示となる。
+CodeDiff の diff を表示している間は、右上最上段の固定枠に現在の hunk 位置（`Hunk N of M`）を常時表示する。カーソル移動・hunk 移動・ファイル切替に追従し、CodeDiff のタブを離れると閉じる。通常の notification はその下へ積まれる。diffのコード行はpane幅を超えると折り返す。通常の CodeDiff とレビューモードで共通の表示となる。
 
 `<leader>gd` はワークスペース内の全 git リポジトリ（parent・submodule・独立 clone）を自動探索し、変更のあるリポジトリごとに CodeDiff タブを開く。複数タブがある場合、ヘルプラインにリポジトリ一覧が表示され、`]r`/`[r` でタブ間を移動できる。
 

--- a/docs/tools/neovim/overview.md
+++ b/docs/tools/neovim/overview.md
@@ -463,7 +463,7 @@ LazyVim のデフォルトキーバインドを使用。`<leader>` は `Space`�
 
 `gs`/`gr` は gitsigns コマンド実行後に diff キャッシュを無効化し、仮想バッファ・実ファイルバッファ・diff 計算結果を自動再読み込みする。ビジュアルモードでの範囲選択にも対応。`gu` は staged diff view（HEAD vs `:0`）でカーソル位置のハンクを `git apply --reverse --cached` で個別 unstage する。
 
-CodeDiff の diff を表示している間は、右上の notification に現在の hunk 位置（`Hunk N of M`）を常時表示する。カーソル移動・hunk 移動・ファイル切替に追従し、CodeDiff のタブを離れると閉じる。通常の CodeDiff とレビューモードで共通の表示となる。
+CodeDiff の diff を表示している間は、右上最上段の固定枠に現在の hunk 位置（`Hunk N of M`）を常時表示する。カーソル移動・hunk 移動・ファイル切替に追従し、CodeDiff のタブを離れると閉じる。通常の notification はその下へ積まれ、画面幅を超える本文は折り返す。通常の CodeDiff とレビューモードで共通の表示となる。
 
 `<leader>gd` はワークスペース内の全 git リポジトリ（parent・submodule・独立 clone）を自動探索し、変更のあるリポジトリごとに CodeDiff タブを開く。複数タブがある場合、ヘルプラインにリポジトリ一覧が表示され、`]r`/`[r` でタブ間を移動できる。
 
@@ -477,7 +477,7 @@ stage/restore/reset 等で全ての変更が解消されると（unstaged・stag
 
 | キー  | 動作                                |
 | ----- | ----------------------------------- |
-| `c`   | レビュー済み印トグル（`○` ↔ `✓`）   |
+| `c`   | ファイル/ディレクトリ配下のレビュー済み印トグル（`○` ↔ `✓`） |
 | `.`   | 次のファイルへ                      |
 | `,`   | 前のファイルへ                      |
 | `]`   | 次の hunk へ（sidebar focus を維持） |
@@ -496,7 +496,9 @@ Diff ビュー（`,`/`.` はサイドバーと同じくファイル移動。hunk
 | `}`   | 次の未チェックファイルへ |
 | `{`   | 前の未チェックファイルへ |
 
-ヘルプラインに `reviewed <チェック済み>/<総数>` の進捗を表示する。レビュー印はメモリ保持のみ（nvim 終了で消える）。`git_root`・`rev1`・`rev2`・path をキーにするため、比較対象が違えば印は独立する。
+左下には現在選択中ファイルの絶対パスと `reviewed <チェック済み>/<総数>` を常時表示する。進捗値は割合に応じて赤から青まで7段階で変化する。`:CodeReviewCopyPath` で現在の絶対パスをclipboardへコピーできる。
+
+レビュー印は `stdpath("state")/codediff/reviewed.json` に永続化する。`git_root`・`rev1`・`rev2`・path をキーにするため比較対象ごとに独立し、対象ファイルのdiffが変わると自動的に未チェックへ戻る。
 
 起動方法:
 
@@ -504,10 +506,15 @@ Diff ビュー（`,`/`.` はサイドバーと同じくファイル移動。hunk
 | -------- | ---- | ---- |
 | `:CodeReview [base] [target]` | nvim 内 | 2コミット間レビュー（省略時 `HEAD~1 HEAD`） |
 | `:CodeReviewBranch [base]` | nvim 内 | 現在ブランチ vs デフォルトブランチの3点diff |
-| `codereview [base] [target]` | シェル関数 | `:CodeReview` を nvim で起動する薄いラッパー |
-| `codereview-branch [base]` | シェル関数 | `:CodeReviewBranch` を nvim で起動する薄いラッパー |
+| `codereview [base] [target]` | shell | `:CodeReview` を nvim で起動 |
+| `codereview status [base] [target]` | shell | チェック進捗を表示 |
+| `codereview unchecked [base] [target]` | shell | 未チェックファイルを1行1件で表示 |
+| `codereview checked [base] [target]` | shell | チェック済みファイルを1行1件で表示 |
+| `codereview check BASE TARGET PATH...` | shell | ファイルまたはディレクトリ配下をチェック |
+| `codereview uncheck BASE TARGET PATH...` | shell | ファイルまたはディレクトリ配下を未チェックへ戻す |
+| `codereview-branch [base]` | shell function | `:CodeReviewBranch` を nvim で起動 |
 
-シェル関数は `common/zsh/.zshrc.common` に定義（独立スクリプトではない）。エイリアス `cr` = `codereview`、`crb` = `codereview-branch`。
+`codereview` の実体は `scripts/codereview`。エイリアス `cr` = `codereview`、`crb` = `codereview-branch`。一覧はパスだけを標準出力するため、そのままコピーしたりLLMへの指示に貼り付けられる。
 
 `:CodeReviewBranch` は3点diff（`merge-base..HEAD`、このブランチ独自のコミットのみ）で開く。`base` 省略時はデフォルトブランチを自動検出する（`origin/HEAD` → なければ `main`/`master`）。ロジックは nvim コマンド側に集約し、シェルコマンドは `nvim -c "..."` で起動するだけ。
 

--- a/scripts/codereview
+++ b/scripts/codereview
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Open CodeReview or inspect/update its persisted reviewed-file state."""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def git(*args: str, cwd: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, text=True, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, check=check,
+    )
+
+
+def git_root() -> str:
+    try:
+        return git("rev-parse", "--show-toplevel").stdout.strip()
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(error.stderr.strip() or "not a git repository") from error
+
+
+def state_path() -> Path:
+    app = os.environ.get("NVIM_APPNAME", "nvim")
+    root = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state"))
+    return root / app / "codediff/reviewed.json"
+
+
+def load_state() -> dict[str, str]:
+    try:
+        value = json.loads(state_path().read_text())
+        return {key: fingerprint for key, fingerprint in value.items()
+                if isinstance(key, str) and isinstance(fingerprint, str)}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(state: dict[str, str]) -> None:
+    path = state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(state, separators=(",", ":")) + "\n")
+    temporary.replace(path)
+
+
+def review_key(root: str, base: str, target: str, path: str) -> str:
+    return "\0".join((root, base, target, path))
+
+
+def changed_files(root: str, base: str, target: str) -> list[str]:
+    result = git("diff", "--name-only", "-z", base, target, "--", cwd=root)
+    return [path for path in result.stdout.split("\0") if path]
+
+
+def fingerprint(root: str, base: str, target: str, path: str) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--no-ext-diff", "--no-color", base, target, "--", path],
+        cwd=root, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True,
+    )
+    return hashlib.sha256(result.stdout).hexdigest()
+
+
+def matches(path: str, selections: list[str]) -> bool:
+    return any(path == item or path.startswith(item.rstrip("/") + "/") for item in selections)
+
+
+def main() -> int:
+    commands = {"status", "unchecked", "checked", "check", "uncheck"}
+    if len(sys.argv) == 1 or sys.argv[1] not in commands | {"-h", "--help"}:
+        os.execvp("nvim", ["nvim", "-c", "CodeReview " + " ".join(sys.argv[1:])])
+
+    parser = argparse.ArgumentParser(
+        prog="codereview",
+        description="Open CodeReview, or inspect/update reviewed-file state.",
+        epilog="Without a subcommand, opens nvim: codereview [BASE] [TARGET]",
+    )
+    parser.add_argument("command", choices=sorted(commands))
+    parser.add_argument("arguments", nargs="*")
+    parser.add_argument("--base")
+    parser.add_argument("--target")
+    args = parser.parse_args()
+
+    arguments = args.arguments
+    if args.base or args.target:
+        base, target = args.base or "HEAD~1", args.target or "HEAD"
+        paths = arguments
+    elif args.command in {"check", "uncheck"}:
+        if len(arguments) < 3:
+            parser.error(f"{args.command} requires BASE TARGET and at least one file or directory")
+        base, target, *paths = arguments
+    else:
+        if len(arguments) > 2:
+            parser.error(f"{args.command} accepts at most BASE and TARGET")
+        base = arguments[0] if arguments else "HEAD~1"
+        target = arguments[1] if len(arguments) > 1 else "HEAD"
+        paths = []
+
+    root = git_root()
+    files = changed_files(root, base, target)
+    state = load_state()
+    checked = []
+    unchecked = []
+    dirty = False
+    for path in files:
+        key = review_key(root, base, target, path)
+        expected = state.get(key)
+        current = fingerprint(root, base, target, path)
+        if expected == current:
+            checked.append(path)
+        else:
+            unchecked.append(path)
+            if expected is not None:
+                state.pop(key, None)
+                dirty = True
+
+    if args.command == "status":
+        print(f"reviewed {len(checked)}/{len(files)}")
+        print(f"unchecked {len(unchecked)}")
+    elif args.command in {"checked", "unchecked"}:
+        print("\n".join(checked if args.command == "checked" else unchecked))
+    else:
+        selected = [path.removeprefix("./").rstrip("/") for path in paths]
+        found = [path for path in files if matches(path, selected)]
+        if not found:
+            raise SystemExit("no changed files matched")
+        for path in found:
+            key = review_key(root, base, target, path)
+            if args.command == "check":
+                state[key] = fingerprint(root, base, target, path)
+            else:
+                state.pop(key, None)
+        dirty = True
+        print("\n".join(found))
+
+    if dirty:
+        save_state(state)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(error.stderr.decode().strip() if isinstance(error.stderr, bytes) else error.stderr.strip()) from error


### PR DESCRIPTION
## Summary

CodeReviewの進捗確認とファイル単位レビューを、Neovim UIとCLIの両方から扱いやすくします。

## Changes

- hunk位置を右上の固定枠へ分離し、通常notificationを下へ積み、長文を折り返すよう変更
- 選択中ファイルの絶対パス表示、clipboardコピー、ディレクトリ配下の一括チェックを追加
- チェック進捗を割合に応じた7段階色で表示し、レビュー画面の不要な`Changes`見出しを整理
- `codereview status/checked/unchecked/check/uncheck` CLIを追加し、Neovimの永続状態と共有
- CodeReviewの操作方法とCLI仕様をドキュメントへ反映

## Test plan

- [x] `python3 -m py_compile scripts/codereview`
- [x] 一時Git repositoryで`check`、`status`、`uncheck`、`unchecked`を実行
- [x] `nvim -i NONE --headless`でCodeDiff設定をロード
- [x] `scripts/check-markdown-links.py`
- [x] `scripts/check-package-duplication.sh`
- [x] `git diff --check`
