### PR TITLE
feat(tmux): show Grok usage and pane state in agent sidebar

### DIFF
--- a/docs/specs/agent-stop-notification.md
+++ b/docs/specs/agent-stop-notification.md
@@ -2,7 +2,7 @@
 
 > **由来:** **Upstream** tmux・各agent hook API / **Configuration** hook・keybinding / **Custom** agent状態管理・通知・index処理（[区分](../provenance.md#区分)）
 
-Claude Code、pi、Codex、Gemini CLI、Cursor Agent、Command Code の実行状態をtmuxへ集約する現行仕様。
+Claude Code、pi、Codex、Gemini CLI、Cursor Agent、Command Code、Grok Build の実行状態をtmuxへ集約する現行仕様。
 
 ## 状態の正本
 
@@ -11,7 +11,7 @@ Claude Code、pi、Codex、Gemini CLI、Cursor Agent、Command Code の実行状
 | option | 内容 |
 | --- | --- |
 | `@agent_status` | `running` / `idle` / `permission` / `complete` / `hang` / `error` |
-| `@agent_provider` | `claude` / `pi` / `codex` / `gemini` / `cursor` / `cmd` |
+| `@agent_provider` | `claude` / `pi` / `codex` / `gemini` / `cursor` / `cmd` / `grok` |
 | `@agent_state_since` | 現状態へ遷移したUnix時刻 |
 | `@agent_heartbeat` | 最後に実イベントまたは画面変化を観測したUnix時刻 |
 | `@agent_heartbeat_source` | `event`または`screen` |
@@ -29,6 +29,7 @@ Claude Code、pi、Codex、Gemini CLI、Cursor Agent、Command Code の実行状
 | Gemini CLI | `BeforeAgent` | `BeforeTool`、`AfterTool` | `AfterAgent` | `SessionEnd` |
 | Cursor Agent | `beforeSubmitPrompt` | shell/read/edit/thought hooks | `stop` | CLI hook APIの範囲でbest effort |
 | Command Code | 最初の`PreToolUse` | `PreToolUse`、`PostToolUse` | `Stop` | prompt開始eventがないためtext-only turnのrunningは取得不可 |
+| Grok Build | `UserPromptSubmit` | `PreToolUse`、`PostToolUse`、`PostToolUseFailure` | `Notification`(permission_prompt)、`Stop` | `StopFailure`、`SessionEnd` |
 
 Provider hookはpane state更新を同期完了してから戻る。pi extensionはPromise queueで更新順を保証する。Codexは初回起動時にhook trust確認が表示されるため、内容を確認して許可する。
 

--- a/docs/tools/tmux.md
+++ b/docs/tools/tmux.md
@@ -467,7 +467,7 @@ AI エージェント状態監視（自前スクリプト）:
 - `scripts/tmux-agent-status.sh`は全agentのread-only previewとpane jumpを提供する。実paneのswapは行わない
 - `scripts/tmux-agent-sidebar.sh`は同じindexからセッショングループ別の状態を常時表示する
 - event heartbeat対応providerではTUI spinnerを無視し、120秒進捗がなければhang表示する
-- サイドバー下部に Claude / Codex / Gemini / Cursor の使用量を表示。Codex は `~/.codex/auth.json` の OAuth token を自動 refresh するが、refresh token invalidated の場合は `codex login` が必要
+- サイドバー下部に Claude / Codex / Gemini / Cursor / Grok の使用量を表示。Codex は `~/.codex/auth.json` の OAuth token を自動 refresh するが、refresh token invalidated の場合は `codex login` が必要。Grok は `~/.grok/auth.json` の session token を使い、切れたら `grok login`
 - サイドバーがある window では `prefix z` / `prefix Z` が native zoom ではなく擬似 zoom（layout 保存 + resize）になり、サイドバーを表示したまま残り領域で最大化する。tmux は pane を隠せないため、他の pane は 1 行のスリットとして残る。`prefix C-z` は常に native zoom（サイドバーごと全画面）
 - 擬似 zoom 中は `window_zoomed_flag` が立たないため、status-right のモード表示と `pane-active-border-style` は `@pzoom_pane` も見て ZOOM を表示する（`regenerate-tmux-theme.sh` が正本）
 - 詳細は[AI agent状態管理](../specs/agent-stop-notification.md)を参照

--- a/install.sh
+++ b/install.sh
@@ -799,6 +799,15 @@ for name, config in servers.items():
     fi
   fi
 
+  # Grok Build
+  if [[ -f "$templates_dir/grok-hooks.json" ]]; then
+    if render_home_template "$templates_dir/grok-hooks.json" "$HOME/.grok/hooks/tmux-agent.json"; then
+      log_success "  Generated ~/.grok/hooks/tmux-agent.json"
+    else
+      log_success "  ~/.grok/hooks/tmux-agent.json already current"
+    fi
+  fi
+
   # Command Code CLI
   if [[ -f "$templates_dir/commandcode-settings.json" ]]; then
     if render_home_template "$templates_dir/commandcode-settings.json" "$HOME/.commandcode/settings.json"; then

--- a/scripts/regenerate-tmux-theme.sh
+++ b/scripts/regenerate-tmux-theme.sh
@@ -168,7 +168,7 @@ HELP="#[fg=${COLOR_WARNING} bg=default]${LEFT}#[fg=${BG_DARK} bg=${COLOR_WARNING
 
 # 通常表示の各パーツ
 # スタイル指定 #[...] 内のカンマを #, でエスケープ（ネストされた #{?...} のカンマはそのまま）
-# AI エージェントの使用量ゲージ(claude/codex/gemini/cursor)はサイドバー(prefix+b)へ移動。
+# AI エージェントの使用量ゲージ(claude/codex/gemini/cursor/grok)はサイドバー(prefix+b)へ移動。
 # ここには cpu/ram/gpu/storage のみ残す。
 SR_SYSSTAT="#[fg=${BG_HIGHLIGHT}${EC}bg=default]${LEFT}#{@sysstat}#[fg=${BG_HIGHLIGHT}${EC}bg=default]${RIGHT} "
 SR_MODE="#{?#{==:#{client_key_table},off},#[fg=${FG_SUBTLE}]${LEFT}#[fg=${BG_DARK} bg=${FG_SUBTLE} bold]  OFF #[fg=${FG_SUBTLE} bg=default]${RIGHT},#{?#{==:#{@reload_mode},1},#[fg=${COLOR_RELOAD}]${LEFT}#[fg=${BG_DARK} bg=${COLOR_RELOAD} bold]  RELOAD #[fg=${COLOR_RELOAD} bg=default]${RIGHT},#{?#{==:#{window_name},[thumbs]},#[fg=${COLOR_THUMBS}]${LEFT}#[fg=${BG_DARK} bg=${COLOR_THUMBS} bold] 󰆤 THUMBS #[fg=${COLOR_THUMBS} bg=default]${RIGHT},#{?pane_in_mode,#[fg=${COLOR_ERROR}]${LEFT}#[fg=${BG_DARK} bg=${COLOR_ERROR} bold] COPY #[fg=${COLOR_ERROR} bg=default]${RIGHT},#{?pane_synchronized,#[fg=${COLOR_SUCCESS}]${LEFT}#[fg=${BG_DARK} bg=${COLOR_SUCCESS} bold] SYNC #[fg=${COLOR_SUCCESS} bg=default]${RIGHT},#{?#{||:#{window_zoomed_flag},#{@pzoom_pane}},#[fg=${COLOR_ZOOM}]${LEFT}#[fg=${BG_DARK} bg=${COLOR_ZOOM} bold]  ZOOM #P/#{window_panes} #[fg=${COLOR_ZOOM} bg=default]${RIGHT},#[fg=${ACCENT_PRIMARY}]${LEFT}#[fg=${BG_DARK} bg=${ACCENT_PRIMARY}] NORMAL #[fg=${ACCENT_PRIMARY} bg=default]${RIGHT}}}}}}}"

--- a/scripts/tmux-agent-sidebar.sh
+++ b/scripts/tmux-agent-sidebar.sh
@@ -125,7 +125,7 @@ session_glyphs() {
 
 # 各 AI の使用量(セッションリミット)を2行で出力(1行目: アイコン+残り時間 / 2行目: ゲージ+%)
 # usage スクリプト出力 "ICON GAUGE PCT/PCT REMAINING"(失敗時 "ICON --")をパースして整形。
-# 4スクリプトを毎 render 走らせると重いので結果を30秒キャッシュする。
+# 各 usage を毎 render 走らせると重いので結果を30秒キャッシュする。
 USAGE_CACHE="$RUNTIME_BASE/claude/sidebar-usage"
 usage_section() {
   local now mt age
@@ -141,13 +141,14 @@ usage_section() {
   local TO; TO="$(command -v timeout || command -v gtimeout || true)"
   {
     local sc out col icon label gauge pct rem
-    for sc in claude codex gemini cursor; do
-      # AI ごとの色分け: claude=橙 codex=水色 gemini=青 cursor=白
+    for sc in claude codex gemini cursor grok; do
+      # AI ごとの色分け: claude=橙 codex=水色 gemini=青 cursor=白 grok=ティール
       case "$sc" in
         claude) col=$'\033[38;2;255;102;0m' ;;
         codex)  col=$'\033[38;2;125;211;252m' ;;
         gemini) col=$'\033[38;2;66;133;244m' ;;
         cursor) col=$'\033[38;2;255;255;255m' ;;
+        grok)   col=$'\033[38;2;94;234;212m' ;;
         *)      col="" ;;
       esac
       out=$(${TO:+$TO 6} ai-usage "$sc" 2>/dev/null)

