### PR TITLE
fix(pi): honor YOLO mode in permission gate

### DIFF
--- a/common/pi/.pi/agent/extensions/permission-gate.ts
+++ b/common/pi/.pi/agent/extensions/permission-gate.ts
@@ -6,12 +6,16 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
+type PermissionSystemGlobal = typeof globalThis & {
+  __piPermissionSystem?: { getYoloMode(): boolean };
+};
+
 const execFileAsync = promisify(execFile);
 
 // Defense-in-depth only. This is a denylist and is inherently bypassable
 // (e.g. `rm -r -f`, base64-encoded commands, obscure flag spellings); it is not
-// a security boundary. Its job is to catch the obvious-footgun cases and force
-// a human decision, not to stop a determined adversary.
+// a security boundary. In manual mode it catches obvious footguns; YOLO mode
+// delegates them to pi-automode while keeping HARD_DENY_PATTERNS unconditional.
 // Capacity creation must originate outside the agent, so these commands do not
 // offer the confirmation escape hatch used by the general denylist.
 const HARD_DENY_PATTERNS = [
@@ -113,6 +117,10 @@ function getShellCommand(input: unknown): string {
   return String(fields.command ?? fields.cmd ?? "");
 }
 
+export function isPermissionSystemYoloEnabled(): boolean {
+  return (globalThis as PermissionSystemGlobal).__piPermissionSystem?.getYoloMode() === true;
+}
+
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, ctx) => {
     if (!SHELL_TOOLS.has(event.toolName)) return;
@@ -126,7 +134,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     const matched = DANGEROUS_PATTERNS.find((p) => p.test(command));
-    if (!matched) return;
+    if (!matched || isPermissionSystemYoloEnabled()) return;
 
     if (await isTrustedGitProjectCommand(command, ctx.cwd)) return;
 

--- a/common/pi/.pi/agent/extensions/statusline.ts
+++ b/common/pi/.pi/agent/extensions/statusline.ts
@@ -260,7 +260,7 @@ function installEditor(pi: ExtensionAPI, ctx: ExtensionContext): void {
       const state = currentTool ? ` TOOL · ${currentTool} ` : running ? " RUN " : " ASK ";
       const stateColor = currentTool ? "warning" : running ? "accent" : "success";
       const topLeft = theme.bold(theme.fg(stateColor, state));
-      const topRight = theme.fg("dim", ` ${pi.getThinkingLevel()} `);
+      const topRight = theme.fg("dim", ` THINK ${pi.getThinkingLevel()} `);
       const bottomLeft = theme.fg("muted", ` ${ctx.model?.id ?? "no-model"} · ${contextLabel(ctx)} `);
       const bottomRight = theme.fg("dim", " /status ");
       lines[0] = fitBorder(topLeft, topRight, width, (text) => theme.fg(stateColor, text));
@@ -341,7 +341,7 @@ export default function (pi: ExtensionAPI) {
       await ctx.ui.custom<void>(
         (_tui, theme, _keybindings, done) => new StatusOverlay(theme, [
           ["PROJECT", `${formatCwd(ctx.cwd)}${dirtyState ? "  *dirty" : ""}`],
-          ["MODEL", `${ctx.model?.provider ?? "—"}/${ctx.model?.id ?? "—"} · ${pi.getThinkingLevel()}`],
+          ["MODEL", `${ctx.model?.provider ?? "—"}/${ctx.model?.id ?? "—"} · THINK ${pi.getThinkingLevel()}`],
           ["CONTEXT", usage?.percent == null ? "unknown" : `${usage.percent.toFixed(1)}% / ${formatTokens(usage.contextWindow ?? 0)}`],
           ["TOKENS", `↑${formatTokens(tokCache.input)}  ↓${formatTokens(tokCache.output)}  $${tokCache.cost.toFixed(3)}`],
           ["CURSOR", cursorLimits],

--- a/scripts/check
+++ b/scripts/check
@@ -25,6 +25,7 @@ scripts/test-install-fast-paths.sh
 [[ ! -x scripts/test-pi-tui-patch.sh ]] || scripts/test-pi-tui-patch.sh
 scripts/test-harness-entrypoints.sh
 scripts/test-codex-config.sh
+scripts/test-pi-permission-gate.sh
 python3 scripts/test_check_markdown_links.py
 scripts/check-markdown-links.py
 scripts/check-doc-provenance.py

--- a/scripts/test-pi-permission-gate.sh
+++ b/scripts/test-pi-permission-gate.sh
@@ -2,12 +2,9 @@
 set -euo pipefail
 
 root=$(cd "$(dirname "$0")/.." && pwd)
-pi_bin=$(realpath "$(command -v pi)")
-pi_package=$(cd "$(dirname "$pi_bin")/.." && pwd)
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-ln -s "$pi_package/node_modules" "$tmp/node_modules"
 ln -s "$root/common/pi/.pi/agent/extensions/permission-gate.ts" "$tmp/permission-gate.ts"
 ln -s "$root/common/pi/.pi/agent/extensions/statusline.ts" "$tmp/statusline.ts"
 

--- a/scripts/test-pi-permission-gate.sh
+++ b/scripts/test-pi-permission-gate.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+pi_bin=$(realpath "$(command -v pi)")
+pi_package=$(cd "$(dirname "$pi_bin")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+ln -s "$pi_package/node_modules" "$tmp/node_modules"
+ln -s "$root/common/pi/.pi/agent/extensions/permission-gate.ts" "$tmp/permission-gate.ts"
+ln -s "$root/common/pi/.pi/agent/extensions/statusline.ts" "$tmp/statusline.ts"
+
+cd "$tmp"
+node --experimental-strip-types --preserve-symlinks --input-type=module - "$tmp" <<'JS'
+import assert from "node:assert/strict";
+
+const tmp = process.argv[2];
+const { isPermissionSystemYoloEnabled } = await import(`file://${tmp}/permission-gate.ts`);
+const statusline = await (await import("node:fs/promises")).readFile(`${tmp}/statusline.ts`, "utf8");
+
+delete globalThis.__piPermissionSystem;
+assert.equal(isPermissionSystemYoloEnabled(), false);
+globalThis.__piPermissionSystem = { getYoloMode: () => false };
+assert.equal(isPermissionSystemYoloEnabled(), false);
+globalThis.__piPermissionSystem = { getYoloMode: () => true };
+assert.equal(isPermissionSystemYoloEnabled(), true);
+assert(statusline.includes('` THINK ${pi.getThinkingLevel()} `'));
+
+console.log("OK: permission gate follows YOLO mode and statusline labels thinking level");
+JS


### PR DESCRIPTION
## Summary

Align the custom permission gate with `pi-permission-system` YOLO mode and clarify the statusline's `off` label.

## Changes

- skip the permission gate's confirmation-only denylist while YOLO mode is enabled
- keep unconditional hard denies such as worktree capacity creation
- continue routing actions through `pi-automode` classifier guardrails
- label thinking state as `THINK off` instead of the ambiguous `off`
- add a focused regression check for YOLO integration and statusline labeling

## Test plan

- [x] Run `scripts/test-pi-permission-gate.sh`
- [x] Run ShellCheck for changed shell scripts
- [x] Run `git diff --check`
- [x] Run Markdown link and package duplication checks