--- a/scripts/tmux-agent-status.sh
+++ b/scripts/tmux-agent-status.sh
@@ -198,11 +198,12 @@ case "${1:-popup}" in
     runtime_dir=$(agent_runtime_dir)
     base=$(agent_runtime_base)
     for lock in "$runtime_dir/hang-watch.pid" "$runtime_dir/index/daemon.pid" \
+                "$runtime_dir/sidebar-daemon.pid" \
                 "$base/claude/hang-watch.pid" "$base/claude/tmux-agent-index/daemon.pid"; do
       [[ -f "$lock" ]] || continue
       daemon_pid=$(cat "$lock" 2>/dev/null || true)
       if [[ -n "$daemon_pid" ]]; then
-        case "$lock" in *index*) expected=tmux-agent-index.sh;; *) expected=tmux-agent-hang-watch.sh;; esac
+        case "$lock" in *index*) expected=tmux-agent-index.sh;; *sidebar*) expected=tmux-agent-sidebar.sh;; *) expected=tmux-agent-hang-watch.sh;; esac
         daemon_command=$(ps -p "$daemon_pid" -o command= 2>/dev/null || true)
         [[ "$daemon_command" == *"$expected"* ]] || continue
         kill "$daemon_pid" 2>/dev/null || true
@@ -215,6 +216,7 @@ case "${1:-popup}" in
     done
     tmux run-shell -b "$SCRIPT_DIR/tmux-agent-index.sh daemon >/dev/null 2>&1 || true"
     tmux run-shell -b "$SCRIPT_DIR/tmux-agent-hang-watch.sh >/dev/null 2>&1 || true"
+    tmux run-shell -b "$SCRIPT_DIR/tmux-agent-sidebar.sh daemon >/dev/null 2>&1 || true"
     "$SCRIPT_DIR/tmux-claude-pane.sh" hang-scan 2>/dev/null || true
     "$SCRIPT_DIR/tmux-agent-index.sh" refresh 2>/dev/null || true
     tmux refresh-client -S 2>/dev/null || true

--- a/scripts/tmux-claude-pane.sh
+++ b/scripts/tmux-claude-pane.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # tmux AI Agent ペーン状態管理 (純tmuxローカル / 状態の正本)
-# 各エージェント(Claude Code / Codex / Cursor / Command Code / pi)の hooks から呼ばれ、
+# 各エージェント(Claude Code / Codex / Cursor / Command Code / pi / Grok)の hooks から呼ばれ、
 # pane user option で状態を管理する。pane option を状態の Single Source of Truth とし、
 # ウィンドウバッジ・SketchyBar・Slack はこの集約から導出する派生ビューとする。
 # 仕様: docs/specs/agent-stop-notification.md

--- a/templates/grok-hooks.json
+++ b/templates/grok-hooks.json
@@ -1,0 +1,95 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh set idle grok"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh start grok event"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat grok event"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat grok event"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh heartbeat grok event"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/ai-notify.sh grok permission"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/ai-notify.sh grok complete"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/ai-notify.sh grok error"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__HOME__/dotfiles/scripts/tmux-claude-pane.sh clear"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tools/ai-usage/src/main.rs
+++ b/tools/ai-usage/src/main.rs
@@ -1,5 +1,5 @@
 // ai-usage — tmux status-right の usage widget を 1 binary に統合。
-//   usage: ai-usage <claude|codex|gemini|cursor>
+//   usage: ai-usage <claude|codex|gemini|cursor|grok>
 //   出力は bash 版と bit 互換の US(0x1f) 区切りレコード。失敗しても exit 0 で
 //   placeholder を出し、呼び出し側 (tmux/sidebar) を絶対に壊さない (fail-open)。
 
@@ -17,6 +17,7 @@ fn provider_for(name: &str) -> Option<Box<dyn Provider>> {
         "codex" => Some(Box::new(providers::codex::Codex)),
         "gemini" => Some(Box::new(providers::gemini::Gemini)),
         "cursor" => Some(Box::new(providers::cursor::Cursor)),
+        "grok" => Some(Box::new(providers::grok::Grok)),
         _ => None,
     }
 }
@@ -72,7 +73,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         None => {
-            eprintln!("usage: ai-usage <claude|codex|gemini|cursor>");
+            eprintln!("usage: ai-usage <claude|codex|gemini|cursor|grok>");
             ExitCode::FAILURE
         }
     }

--- a/tools/ai-usage/src/providers/grok.rs
+++ b/tools/ai-usage/src/providers/grok.rs
@@ -1,0 +1,297 @@
+// Grok / SuperGrok usage — ~/.grok/auth.json の session token で
+// cli-chat-proxy.grok.com の billing を叩く。refresh は grok CLI に任せる。
+
+use super::{Provider, Reset, Usage, clamp_pct, tmux_cache_path};
+use crate::http;
+use anyhow::{Context, Result, anyhow};
+use serde_json::Value;
+use std::path::PathBuf;
+
+const API_KEY_SCOPE: &str = "xai::api_key";
+const DEFAULT_PROXY: &str = "https://cli-chat-proxy.grok.com/v1";
+
+pub struct Grok;
+
+fn home() -> String {
+    std::env::var("HOME").unwrap_or_default()
+}
+
+fn grok_home() -> PathBuf {
+    if let Ok(p) = std::env::var("GROK_HOME")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    PathBuf::from(home()).join(".grok")
+}
+
+fn auth_file() -> PathBuf {
+    std::env::var("GROK_AUTH_FILE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| grok_home().join("auth.json"))
+}
+
+fn pi_auth_file() -> PathBuf {
+    std::env::var("PI_AUTH_FILE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(home()).join(".pi/agent/auth.json"))
+}
+
+fn proxy_base() -> String {
+    std::env::var("GROK_CLI_CHAT_PROXY_BASE_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_PROXY.to_string())
+}
+
+/// pi `/login xai` の OAuth access token。API key は SuperGrok 週次枠ではないので使わない。
+fn pi_oauth(store: &Value) -> Option<(String, String)> {
+    let xai = store.get("xai")?;
+    if xai.get("type").and_then(Value::as_str) != Some("oauth") {
+        return None;
+    }
+    let access = xai
+        .get("access")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())?
+        .to_string();
+    Some((access, String::new()))
+}
+
+/// session scope を優先し、API key scope は SuperGrok 週次枠ではないので使わない。
+fn session_auth(store: &Value) -> Option<(String, String)> {
+    let obj = store.as_object()?;
+    let mut fallback = None;
+    for (scope, entry) in obj {
+        if scope == API_KEY_SCOPE {
+            continue;
+        }
+        let key = entry.get("key").and_then(Value::as_str).unwrap_or("");
+        if key.is_empty() {
+            continue;
+        }
+        let user_id = entry
+            .get("user_id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let mode = entry.get("auth_mode").and_then(Value::as_str).unwrap_or("");
+        let pair = (key.to_string(), user_id);
+        if matches!(mode, "oidc" | "web_login" | "external") {
+            return Some(pair);
+        }
+        fallback.get_or_insert(pair);
+    }
+    fallback
+}
+
+fn cents(v: &Value) -> Option<i64> {
+    v.get("val").and_then(Value::as_i64).or_else(|| v.as_i64())
+}
+
+fn reset_of(s: Option<&str>) -> Reset {
+    match s {
+        Some(s) if !s.is_empty() => Reset::Iso(s.to_string()),
+        _ => Reset::None,
+    }
+}
+
+fn parse_billing(v: &Value) -> Option<Usage> {
+    let cfg = v.get("config").unwrap_or(v);
+    if !cfg.is_object() {
+        return None;
+    }
+
+    let weekly = cfg
+        .get("creditUsagePercent")
+        .or_else(|| cfg.get("credit_usage_percent"))
+        .and_then(Value::as_f64)
+        .map(|p| clamp_pct(p.round() as i64))
+        .or_else(|| {
+            let used = cfg.get("used").and_then(cents)?;
+            let limit = cfg.get("monthlyLimit").or_else(|| cfg.get("monthly_limit")).and_then(cents)?;
+            if limit <= 0 {
+                return None;
+            }
+            Some(clamp_pct((used * 100 + limit / 2) / limit))
+        })?;
+
+    let period = cfg.get("currentPeriod").or_else(|| cfg.get("current_period"));
+    let weekly_reset = reset_of(
+        period
+            .and_then(|p| p.get("end"))
+            .and_then(Value::as_str)
+            .or_else(|| {
+                cfg.get("billingPeriodEnd")
+                    .or_else(|| cfg.get("billing_period_end"))
+                    .and_then(Value::as_str)
+            }),
+    );
+
+    let extra_used = cfg
+        .get("onDemandUsed")
+        .or_else(|| cfg.get("on_demand_used"))
+        .and_then(cents)
+        .unwrap_or(0);
+    let extra_cap = cfg
+        .get("onDemandCap")
+        .or_else(|| cfg.get("on_demand_cap"))
+        .and_then(cents)
+        .unwrap_or(0);
+    let extra = if extra_cap > 0 {
+        clamp_pct((extra_used * 100 + extra_cap / 2) / extra_cap)
+    } else {
+        0
+    };
+
+    Some(Usage {
+        a_pct: weekly,
+        a_reset: weekly_reset,
+        b_pct: extra,
+        b_reset: Reset::None,
+    })
+}
+
+impl Grok {
+    fn token(&self) -> Result<(String, String)> {
+        if let Ok(t) = std::env::var("GROK_AUTH_TOKEN")
+            && !t.is_empty()
+        {
+            return Ok((t, String::new()));
+        }
+        if let Ok(body) = std::fs::read_to_string(auth_file())
+            && let Ok(v) = serde_json::from_str::<Value>(body.trim())
+            && let Some(auth) = session_auth(&v)
+        {
+            return Ok(auth);
+        }
+        let path = pi_auth_file();
+        let body = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        let v: Value = serde_json::from_str(body.trim()).context("parsing pi auth.json")?;
+        pi_oauth(&v).ok_or_else(|| anyhow!("no grok session token"))
+    }
+}
+
+impl Provider for Grok {
+    fn icon(&self) -> &'static str {
+        "\u{f135}" // 
+    }
+
+    fn labels(&self) -> (&'static str, &'static str) {
+        ("weekly", "extra")
+    }
+
+    fn cache_path(&self) -> PathBuf {
+        tmux_cache_path("grok_usage")
+    }
+
+    fn fetch(&self) -> Result<Usage> {
+        let (token, user_id) = self.token()?;
+        let url = format!("{}/billing?format=credits", proxy_base().trim_end_matches('/'));
+        let mut req = http::agent()
+            .get(&url)
+            .header("Authorization", &format!("Bearer {token}"))
+            .header("X-XAI-Token-Auth", "xai-grok-cli");
+        if !user_id.is_empty() {
+            req = req.header("x-userid", &user_id);
+        }
+        let mut res = req.call().context("grok billing request")?;
+        let body = res.body_mut().read_to_string().context("reading body")?;
+        let v: Value = serde_json::from_str(&body).context("parsing billing json")?;
+        parse_billing(&v).ok_or_else(|| anyhow!("no usable grok billing"))
+    }
+
+    fn to_cache(&self, u: &Usage) -> String {
+        format!(
+            "{}|{}|{}|{}",
+            u.a_pct,
+            u.b_pct,
+            u.a_reset.to_field(),
+            u.b_reset.to_field()
+        )
+    }
+
+    fn from_cache(&self, line: &str) -> Option<Usage> {
+        super::parse_two_iso_cache(line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_weekly_credits() {
+        let v: Value = serde_json::from_str(
+            r#"{
+                "config": {
+                    "creditUsagePercent": 42.4,
+                    "currentPeriod": {"type":"USAGE_PERIOD_TYPE_WEEKLY","end":"2026-08-20T00:00:00Z"},
+                    "onDemandUsed": {"val": 25},
+                    "onDemandCap": {"val": 100}
+                }
+            }"#,
+        )
+        .unwrap();
+        let u = parse_billing(&v).unwrap();
+        assert_eq!(u.a_pct, 42);
+        assert_eq!(u.a_reset, Reset::Iso("2026-08-20T00:00:00Z".into()));
+        assert_eq!(u.b_pct, 25);
+        assert_eq!(u.b_reset, Reset::None);
+    }
+
+    #[test]
+    fn parse_legacy_monthly_limit() {
+        let v: Value = serde_json::from_str(
+            r#"{"config":{"used":{"val":1234},"monthlyLimit":{"val":2000},"billingPeriodEnd":"2026-09-01T00:00:00Z"}}"#,
+        )
+        .unwrap();
+        let u = parse_billing(&v).unwrap();
+        assert_eq!(u.a_pct, 62);
+        assert_eq!(u.a_reset, Reset::Iso("2026-09-01T00:00:00Z".into()));
+        assert_eq!(u.b_pct, 0);
+    }
+
+    #[test]
+    fn session_auth_skips_api_key() {
+        let v: Value = serde_json::from_str(
+            r#"{
+                "xai::api_key": {"key":"xai-secret","user_id":"u0","auth_mode":"api_key"},
+                "https://auth.x.ai": {"key":"sess","user_id":"u1","auth_mode":"oidc"}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(session_auth(&v), Some(("sess".into(), "u1".into())));
+    }
+
+    #[test]
+    fn pi_oauth_reads_access() {
+        let v: Value = serde_json::from_str(
+            r#"{"xai":{"type":"oauth","access":"sess","refresh":"rt"}}"#,
+        )
+        .unwrap();
+        assert_eq!(pi_oauth(&v), Some(("sess".into(), "".into())));
+        let key_only: Value =
+            serde_json::from_str(r#"{"xai":{"type":"api_key","key":"xai-secret"}}"#).unwrap();
+        assert_eq!(pi_oauth(&key_only), None);
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let g = Grok;
+        let u = Usage {
+            a_pct: 42,
+            a_reset: Reset::Iso("2026-08-20T00:00:00Z".into()),
+            b_pct: 10,
+            b_reset: Reset::None,
+        };
+        let line = g.to_cache(&u);
+        assert_eq!(line, "42|10|2026-08-20T00:00:00Z|");
+        assert_eq!(g.from_cache(&line), Some(u));
+    }
+}

--- a/tools/ai-usage/src/providers/mod.rs
+++ b/tools/ai-usage/src/providers/mod.rs
@@ -1,10 +1,11 @@
-// Provider 抽象 — 4 プロバイダ共通の「token → fetch → parse → 2 window」の型。
+// Provider 抽象 — 各プロバイダ共通の「token → fetch → parse → 2 window」の型。
 // 各 provider は cache 行の serialize/deserialize を bash 互換で実装する。
 
 pub mod claude;
 pub mod codex;
 pub mod cursor;
 pub mod gemini;
+pub mod grok;
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary
- SuperGrok / Grok Build を AI agent サイドバーの使用量ゲージに追加
- Grok Build の pane 状態を既存 agent と同じ hook 経路で集約
- `prefix+R` で sidebar daemon も再起動できるようにして、描画更新を確実にする

## Changes
- `ai-usage grok` provider を追加
  - `~/.grok/auth.json` の session token
  - fallback として `~/.pi/agent/auth.json` の xAI OAuth access token
  - `cli-chat-proxy.grok.com` billing から weekly / extra を表示
- sidebar usage loop に `grok` を追加
- `templates/grok-hooks.json` を追加し、`install.sh` で `~/.grok/hooks/tmux-agent.json` を生成
- agent status 仕様と tmux docs を更新
- `tmux-agent-status.sh reload` が sidebar daemon も再起動するよう修正

## Test plan
- [x] `cargo test -p ai-usage`
- [x] `ai-usage grok` が `weekly` / `extra` を返すことを確認
- [ ] `prefix+R` 後、sidebar 下部 USAGE に Grok が出る
- [ ] `grok` を起動して prompt を送ると、sidebar / `prefix+a` に `grok` pane が出る
- [ ] Grok 未ログイン時は USAGE が `--` で fail-open になる